### PR TITLE
feat: add requestExport to SDK with returnData support

### DIFF
--- a/docs/extensions.ja.md
+++ b/docs/extensions.ja.md
@@ -250,7 +250,7 @@ open "http://localhost:3000/?ext=http://localhost:3001/manifest.json"
 | `ext:shapes-delete` | `shapes:write` | シェイプを削除 |
 | `ext:shapes-request` | `shapes:read` | シェイプデータを要求（フィルター付き） |
 | `ext:snapshot-request` | `snapshot:read` | スナップショットを要求 |
-| `ext:export-request` | `snapshot:export` | シーンをエクスポート（format: svg/png/jpeg/pdf/eps） |
+| `ext:export-request` | `snapshot:export` | シーンをエクスポート（format: svg/png/jpeg/pdf/eps）。`returnData: true`でBase64 data URIとしてデータを取得可能 |
 | `ext:viewport-request` | `viewport:read` | ビューポート情報を要求 |
 | `ext:selection-request` | `selection:read` | 選択状態を要求 |
 | `ext:notify` | `ui:notify` | トースト通知を表示 |
@@ -263,7 +263,7 @@ open "http://localhost:3000/?ext=http://localhost:3001/manifest.json"
 | `ext:init` | ready後、ケイパビリティ/ビューポート情報を送信 |
 | `ext:shapes-response` | shapes-requestへの応答 |
 | `ext:snapshot-response` | snapshot-requestへの応答 |
-| `ext:export-response` | export-requestへの応答（ホスト側でダウンロード実行） |
+| `ext:export-response` | export-requestへの応答。`returnData: true`の場合`data`にBase64 data URIが含まれる。それ以外はホスト側でダウンロード実行 |
 | `ext:viewport-response` | viewport-requestへの応答 |
 | `ext:selection-response` | selection-requestへの応答 |
 | `ext:error` | エラー発生時 |
@@ -295,6 +295,15 @@ const shapes = await client.requestShapes({ types: ['vehicle'] })
 
 // スナップショットを取得
 const snapshot = await client.requestSnapshot()
+
+// シーンをBase64 data URIとしてエクスポート（snapshot:exportケイパビリティが必要）
+const result = await client.requestExport('png', { returnData: true })
+// result.data = "data:image/png;base64,iVBOR..."
+// result.mimeType = "image/png"
+// result.filename = "scene-2026-04-02T12-00-00.png"
+
+// エクスポートしてファイルダウンロード（デフォルト動作）
+await client.requestExport('svg')
 
 // ビューポートを取得
 const viewport = await client.requestViewport()

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -250,7 +250,7 @@ Extensions communicate with the host via `window.parent.postMessage()`.
 | `ext:shapes-delete` | `shapes:write` | Delete shapes |
 | `ext:shapes-request` | `shapes:read` | Request shape data (with filter) |
 | `ext:snapshot-request` | `snapshot:read` | Request snapshot |
-| `ext:export-request` | `snapshot:export` | Export scene (format: svg/png/jpeg/pdf/eps) |
+| `ext:export-request` | `snapshot:export` | Export scene (format: svg/png/jpeg/pdf/eps). Set `returnData: true` to receive Base64 data URI instead of downloading |
 | `ext:viewport-request` | `viewport:read` | Request viewport info |
 | `ext:selection-request` | `selection:read` | Request selection state |
 | `ext:notify` | `ui:notify` | Show toast notification |
@@ -263,7 +263,7 @@ Extensions communicate with the host via `window.parent.postMessage()`.
 | `ext:init` | After ready, sends capability/viewport info |
 | `ext:shapes-response` | Response to shapes-request |
 | `ext:snapshot-response` | Response to snapshot-request |
-| `ext:export-response` | Response to export-request (file downloaded by host) |
+| `ext:export-response` | Response to export-request. `data` contains Base64 data URI when `returnData: true`, empty string otherwise (file downloaded by host) |
 | `ext:viewport-response` | Response to viewport-request |
 | `ext:selection-response` | Response to selection-request |
 | `ext:error` | On error |
@@ -295,6 +295,15 @@ const shapes = await client.requestShapes({ types: ['vehicle'] })
 
 // Get snapshot
 const snapshot = await client.requestSnapshot()
+
+// Export scene as Base64 data URI (requires snapshot:export capability)
+const result = await client.requestExport('png', { returnData: true })
+// result.data = "data:image/png;base64,iVBOR..."
+// result.mimeType = "image/png"
+// result.filename = "scene-2026-04-02T12-00-00.png"
+
+// Export and trigger file download (default behavior)
+await client.requestExport('svg')
 
 // Get viewport
 const viewport = await client.requestViewport()

