### PR TITLE
docs: support exporting as pdf/esp

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,12 @@ Double-click Linestring, Lane, or Polygon to select and edit segments (between t
 | **SVG**            | ✓      | ✓      |                       |
 | **PNG**            | ✓      | ✓      |                       |
 | **JPG**            | ✓      | ✓      |                       |
+| **PDF**            | ✓      |        |                       |
+| **EPS**            | ✓      |        | No transparency       |
 | **drawtonomy.svg** | ✓      | ✓      | Re-editable           |
 | **OSM (Lanelet2)** |        | ✓      |                       |
+
+> **Note on EPS export**: EPS format does not support transparency. When exporting shapes with opacity settings, the exported EPS will show shapes at full opacity, which may differ from the canvas display. For accurate transparency rendering, use PDF export instead.
 
 <p align="center">
   <img src="./docs/videos/export-demo.gif" width="80%" />


### PR DESCRIPTION
solve #6
support pdf/eps

<img width="3262" height="1854" alt="image" src="https://github.com/user-attachments/assets/adc26f38-0b1e-4560-95b0-b6ad68a07a9e" />

<img width="3354" height="1860" alt="image" src="https://github.com/user-attachments/assets/484d4df1-4383-49ce-91d7-81d9be0924a3" />



| Format             | Export | Import | Note                  |
| ------------------ | :----: | :----: | --------------------- |
| **SVG**            | ✓      | ✓      |                       |
| **PNG**            | ✓      | ✓      |                       |
| **JPG**            | ✓      | ✓      |                       |
| **PDF**            | ✓      |        |                       |
| **EPS**            | ✓      |        | No transparency       |
| **drawtonomy.svg** | ✓      | ✓      | Re-editable           |
| **OSM (Lanelet2)** |        | ✓      |                       |

> **Note on EPS export**: EPS format does not support transparency. When exporting shapes with opacity settings, the exported EPS will show shapes at full opacity, which may differ from the canvas display. For accurate transparency rendering, use PDF export instead.