--- a/packages/drawtonomy-sdk/__tests__/ExtensionClient.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/ExtensionClient.test.ts
@@ -1,0 +1,302 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ExtensionClient } from '../src/ExtensionClient'
+
+// Simulate postMessage round-trip: capture messages sent to parent,
+// then dispatch responses back via window 'message' event.
+let posted: Array<{ type: string; payload: any }>
+
+function mockPostMessage() {
+  posted = []
+  vi.stubGlobal('parent', {
+    postMessage: (msg: any, _target: string) => {
+      posted.push(msg)
+    },
+  })
+}
+
+function dispatchMessage(data: any) {
+  window.dispatchEvent(new MessageEvent('message', { data }))
+}
+
+describe('ExtensionClient', () => {
+  beforeEach(() => {
+    mockPostMessage()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // --- Constructor & Init ---
+
+  it('sends ext:ready on construction', () => {
+    new ExtensionClient('test-ext')
+    expect(posted.length).toBe(1)
+    expect(posted[0]).toEqual({
+      type: 'ext:ready',
+      payload: { manifestId: 'test-ext' },
+    })
+  })
+
+  it('waitForInit resolves when ext:init is received', async () => {
+    const client = new ExtensionClient('test-ext')
+    const initPayload = {
+      hostVersion: '1.0.0',
+      grantedCapabilities: ['shapes:write'],
+      viewport: { width: 800, height: 600 },
+    }
+
+    const promise = client.waitForInit()
+    dispatchMessage({ type: 'ext:init', payload: initPayload })
+
+    const result = await promise
+    expect(result).toEqual(initPayload)
+  })
+
+  // --- shapes:write ---
+
+  it('addShapes sends ext:shapes-add', () => {
+    const client = new ExtensionClient('test-ext')
+    posted = [] // clear ready message
+    const shapes = [{ id: 's1', type: 'vehicle', x: 0, y: 0, rotation: 0, zIndex: 0, props: {} }]
+    client.addShapes(shapes)
+    expect(posted[0].type).toBe('ext:shapes-add')
+    expect(posted[0].payload.shapes).toEqual(shapes)
+  })
+
+  it('updateShapes sends ext:shapes-update', () => {
+    const client = new ExtensionClient('test-ext')
+    posted = []
+    const updates = [{ id: 's1', props: { color: 'red' } }]
+    client.updateShapes(updates)
+    expect(posted[0].type).toBe('ext:shapes-update')
+    expect(posted[0].payload.updates).toEqual(updates)
+  })
+
+  it('deleteShapes sends ext:shapes-delete', () => {
+    const client = new ExtensionClient('test-ext')
+    posted = []
+    client.deleteShapes(['s1', 's2'])
+    expect(posted[0].type).toBe('ext:shapes-delete')
+    expect(posted[0].payload.ids).toEqual(['s1', 's2'])
+  })
+
+  // --- shapes:read ---
+
+  it('requestShapes sends request and resolves with shapes', async () => {
+    const client = new ExtensionClient('test-ext')
+    posted = []
+
+    const promise = client.requestShapes({ types: ['vehicle'] })
+    const requestId = posted[0].payload.requestId
+
+    expect(posted[0].type).toBe('ext:shapes-request')
+    expect(posted[0].payload.filter).toEqual({ types: ['vehicle'] })
+
+    const shapes = [{ id: 's1', type: 'vehicle', x: 0, y: 0, rotation: 0, zIndex: 0, props: {} }]
+    dispatchMessage({ type: 'ext:shapes-response', payload: { requestId, shapes } })
+
+    const result = await promise
+    expect(result).toEqual(shapes)
+  })
+
+  // --- snapshot:read ---
+
+  it('requestSnapshot sends request and resolves with snapshot', async () => {
+    const client = new ExtensionClient('test-ext')
+    posted = []
+
+    const promise = client.requestSnapshot()
+    const requestId = posted[0].payload.requestId
+
+    expect(posted[0].type).toBe('ext:snapshot-request')
+
+    const snapshot = { version: '1.1', timestamp: '2026-01-01', shapes: [], camera: { x: 0, y: 0, z: 1 } }
+    dispatchMessage({ type: 'ext:snapshot-response', payload: { requestId, snapshot } })
+
+    const result = await promise
+    expect(result).toEqual(snapshot)
+  })
+
+  // --- snapshot:export ---
+
+  it('requestExport sends request with returnData and resolves with data URI', async () => {
+    const client = new ExtensionClient('test-ext')
+    posted = []
+
+    const promise = client.requestExport('png', { returnData: true })
+    const requestId = posted[0].payload.requestId
+
+    expect(posted[0].type).toBe('ext:export-request')
+    expect(posted[0].payload.format).toBe('png')
+    expect(posted[0].payload.returnData).toBe(true)
+
+    const response = {
+      requestId,
+      data: 'data:image/png;base64,abc123',
+      mimeType: 'image/png',
+      filename: 'scene-2026-01-01.png',
+    }
+    dispatchMessage({ type: 'ext:export-response', payload: response })
+
+    const result = await promise
+    expect(result.data).toBe('data:image/png;base64,abc123')
+    expect(result.mimeType).toBe('image/png')
+    expect(result.filename).toBe('scene-2026-01-01.png')
+  })
+
+  it('requestExport without returnData sends undefined', async () => {
+    const client = new ExtensionClient('test-ext')
+    posted = []
+
+    const promise = client.requestExport('svg')
+    const requestId = posted[0].payload.requestId
+
+    expect(posted[0].payload.returnData).toBeUndefined()
+
+    dispatchMessage({
+      type: 'ext:export-response',
+      payload: { requestId, data: '', mimeType: 'image/svg+xml', filename: 'scene.svg' },
+    })
+
+    const result = await promise
+    expect(result.data).toBe('')
+  })
+
+  // --- viewport:read ---
+
+  it('requestViewport sends request and resolves with viewport data', async () => {
+    const client = new ExtensionClient('test-ext')
+    posted = []
+
+    const promise = client.requestViewport()
+    const requestId = posted[0].payload.requestId
+
+    expect(posted[0].type).toBe('ext:viewport-request')
+
+    const viewport = { requestId, x: 10, y: 20, zoom: 1.5, width: 800, height: 600 }
+    dispatchMessage({ type: 'ext:viewport-response', payload: viewport })
+
+    const result = await promise
+    expect(result.x).toBe(10)
+    expect(result.y).toBe(20)
+    expect(result.zoom).toBe(1.5)
+    expect(result.width).toBe(800)
+    expect(result.height).toBe(600)
+  })
+
+  // --- selection:read ---
+
+  it('requestSelection sends request and resolves with selection', async () => {
+    const client = new ExtensionClient('test-ext')
+    posted = []
+
+    const promise = client.requestSelection()
+    const requestId = posted[0].payload.requestId
+
+    expect(posted[0].type).toBe('ext:selection-request')
+
+    dispatchMessage({ type: 'ext:selection-response', payload: { requestId, ids: ['s1', 's2'] } })
+
+    const result = await promise
+    expect(result.ids).toEqual(['s1', 's2'])
+  })
+
+  // --- ui:notify ---
+
+  it('notify sends ext:notify with default level', () => {
+    const client = new ExtensionClient('test-ext')
+    posted = []
+    client.notify('Hello')
+    expect(posted[0]).toEqual({
+      type: 'ext:notify',
+      payload: { message: 'Hello', level: 'info' },
+    })
+  })
+
+  it('notify sends ext:notify with specified level', () => {
+    const client = new ExtensionClient('test-ext')
+    posted = []
+    client.notify('Error!', 'error')
+    expect(posted[0].payload.level).toBe('error')
+  })
+
+  // --- ui:panel ---
+
+  it('resize sends ext:resize', () => {
+    const client = new ExtensionClient('test-ext')
+    posted = []
+    client.resize(400, 300)
+    expect(posted[0]).toEqual({
+      type: 'ext:resize',
+      payload: { height: 400, width: 300 },
+    })
+  })
+
+  it('resize sends ext:resize without width', () => {
+    const client = new ExtensionClient('test-ext')
+    posted = []
+    client.resize(500)
+    expect(posted[0].payload.height).toBe(500)
+    expect(posted[0].payload.width).toBeUndefined()
+  })
+
+  // --- Error handling ---
+
+  it('rejects pending request on ext:error', async () => {
+    const client = new ExtensionClient('test-ext')
+    posted = []
+
+    const promise = client.requestShapes()
+    const requestId = posted[0].payload.requestId
+
+    dispatchMessage({
+      type: 'ext:error',
+      payload: { requestId, message: 'Permission denied' },
+    })
+
+    await expect(promise).rejects.toThrow('Permission denied')
+  })
+
+  // --- Timeout ---
+
+  it('rejects on timeout', async () => {
+    const client = new ExtensionClient('test-ext', { requestTimeout: 50 })
+    posted = []
+
+    const promise = client.requestViewport()
+    // No response dispatched — should timeout
+
+    await expect(promise).rejects.toThrow(/timed out/)
+  })
+
+  // --- Message filtering ---
+
+  it('ignores messages without ext: prefix', async () => {
+    const client = new ExtensionClient('test-ext')
+    posted = []
+
+    const promise = client.requestViewport()
+    const requestId = posted[0].payload.requestId
+
+    // This should be ignored
+    dispatchMessage({ type: 'other-message', payload: { requestId, x: 0, y: 0, zoom: 1, width: 100, height: 100 } })
+
+    // Now send the real response
+    dispatchMessage({ type: 'ext:viewport-response', payload: { requestId, x: 0, y: 0, zoom: 1, width: 100, height: 100 } })
+
+    const result = await promise
+    expect(result.width).toBe(100)
+  })
+
+  it('ignores malformed messages', () => {
+    new ExtensionClient('test-ext')
+    // Should not throw
+    dispatchMessage(null)
+    dispatchMessage(undefined)
+    dispatchMessage('string')
+    dispatchMessage({ noType: true })
+    dispatchMessage({ type: 123 })
+  })
+})

--- a/packages/drawtonomy-sdk/package.json
+++ b/packages/drawtonomy-sdk/package.json
@@ -29,6 +29,7 @@
   ],
   "license": "Apache-2.0",
   "devDependencies": {
+    "jsdom": "^29.0.1",
     "typescript": "^5.7.0",
     "vitest": "^4.1.2"
   }

--- a/packages/drawtonomy-sdk/src/ExtensionClient.ts
+++ b/packages/drawtonomy-sdk/src/ExtensionClient.ts
@@ -4,6 +4,8 @@ import type {
   ShapeFilter,
   BaseShape,
   DrawtonomySnapshot,
+  ExportFormat,
+  ExportResponse,
 } from './types'
 
 interface PendingRequest {
@@ -70,6 +72,19 @@ export class ExtensionClient {
     this.send({ type: 'ext:snapshot-request', payload: { requestId } })
     const response = await this.waitForResponse(requestId) as { snapshot: DrawtonomySnapshot }
     return response.snapshot
+  }
+
+  // --- snapshot:export ---
+
+  /**
+   * Export the scene in the specified format.
+   * When `returnData` is true, returns a Base64 data URI string instead of triggering a file download.
+   * Requires `snapshot:export` capability.
+   */
+  async requestExport(format: ExportFormat, options?: { returnData?: boolean }): Promise<ExportResponse> {
+    const requestId = this.nextRequestId()
+    this.send({ type: 'ext:export-request', payload: { requestId, format, returnData: options?.returnData } })
+    return await this.waitForResponse(requestId) as ExportResponse
   }
 
   // --- viewport:read ---

--- a/packages/drawtonomy-sdk/src/types.ts
+++ b/packages/drawtonomy-sdk/src/types.ts
@@ -188,6 +188,16 @@ export interface ExtensionManifest {
   minHostVersion?: string
 }
 
+// Export
+export type ExportFormat = 'svg' | 'png' | 'jpeg' | 'eps' | 'pdf' | 'drawtonomy.svg' | 'json'
+
+export interface ExportResponse {
+  requestId: string
+  data: string
+  mimeType: string
+  filename: string
+}
+
 // Message types (for extension-side use)
 export interface ShapeFilter {
   types?: string[]


### PR DESCRIPTION
## Summary

- Add `requestExport(format, { returnData })` method to `ExtensionClient`
- Add `ExportFormat` / `ExportResponse` types to SDK
- Update English and Japanese extension docs

## Usage

### Manifest

```json
{
  "capabilities": ["snapshot:export"]
}
```

### With SDK

```typescript
import { ExtensionClient } from '@drawtonomy/sdk'

const client = new ExtensionClient('my-extension')
await client.waitForInit()

// Get image as Base64 data URI (no file download)
const result = await client.requestExport('png', { returnData: true })
result.data      // "data:image/png;base64,iVBOR..."
result.mimeType  // "image/png"
result.filename  // "scene-2026-04-02T12-00-00.png"

// Trigger file download (default)
await client.requestExport('svg')
```

### Supported formats

`'svg' | 'png' | 'jpeg' | 'eps' | 'pdf' | 'drawtonomy.svg' | 'json'`

### Without SDK

```javascript
window.parent.postMessage({
  type: 'ext:export-request',
  payload: { requestId: 'req-1', format: 'png', returnData: true }
}, '*')

window.addEventListener('message', (event) => {
  if (event.data.type === 'ext:export-response') {
    const { data, mimeType, filename } = event.data.payload
    // data = "data:image/png;base64,..." when returnData is true
  }
})
```

## Notes

- Max message size: 10MB
- PNG/JPEG exported at pixelRatio 2
- Omitting `returnData` or setting it to `false` triggers a file download (existing behavior)