### PR TITLE
Add international traffic sign templates

### DIFF
--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,64 +1,2078 @@
 {
   "vehicle": [
-    { "id": "sedan", "name": "Sedan", "svg": "vehicle/sedan.svg", "w": 30, "h": 56, "viewBox": [25, 47.032] },
-    { "id": "bus", "name": "Bus", "svg": "vehicle/bus.svg", "w": 37, "h": 92, "viewBox": [341, 850] },
-    { "id": "truck", "name": "Truck", "svg": "vehicle/truck.svg", "w": 43, "h": 147, "viewBox": [328, 1114] },
-    { "id": "golf_cart", "name": "Golf Cart", "svg": "vehicle/golf_cart.svg", "w": 23, "h": 43, "viewBox": [335, 613] },
-    { "id": "amr", "name": "AMR", "svg": "vehicle/amr.svg", "w": 11, "h": 16, "viewBox": [601, 870] },
-    { "id": "amr2", "name": "AMR 2", "svg": "vehicle/amr2.svg", "w": 11, "h": 16, "viewBox": [477, 694] },
-    { "id": "robovac", "name": "Robovac", "svg": "vehicle/robovac.svg", "w": 11, "h": 11, "viewBox": [678, 665] },
-    { "id": "motorcycle", "name": "Motorcycle", "svg": "vehicle/motorcycle.svg", "w": 18, "h": 36, "viewBox": [410, 830] },
-    { "id": "motorcycle2", "name": "Motorcycle 2", "svg": "vehicle/motorcycle2.svg", "w": 22, "h": 43, "viewBox": [542, 921] },
-    { "id": "bicycle", "name": "Bicycle", "svg": "vehicle/bicycle.svg", "w": 18, "h": 36, "viewBox": [619, 1212] },
-    { "id": "bicycle2", "name": "Bicycle 2", "svg": "vehicle/bicycle2.svg", "w": 17, "h": 42, "viewBox": [497, 1224] },
-    { "id": "rectangle", "name": "Rectangle", "svg": "", "w": 30, "h": 56, "viewBox": [30, 56] },
-    { "id": "default", "name": "Simple", "svg": "", "w": 30, "h": 56, "viewBox": [30, 56] }
+    {
+      "id": "sedan",
+      "name": "Sedan",
+      "svg": "vehicle/sedan.svg",
+      "w": 30,
+      "h": 56,
+      "viewBox": [
+        25,
+        47.032
+      ]
+    },
+    {
+      "id": "bus",
+      "name": "Bus",
+      "svg": "vehicle/bus.svg",
+      "w": 37,
+      "h": 92,
+      "viewBox": [
+        341,
+        850
+      ]
+    },
+    {
+      "id": "truck",
+      "name": "Truck",
+      "svg": "vehicle/truck.svg",
+      "w": 43,
+      "h": 147,
+      "viewBox": [
+        328,
+        1114
+      ]
+    },
+    {
+      "id": "golf_cart",
+      "name": "Golf Cart",
+      "svg": "vehicle/golf_cart.svg",
+      "w": 23,
+      "h": 43,
+      "viewBox": [
+        335,
+        613
+      ]
+    },
+    {
+      "id": "amr",
+      "name": "AMR",
+      "svg": "vehicle/amr.svg",
+      "w": 11,
+      "h": 16,
+      "viewBox": [
+        601,
+        870
+      ]
+    },
+    {
+      "id": "amr2",
+      "name": "AMR 2",
+      "svg": "vehicle/amr2.svg",
+      "w": 11,
+      "h": 16,
+      "viewBox": [
+        477,
+        694
+      ]
+    },
+    {
+      "id": "robovac",
+      "name": "Robovac",
+      "svg": "vehicle/robovac.svg",
+      "w": 11,
+      "h": 11,
+      "viewBox": [
+        678,
+        665
+      ]
+    },
+    {
+      "id": "motorcycle",
+      "name": "Motorcycle",
+      "svg": "vehicle/motorcycle.svg",
+      "w": 18,
+      "h": 36,
+      "viewBox": [
+        410,
+        830
+      ]
+    },
+    {
+      "id": "motorcycle2",
+      "name": "Motorcycle 2",
+      "svg": "vehicle/motorcycle2.svg",
+      "w": 22,
+      "h": 43,
+      "viewBox": [
+        542,
+        921
+      ]
+    },
+    {
+      "id": "bicycle",
+      "name": "Bicycle",
+      "svg": "vehicle/bicycle.svg",
+      "w": 18,
+      "h": 36,
+      "viewBox": [
+        619,
+        1212
+      ]
+    },
+    {
+      "id": "bicycle2",
+      "name": "Bicycle 2",
+      "svg": "vehicle/bicycle2.svg",
+      "w": 17,
+      "h": 42,
+      "viewBox": [
+        497,
+        1224
+      ]
+    },
+    {
+      "id": "rectangle",
+      "name": "Rectangle",
+      "svg": "",
+      "w": 30,
+      "h": 56,
+      "viewBox": [
+        30,
+        56
+      ]
+    },
+    {
+      "id": "default",
+      "name": "Simple",
+      "svg": "",
+      "w": 30,
+      "h": 56,
+      "viewBox": [
+        30,
+        56
+      ]
+    }
   ],
   "pedestrian": [
-    { "id": "filled", "name": "Pedestrian (Filled)", "svg": "pedestrian/pedestrian_filled.svg", "w": 22, "h": 22, "viewBox": [620, 620], "replaceColor": null },
-    { "id": "pedestrian", "name": "Pedestrian", "svg": "pedestrian/pedestrian.svg", "w": 22, "h": 22, "viewBox": [590, 590], "replaceColor": null },
-    { "id": "walk", "name": "Pedestrian (Walking)", "svg": "pedestrian/pedestrian_walk.svg", "w": 22, "h": 22, "viewBox": [220, 220], "replaceColor": "#b3b3b3", "defaultColor": "grey-300" },
-    { "id": "simple", "name": "Pedestrian (Simple)", "svg": "pedestrian/pedestrian_simple.svg", "w": 22, "h": 22, "viewBox": [210, 210], "replaceColor": "#b3b3b3", "defaultColor": "grey-300" }
+    {
+      "id": "filled",
+      "name": "Pedestrian (Filled)",
+      "svg": "pedestrian/pedestrian_filled.svg",
+      "w": 22,
+      "h": 22,
+      "viewBox": [
+        620,
+        620
+      ],
+      "replaceColor": null
+    },
+    {
+      "id": "pedestrian",
+      "name": "Pedestrian",
+      "svg": "pedestrian/pedestrian.svg",
+      "w": 22,
+      "h": 22,
+      "viewBox": [
+        590,
+        590
+      ],
+      "replaceColor": null
+    },
+    {
+      "id": "walk",
+      "name": "Pedestrian (Walking)",
+      "svg": "pedestrian/pedestrian_walk.svg",
+      "w": 22,
+      "h": 22,
+      "viewBox": [
+        220,
+        220
+      ],
+      "replaceColor": "#b3b3b3",
+      "defaultColor": "grey-300"
+    },
+    {
+      "id": "simple",
+      "name": "Pedestrian (Simple)",
+      "svg": "pedestrian/pedestrian_simple.svg",
+      "w": 22,
+      "h": 22,
+      "viewBox": [
+        210,
+        210
+      ],
+      "replaceColor": "#b3b3b3",
+      "defaultColor": "grey-300"
+    }
+  ],
+  "sign": [
+    {
+      "id": "stop_sign",
+      "name": "Stop",
+      "svg": "sign/stop_sign.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_yield",
+      "name": "Yield",
+      "svg": "sign/sign_yield.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_yield_give_way",
+      "name": "Give Way (with text)",
+      "svg": "sign/sign_yield_give_way.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_no_entry",
+      "name": "No Entry",
+      "svg": "sign/sign_no_entry.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_do_not_enter",
+      "name": "Do Not Enter",
+      "svg": "sign/sign_do_not_enter.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_one_way",
+      "name": "One Way",
+      "svg": "sign/sign_one_way.svg",
+      "w": 36,
+      "h": 18,
+      "viewBox": [
+        160,
+        80
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_no_parking",
+      "name": "No Parking",
+      "svg": "sign/sign_no_parking.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_no_overtaking",
+      "name": "No Overtaking",
+      "svg": "sign/sign_no_overtaking.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_end_no_overtaking",
+      "name": "End of No Overtaking",
+      "svg": "sign/sign_end_no_overtaking.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_no_truck",
+      "name": "No Trucks",
+      "svg": "sign/sign_no_truck.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_no_pedestrian",
+      "name": "No Pedestrians",
+      "svg": "sign/sign_no_pedestrian.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_no_bicycle",
+      "name": "No Bicycles",
+      "svg": "sign/sign_no_bicycle.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_no_horn",
+      "name": "No Horn",
+      "svg": "sign/sign_no_horn.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_no_left_turn",
+      "name": "No Left Turn",
+      "svg": "sign/sign_no_left_turn.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_no_right_turn",
+      "name": "No Right Turn",
+      "svg": "sign/sign_no_right_turn.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "speed_sign",
+      "name": "Speed (blank)",
+      "svg": "sign/speed_sign.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_speed_limit",
+      "name": "Speed Limit",
+      "svg": "sign/sign_speed_limit.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_minimum_speed",
+      "name": "Minimum Speed",
+      "svg": "sign/sign_minimum_speed.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_end_speed_limit",
+      "name": "End of Speed Limit",
+      "svg": "sign/sign_end_speed_limit.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_warning_generic",
+      "name": "Warning",
+      "svg": "sign/sign_warning_generic.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "crosswalk_sign",
+      "name": "Crosswalk",
+      "svg": "sign/crosswalk_sign.svg",
+      "w": 27,
+      "h": 30,
+      "viewBox": [
+        120,
+        135
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_pedestrian_crossing",
+      "name": "Pedestrian Crossing",
+      "svg": "sign/sign_pedestrian_crossing.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_school_zone",
+      "name": "School Zone",
+      "svg": "sign/sign_school_zone.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_railway_crossing",
+      "name": "Railway Crossing",
+      "svg": "sign/sign_railway_crossing.svg",
+      "w": 33,
+      "h": 24,
+      "viewBox": [
+        160,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_curve_ahead",
+      "name": "Curve Ahead",
+      "svg": "sign/sign_curve_ahead.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_roundabout_ahead",
+      "name": "Roundabout Ahead",
+      "svg": "sign/sign_roundabout_ahead.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_slippery_road",
+      "name": "Slippery Road",
+      "svg": "sign/sign_slippery_road.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_animal_crossing",
+      "name": "Animal Crossing",
+      "svg": "sign/sign_animal_crossing.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_signal_ahead",
+      "name": "Signal Ahead",
+      "svg": "sign/sign_signal_ahead.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_two_way_traffic",
+      "name": "Two-Way Traffic",
+      "svg": "sign/sign_two_way_traffic.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_road_narrows",
+      "name": "Road Narrows",
+      "svg": "sign/sign_road_narrows.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_priority_road",
+      "name": "Priority Road",
+      "svg": "sign/sign_priority_road.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_end_priority_road",
+      "name": "End of Priority Road",
+      "svg": "sign/sign_end_priority_road.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_keep_right",
+      "name": "Keep Right",
+      "svg": "sign/sign_keep_right.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_keep_left",
+      "name": "Keep Left",
+      "svg": "sign/sign_keep_left.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_roundabout",
+      "name": "Roundabout",
+      "svg": "sign/sign_roundabout.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_motorway",
+      "name": "Motorway",
+      "svg": "sign/sign_motorway.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_end_motorway",
+      "name": "End of Motorway",
+      "svg": "sign/sign_end_motorway.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_pedestrian_zone",
+      "name": "Pedestrian Zone",
+      "svg": "sign/sign_pedestrian_zone.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_residential_area",
+      "name": "Residential Area",
+      "svg": "sign/sign_residential_area.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_parking",
+      "name": "Parking",
+      "svg": "sign/sign_parking.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_hospital",
+      "name": "Hospital",
+      "svg": "sign/sign_hospital.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_bus_lane",
+      "name": "Bus Lane",
+      "svg": "sign/sign_bus_lane.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_bike_lane",
+      "name": "Bike Lane",
+      "svg": "sign/sign_bike_lane.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_airport",
+      "name": "Airport",
+      "svg": "sign/sign_airport.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_gas_station",
+      "name": "Gas Station",
+      "svg": "sign/sign_gas_station.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_lodging",
+      "name": "Lodging",
+      "svg": "sign/sign_lodging.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_food",
+      "name": "Food",
+      "svg": "sign/sign_food.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_camping",
+      "name": "Camping",
+      "svg": "sign/sign_camping.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_information",
+      "name": "Information",
+      "svg": "sign/sign_information.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign",
+      "name": "Generic Sign",
+      "svg": "sign/sign.svg",
+      "w": 33,
+      "h": 21,
+      "viewBox": [
+        200,
+        130
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "construction_sign",
+      "name": "Construction",
+      "svg": "sign/construction_sign.svg",
+      "w": 33,
+      "h": 21,
+      "viewBox": [
+        200,
+        130
+      ],
+      "defaultColor": "transparent",
+      "region": "International"
+    },
+    {
+      "id": "sign_jp_stop",
+      "name": "Stop / 止まれ",
+      "svg": "sign/sign_jp_stop.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "Japan"
+    },
+    {
+      "id": "sign_jp_slow",
+      "name": "Slow / 徐行",
+      "svg": "sign/sign_jp_slow.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "Japan"
+    },
+    {
+      "id": "sign_jp_no_entry",
+      "name": "No Entry / 進入禁止",
+      "svg": "sign/sign_jp_no_entry.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "Japan"
+    },
+    {
+      "id": "sign_jp_no_thoroughfare",
+      "name": "No Thoroughfare / 通行止",
+      "svg": "sign/sign_jp_no_thoroughfare.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "Japan"
+    },
+    {
+      "id": "sign_jp_no_parking",
+      "name": "No Parking / 駐車禁止",
+      "svg": "sign/sign_jp_no_parking.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "Japan"
+    },
+    {
+      "id": "sign_jp_no_stopping",
+      "name": "No Stopping / 駐停車禁止",
+      "svg": "sign/sign_jp_no_stopping.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "Japan"
+    },
+    {
+      "id": "sign_jp_one_way",
+      "name": "One Way / 一方通行",
+      "svg": "sign/sign_jp_one_way.svg",
+      "w": 36,
+      "h": 18,
+      "viewBox": [
+        160,
+        80
+      ],
+      "defaultColor": "transparent",
+      "region": "Japan"
+    },
+    {
+      "id": "sign_jp_warning_curve",
+      "name": "Curve Ahead / 屈曲",
+      "svg": "sign/sign_jp_warning_curve.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "Japan"
+    },
+    {
+      "id": "sign_jp_warning_pedestrian",
+      "name": "Pedestrian / 横断歩道あり",
+      "svg": "sign/sign_jp_warning_pedestrian.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "Japan"
+    },
+    {
+      "id": "sign_jp_warning_school",
+      "name": "School / 学校あり",
+      "svg": "sign/sign_jp_warning_school.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "Japan"
+    },
+    {
+      "id": "sign_us_pedestrian_crossing",
+      "name": "Pedestrian Crossing (US)",
+      "svg": "sign/sign_us_pedestrian_crossing.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "United States"
+    },
+    {
+      "id": "sign_us_school_xing",
+      "name": "School Crossing (US)",
+      "svg": "sign/sign_us_school_xing.svg",
+      "w": 27,
+      "h": 30,
+      "viewBox": [
+        120,
+        130
+      ],
+      "defaultColor": "transparent",
+      "region": "United States"
+    },
+    {
+      "id": "sign_us_signal_ahead",
+      "name": "Signal Ahead (US)",
+      "svg": "sign/sign_us_signal_ahead.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "United States"
+    },
+    {
+      "id": "sign_us_railroad",
+      "name": "Railroad Crossing (US)",
+      "svg": "sign/sign_us_railroad.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "United States"
+    },
+    {
+      "id": "sign_us_no_uturn",
+      "name": "No U-Turn (US)",
+      "svg": "sign/sign_us_no_uturn.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "United States"
+    },
+    {
+      "id": "sign_us_merge",
+      "name": "Merge (US)",
+      "svg": "sign/sign_us_merge.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "United States"
+    },
+    {
+      "id": "sign_us_truck_route",
+      "name": "Truck Route (US)",
+      "svg": "sign/sign_us_truck_route.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "United States"
+    },
+    {
+      "id": "sign_us_speed_limit",
+      "name": "Speed Limit (US)",
+      "svg": "sign/sign_us_speed_limit.svg",
+      "w": 24,
+      "h": 33,
+      "viewBox": [
+        120,
+        160
+      ],
+      "defaultColor": "transparent",
+      "region": "United States"
+    },
+    {
+      "id": "sign_us_do_not_pass",
+      "name": "Do Not Pass (US)",
+      "svg": "sign/sign_us_do_not_pass.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "United States"
+    },
+    {
+      "id": "sign_us_divided_highway",
+      "name": "Divided Highway (US)",
+      "svg": "sign/sign_us_divided_highway.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "United States"
+    },
+    {
+      "id": "sign_us_deer_crossing",
+      "name": "Deer Crossing (US)",
+      "svg": "sign/sign_us_deer_crossing.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "United States"
+    },
+    {
+      "id": "sign_us_wrong_way",
+      "name": "Wrong Way (US)",
+      "svg": "sign/sign_us_wrong_way.svg",
+      "w": 36,
+      "h": 18,
+      "viewBox": [
+        160,
+        80
+      ],
+      "defaultColor": "transparent",
+      "region": "United States"
+    },
+    {
+      "id": "sign_us_road_work",
+      "name": "Road Work (US)",
+      "svg": "sign/sign_us_road_work.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "United States"
+    },
+    {
+      "id": "sign_us_no_turn_on_red",
+      "name": "No Turn On Red (US)",
+      "svg": "sign/sign_us_no_turn_on_red.svg",
+      "w": 24,
+      "h": 33,
+      "viewBox": [
+        120,
+        160
+      ],
+      "defaultColor": "transparent",
+      "region": "United States"
+    },
+    {
+      "id": "sign_us_slippery",
+      "name": "Slippery When Wet (US)",
+      "svg": "sign/sign_us_slippery.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "United States"
+    },
+    {
+      "id": "sign_eu_priority_to_oncoming",
+      "name": "Priority to Oncoming (EU)",
+      "svg": "sign/sign_eu_priority_to_oncoming.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "Europe"
+    },
+    {
+      "id": "sign_eu_priority_over_oncoming",
+      "name": "Priority over Oncoming (EU)",
+      "svg": "sign/sign_eu_priority_over_oncoming.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "Europe"
+    },
+    {
+      "id": "sign_eu_uneven_road",
+      "name": "Uneven Road (EU)",
+      "svg": "sign/sign_eu_uneven_road.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "Europe"
+    },
+    {
+      "id": "sign_eu_falling_rocks",
+      "name": "Falling Rocks (EU)",
+      "svg": "sign/sign_eu_falling_rocks.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "Europe"
+    },
+    {
+      "id": "sign_eu_traffic_jam",
+      "name": "Traffic Jam (EU)",
+      "svg": "sign/sign_eu_traffic_jam.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "Europe"
+    },
+    {
+      "id": "sign_cn_stop",
+      "name": "Stop / 停 (China)",
+      "svg": "sign/sign_cn_stop.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "China"
+    },
+    {
+      "id": "sign_cn_no_entry",
+      "name": "Caution / 注意前方 (China)",
+      "svg": "sign/sign_cn_no_entry.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "China"
+    },
+    {
+      "id": "sign_cn_slow",
+      "name": "Slow / 慢 (China)",
+      "svg": "sign/sign_cn_slow.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "China"
+    },
+    {
+      "id": "sign_cn_no_parking",
+      "name": "No Parking / 停 (China)",
+      "svg": "sign/sign_cn_no_parking.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "China"
+    },
+    {
+      "id": "sign_cn_no_thoroughfare",
+      "name": "No Thoroughfare / 禁止通行 (China)",
+      "svg": "sign/sign_cn_no_thoroughfare.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "China"
+    },
+    {
+      "id": "sign_cn_pedestrian_warning",
+      "name": "Pedestrian Warning / 注意行人 (China)",
+      "svg": "sign/sign_cn_pedestrian_warning.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "China"
+    },
+    {
+      "id": "sign_cn_children",
+      "name": "Children Warning / 注意儿童 (China)",
+      "svg": "sign/sign_cn_children.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "China"
+    },
+    {
+      "id": "sign_cn_turn_left",
+      "name": "Turn Left (China)",
+      "svg": "sign/sign_cn_turn_left.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "China"
+    },
+    {
+      "id": "sign_cn_turn_right",
+      "name": "Turn Right (China)",
+      "svg": "sign/sign_cn_turn_right.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "China"
+    },
+    {
+      "id": "sign_cn_go_straight",
+      "name": "Go Straight (China)",
+      "svg": "sign/sign_cn_go_straight.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "China"
+    },
+    {
+      "id": "sign_au_sharp_turn",
+      "name": "Sharp Turn (AU)",
+      "svg": "sign/sign_au_sharp_turn.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "Australia"
+    },
+    {
+      "id": "sign_au_wombat",
+      "name": "Wombat / Wildlife (AU)",
+      "svg": "sign/sign_au_wombat.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "Australia"
+    },
+    {
+      "id": "sign_au_roundabout_ahead",
+      "name": "Roundabout Ahead (AU)",
+      "svg": "sign/sign_au_roundabout_ahead.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "Australia"
+    },
+    {
+      "id": "sign_au_kangaroo",
+      "name": "Kangaroo Crossing (AU)",
+      "svg": "sign/sign_au_kangaroo.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "Australia"
+    },
+    {
+      "id": "sign_de_priority",
+      "name": "Vorfahrtstraße (DE)",
+      "svg": "sign/sign_de_priority.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "Germany"
+    },
+    {
+      "id": "sign_de_no_vehicles",
+      "name": "Verbot für Fahrzeuge (DE)",
+      "svg": "sign/sign_de_no_vehicles.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "Germany"
+    },
+    {
+      "id": "sign_de_30_zone",
+      "name": "Tempo 30 Zone (DE)",
+      "svg": "sign/sign_de_30_zone.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "Germany"
+    },
+    {
+      "id": "sign_de_end_restrictions",
+      "name": "End of All Restrictions (DE)",
+      "svg": "sign/sign_de_end_restrictions.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "Germany"
+    },
+    {
+      "id": "sign_de_play_street",
+      "name": "Spielstraße / Play Street (DE)",
+      "svg": "sign/sign_de_play_street.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "Germany"
+    },
+    {
+      "id": "sign_uk_national_speed_limit",
+      "name": "National Speed Limit (UK)",
+      "svg": "sign/sign_uk_national_speed_limit.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "United Kingdom"
+    },
+    {
+      "id": "sign_uk_school_children",
+      "name": "School Children (UK)",
+      "svg": "sign/sign_uk_school_children.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "United Kingdom"
+    },
+    {
+      "id": "sign_uk_roundabout",
+      "name": "Roundabout (UK)",
+      "svg": "sign/sign_uk_roundabout.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "United Kingdom"
+    },
+    {
+      "id": "sign_it_merge_right",
+      "name": "Confluenza Destra (IT)",
+      "svg": "sign/sign_it_merge_right.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "Italy"
+    },
+    {
+      "id": "sign_it_ztl",
+      "name": "ZTL / Limited Traffic Zone (IT)",
+      "svg": "sign/sign_it_ztl.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "Italy"
+    },
+    {
+      "id": "sign_in_stop",
+      "name": "Stop (India)",
+      "svg": "sign/sign_in_stop.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "India"
+    },
+    {
+      "id": "sign_in_give_way",
+      "name": "Give Way (India)",
+      "svg": "sign/sign_in_give_way.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "India"
+    },
+    {
+      "id": "sign_in_school_ahead",
+      "name": "School Ahead (India)",
+      "svg": "sign/sign_in_school_ahead.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "India"
+    },
+    {
+      "id": "sign_in_cattle_crossing",
+      "name": "Cattle Crossing (India)",
+      "svg": "sign/sign_in_cattle_crossing.svg",
+      "w": 27,
+      "h": 27,
+      "viewBox": [
+        120,
+        120
+      ],
+      "defaultColor": "transparent",
+      "region": "India"
+    },
+    {
+      "id": "sign_in_horn_prohibited",
+      "name": "Horn Prohibited (India)",
+      "svg": "sign/sign_in_horn_prohibited.svg",
+      "w": 27,
+      "h": 33,
+      "viewBox": [
+        120,
+        150
+      ],
+      "defaultColor": "transparent",
+      "region": "India"
+    }
   ],
   "other": [
-    { "id": "building", "name": "Building", "svg": "other/building.svg", "w": 80, "h": 100, "viewBox": [200, 250], "defaultColor": "transparent" },
-    { "id": "house", "name": "House", "svg": "other/house.svg", "w": 70, "h": 70, "viewBox": [200, 200], "defaultColor": "transparent" },
-    { "id": "shop", "name": "Shop", "svg": "other/shop.svg", "w": 80, "h": 72, "viewBox": [200, 180], "defaultColor": "transparent" },
-    { "id": "warehouse", "name": "Warehouse", "svg": "other/warehouse.svg", "w": 110, "h": 70, "viewBox": [250, 160], "defaultColor": "transparent" },
-    { "id": "guardrail", "name": "Guardrail", "svg": "other/guardrail.svg", "w": 50, "h": 10, "viewBox": [300, 60], "defaultColor": "transparent" },
-    { "id": "barrier", "name": "Barrier", "svg": "other/barrier.svg", "w": 40, "h": 16, "viewBox": [300, 120], "defaultColor": "transparent" },
-    { "id": "fence", "name": "Fence", "svg": "other/fence.svg", "w": 50, "h": 20, "viewBox": [300, 120], "defaultColor": "transparent" },
-    { "id": "curb", "name": "Curb", "svg": "other/curb.svg", "w": 50, "h": 7, "viewBox": [300, 40], "defaultColor": "transparent" },
-    { "id": "median", "name": "Median Strip", "svg": "other/median.svg", "w": 50, "h": 10, "viewBox": [300, 60], "defaultColor": "transparent" },
-    { "id": "manhole", "name": "Manhole", "svg": "other/manhole.svg", "w": 16, "h": 16, "viewBox": [100, 100], "defaultColor": "transparent" },
-    { "id": "bollard", "name": "Bollard", "svg": "other/bollard.svg", "w": 10, "h": 21, "viewBox": [100, 200], "defaultColor": "transparent" },
-    { "id": "cone", "name": "Cone", "svg": "other/cone.svg", "w": 16, "h": 23, "viewBox": [200, 300], "defaultColor": "transparent" },
-    { "id": "stop_sign", "name": "Stop Sign", "svg": "other/stop_sign.svg", "w": 12, "h": 26, "viewBox": [120, 260], "defaultColor": "transparent" },
-    { "id": "speed_sign", "name": "Speed Sign", "svg": "other/speed_sign.svg", "w": 12, "h": 26, "viewBox": [120, 260], "defaultColor": "transparent" },
-    { "id": "crosswalk_sign", "name": "Crosswalk Sign", "svg": "other/crosswalk_sign.svg", "w": 12, "h": 26, "viewBox": [120, 260], "defaultColor": "transparent" },
-    { "id": "sign", "name": "Sign", "svg": "other/sign.svg", "w": 18, "h": 27, "viewBox": [200, 300], "defaultColor": "transparent" },
-    { "id": "construction_sign", "name": "Construction Sign", "svg": "other/construction_sign.svg", "w": 16, "h": 20, "viewBox": [200, 250], "defaultColor": "transparent" },
-    { "id": "construction_fence", "name": "Construction Fence", "svg": "other/construction_fence.svg", "w": 50, "h": 20, "viewBox": [300, 120], "defaultColor": "transparent" },
-    { "id": "streetlight", "name": "Streetlight", "svg": "other/streetlight.svg", "w": 10, "h": 30, "viewBox": [100, 300], "defaultColor": "transparent" },
-    { "id": "utility_pole", "name": "Utility Pole", "svg": "other/utility_pole.svg", "w": 10, "h": 25, "viewBox": [120, 300], "defaultColor": "transparent" },
-    { "id": "pole", "name": "Pole", "svg": "other/pole.svg", "w": 5, "h": 30, "viewBox": [40, 250], "defaultColor": "transparent" },
-    { "id": "bus_stop", "name": "Bus Stop", "svg": "other/bus_stop.svg", "w": 11, "h": 26, "viewBox": [120, 280], "defaultColor": "transparent" },
-    { "id": "bench", "name": "Bench", "svg": "other/bench.svg", "w": 36, "h": 22, "viewBox": [300, 180], "defaultColor": "transparent" },
-    { "id": "trash_can", "name": "Trash Can", "svg": "other/trash_can.svg", "w": 14, "h": 21, "viewBox": [120, 180], "defaultColor": "transparent" },
-    { "id": "mailbox", "name": "Mailbox", "svg": "other/mailbox.svg", "w": 12, "h": 20, "viewBox": [120, 200], "defaultColor": "transparent" },
-    { "id": "vending_machine", "name": "Vending Machine", "svg": "other/vending_machine.svg", "w": 18, "h": 26, "viewBox": [140, 200], "defaultColor": "transparent" },
-    { "id": "fire_hydrant", "name": "Fire Hydrant", "svg": "other/fire_hydrant.svg", "w": 14, "h": 20, "viewBox": [140, 200], "defaultColor": "transparent" },
-    { "id": "parking_meter", "name": "Parking Meter", "svg": "other/parking_meter.svg", "w": 10, "h": 25, "viewBox": [100, 250], "defaultColor": "transparent" },
-    { "id": "tree", "name": "Tree", "svg": "other/tree.svg", "w": 30, "h": 45, "viewBox": [200, 300], "defaultColor": "transparent" },
-    { "id": "palm_tree", "name": "Palm Tree", "svg": "other/palm_tree.svg", "w": 22, "h": 36, "viewBox": [180, 300], "defaultColor": "transparent" },
-    { "id": "bush", "name": "Bush", "svg": "other/bush.svg", "w": 26, "h": 17, "viewBox": [200, 130], "defaultColor": "transparent" },
-    { "id": "flower_bed", "name": "Flower Bed", "svg": "other/flower_bed.svg", "w": 30, "h": 15, "viewBox": [200, 100], "defaultColor": "transparent" },
-    { "id": "rock", "name": "Rock", "svg": "other/rock.svg", "w": 20, "h": 16, "viewBox": [150, 120], "defaultColor": "transparent" },
-    { "id": "wheelchair", "name": "Wheelchair", "svg": "other/wheelchair.svg", "w": 22, "h": 22, "viewBox": [200, 200], "defaultColor": "transparent" },
-    { "id": "stroller", "name": "Stroller", "svg": "other/stroller.svg", "w": 20, "h": 22, "viewBox": [180, 200], "defaultColor": "transparent" },
-    { "id": "suitcase", "name": "Suitcase", "svg": "other/suitcase.svg", "w": 14, "h": 18, "viewBox": [140, 180], "defaultColor": "transparent" },
-    { "id": "stairs", "name": "Stairs", "svg": "other/stairs.svg", "w": 26, "h": 26, "viewBox": [200, 200], "defaultColor": "transparent" },
-    { "id": "ramp", "name": "Ramp", "svg": "other/ramp.svg", "w": 32, "h": 15, "viewBox": [250, 120], "defaultColor": "transparent" },
-    { "id": "flag", "name": "Flag", "svg": "other/flag.svg", "w": 12, "h": 25, "viewBox": [120, 250], "defaultColor": "transparent" }
+    {
+      "id": "building",
+      "name": "Building",
+      "svg": "other/building.svg",
+      "w": 80,
+      "h": 100,
+      "viewBox": [
+        200,
+        250
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "house",
+      "name": "House",
+      "svg": "other/house.svg",
+      "w": 70,
+      "h": 70,
+      "viewBox": [
+        200,
+        200
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "shop",
+      "name": "Shop",
+      "svg": "other/shop.svg",
+      "w": 80,
+      "h": 72,
+      "viewBox": [
+        200,
+        180
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "warehouse",
+      "name": "Warehouse",
+      "svg": "other/warehouse.svg",
+      "w": 110,
+      "h": 70,
+      "viewBox": [
+        250,
+        160
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "guardrail",
+      "name": "Guardrail",
+      "svg": "other/guardrail.svg",
+      "w": 50,
+      "h": 10,
+      "viewBox": [
+        300,
+        60
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "barrier",
+      "name": "Barrier",
+      "svg": "other/barrier.svg",
+      "w": 40,
+      "h": 16,
+      "viewBox": [
+        300,
+        120
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "fence",
+      "name": "Fence",
+      "svg": "other/fence.svg",
+      "w": 50,
+      "h": 20,
+      "viewBox": [
+        300,
+        120
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "curb",
+      "name": "Curb",
+      "svg": "other/curb.svg",
+      "w": 50,
+      "h": 7,
+      "viewBox": [
+        300,
+        40
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "median",
+      "name": "Median Strip",
+      "svg": "other/median.svg",
+      "w": 50,
+      "h": 10,
+      "viewBox": [
+        300,
+        60
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "manhole",
+      "name": "Manhole",
+      "svg": "other/manhole.svg",
+      "w": 16,
+      "h": 16,
+      "viewBox": [
+        100,
+        100
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "bollard",
+      "name": "Bollard",
+      "svg": "other/bollard.svg",
+      "w": 10,
+      "h": 21,
+      "viewBox": [
+        100,
+        200
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "cone",
+      "name": "Cone",
+      "svg": "other/cone.svg",
+      "w": 16,
+      "h": 23,
+      "viewBox": [
+        200,
+        300
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "construction_fence",
+      "name": "Construction Fence",
+      "svg": "other/construction_fence.svg",
+      "w": 50,
+      "h": 20,
+      "viewBox": [
+        300,
+        120
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "streetlight",
+      "name": "Streetlight",
+      "svg": "other/streetlight.svg",
+      "w": 10,
+      "h": 30,
+      "viewBox": [
+        100,
+        300
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "utility_pole",
+      "name": "Utility Pole",
+      "svg": "other/utility_pole.svg",
+      "w": 10,
+      "h": 25,
+      "viewBox": [
+        120,
+        300
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "utility_pole_concrete",
+      "name": "Utility Pole (Concrete)",
+      "svg": "other/utility_pole_concrete.svg",
+      "w": 10,
+      "h": 25,
+      "viewBox": [
+        120,
+        300
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "pole",
+      "name": "Pole",
+      "svg": "other/pole.svg",
+      "w": 5,
+      "h": 30,
+      "viewBox": [
+        40,
+        250
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "bus_stop",
+      "name": "Bus Stop",
+      "svg": "other/bus_stop.svg",
+      "w": 11,
+      "h": 26,
+      "viewBox": [
+        120,
+        280
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "bench",
+      "name": "Bench",
+      "svg": "other/bench.svg",
+      "w": 36,
+      "h": 22,
+      "viewBox": [
+        300,
+        180
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "trash_can",
+      "name": "Trash Can",
+      "svg": "other/trash_can.svg",
+      "w": 14,
+      "h": 21,
+      "viewBox": [
+        120,
+        180
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "mailbox",
+      "name": "Mailbox",
+      "svg": "other/mailbox.svg",
+      "w": 12,
+      "h": 20,
+      "viewBox": [
+        120,
+        200
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "mailbox_us",
+      "name": "Mailbox (US)",
+      "svg": "other/mailbox_us.svg",
+      "w": 16,
+      "h": 20,
+      "viewBox": [
+        160,
+        200
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "vending_machine",
+      "name": "Vending Machine",
+      "svg": "other/vending_machine.svg",
+      "w": 18,
+      "h": 26,
+      "viewBox": [
+        140,
+        200
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "fire_hydrant",
+      "name": "Fire Hydrant",
+      "svg": "other/fire_hydrant.svg",
+      "w": 14,
+      "h": 20,
+      "viewBox": [
+        140,
+        200
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "parking_meter",
+      "name": "Parking Meter",
+      "svg": "other/parking_meter.svg",
+      "w": 10,
+      "h": 25,
+      "viewBox": [
+        100,
+        250
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "tree",
+      "name": "Tree",
+      "svg": "other/tree.svg",
+      "w": 30,
+      "h": 45,
+      "viewBox": [
+        200,
+        300
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "palm_tree",
+      "name": "Palm Tree",
+      "svg": "other/palm_tree.svg",
+      "w": 22,
+      "h": 36,
+      "viewBox": [
+        180,
+        300
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "bush",
+      "name": "Bush",
+      "svg": "other/bush.svg",
+      "w": 26,
+      "h": 17,
+      "viewBox": [
+        200,
+        130
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "flower_bed",
+      "name": "Flower Bed",
+      "svg": "other/flower_bed.svg",
+      "w": 30,
+      "h": 15,
+      "viewBox": [
+        200,
+        100
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "rock",
+      "name": "Rock",
+      "svg": "other/rock.svg",
+      "w": 20,
+      "h": 16,
+      "viewBox": [
+        150,
+        120
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "wheelchair",
+      "name": "Wheelchair",
+      "svg": "other/wheelchair.svg",
+      "w": 22,
+      "h": 22,
+      "viewBox": [
+        200,
+        200
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "stroller",
+      "name": "Stroller",
+      "svg": "other/stroller.svg",
+      "w": 20,
+      "h": 22,
+      "viewBox": [
+        180,
+        200
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "suitcase",
+      "name": "Suitcase",
+      "svg": "other/suitcase.svg",
+      "w": 14,
+      "h": 18,
+      "viewBox": [
+        140,
+        180
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "stairs",
+      "name": "Stairs",
+      "svg": "other/stairs.svg",
+      "w": 26,
+      "h": 26,
+      "viewBox": [
+        200,
+        200
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "ramp",
+      "name": "Ramp",
+      "svg": "other/ramp.svg",
+      "w": 32,
+      "h": 15,
+      "viewBox": [
+        250,
+        120
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "flag",
+      "name": "Flag",
+      "svg": "other/flag.svg",
+      "w": 12,
+      "h": 25,
+      "viewBox": [
+        120,
+        250
+      ],
+      "defaultColor": "transparent"
+    }
   ]
 }

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1355,32 +1355,6 @@
       "region": "China"
     },
     {
-      "id": "sign_cn_turn_left",
-      "name": "Turn Left (China)",
-      "svg": "sign/sign_cn_turn_left.svg",
-      "w": 27,
-      "h": 27,
-      "viewBox": [
-        120,
-        120
-      ],
-      "defaultColor": "transparent",
-      "region": "China"
-    },
-    {
-      "id": "sign_cn_turn_right",
-      "name": "Turn Right (China)",
-      "svg": "sign/sign_cn_turn_right.svg",
-      "w": 27,
-      "h": 27,
-      "viewBox": [
-        120,
-        120
-      ],
-      "defaultColor": "transparent",
-      "region": "China"
-    },
-    {
       "id": "sign_cn_go_straight",
       "name": "Go Straight (China)",
       "svg": "sign/sign_cn_go_straight.svg",
@@ -1592,19 +1566,6 @@
       "id": "sign_in_give_way",
       "name": "Give Way (India)",
       "svg": "sign/sign_in_give_way.svg",
-      "w": 27,
-      "h": 27,
-      "viewBox": [
-        120,
-        120
-      ],
-      "defaultColor": "transparent",
-      "region": "India"
-    },
-    {
-      "id": "sign_in_school_ahead",
-      "name": "School Ahead (India)",
-      "svg": "sign/sign_in_school_ahead.svg",
       "w": 27,
       "h": 27,
       "viewBox": [

--- a/templates/other/mailbox_us.svg
+++ b/templates/other/mailbox_us.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 160 200" fill="none">
+  <rect x="70" y="110" width="14" height="85" rx="2" fill="#777777"/>
+  <rect x="40" y="180" width="75" height="10" rx="2" fill="#666666"/>
+  <path d="M10 100 L10 60 Q10 30 70 30 L130 30 Q130 70 130 100 Z" fill="#DDDDDD" stroke="#999999" stroke-width="2"/>
+  <path d="M10 60 Q10 30 70 30 L130 30 L130 60 Z" fill="#CCCCCC"/>
+  <rect x="116" y="62" width="14" height="20" rx="2" fill="#888888"/>
+  <rect x="120" y="82" width="6" height="12" fill="#555555"/>
+  <rect x="125" y="55" width="6" height="45" fill="#AA1111"/>
+  <polygon points="131,55 148,60 131,72" fill="#CC2222"/>
+</svg>

--- a/templates/other/sign.svg
+++ b/templates/other/sign.svg
@@ -1,8 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 200 300" fill="none">
-  <!-- Pole -->
-  <rect x="90" y="120" width="20" height="170" rx="3" fill="#888888"/>
-  <!-- Sign board -->
-  <rect x="20" y="10" width="160" height="120" rx="8" fill="#3366CC" stroke="#222222" stroke-width="4"/>
-  <!-- Inner border -->
-  <rect x="30" y="20" width="140" height="100" rx="4" fill="none" stroke="white" stroke-width="2"/>
-</svg>

--- a/templates/other/speed_sign.svg
+++ b/templates/other/speed_sign.svg
@@ -1,5 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 260" fill="none">
-  <rect x="52" y="120" width="16" height="130" rx="3" fill="#888888"/>
-  <circle cx="60" cy="65" r="55" fill="white" stroke="#DD0000" stroke-width="8"/>
-  <circle cx="60" cy="65" r="40" fill="white"/>
-</svg>

--- a/templates/other/stop_sign.svg
+++ b/templates/other/stop_sign.svg
@@ -1,5 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 260" fill="none">
-  <rect x="52" y="110" width="16" height="140" rx="3" fill="#888888"/>
-  <polygon points="60,10 95,25 108,60 108,90 95,125 60,140 25,125 12,90 12,60 25,25" fill="#DD0000" stroke="#AA0000" stroke-width="3"/>
-  <polygon points="60,22 88,34 99,62 99,88 88,116 60,128 32,116 21,88 21,62 32,34" fill="none" stroke="white" stroke-width="2"/>
-</svg>

--- a/templates/other/utility_pole_concrete.svg
+++ b/templates/other/utility_pole_concrete.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 300" fill="none">
+  <rect x="52" y="15" width="16" height="275" rx="3" fill="#AAAAAA"/>
+  <rect x="52" y="15" width="16" height="275" rx="3" stroke="#888888" stroke-width="1" fill="none"/>
+  <rect x="15" y="25" width="90" height="8" rx="2" fill="#999999"/>
+  <rect x="25" y="55" width="70" height="7" rx="2" fill="#999999"/>
+  <line x1="20" y1="28" x2="20" y2="45" stroke="#333333" stroke-width="2"/>
+  <line x1="50" y1="28" x2="50" y2="45" stroke="#333333" stroke-width="2"/>
+  <line x1="70" y1="28" x2="70" y2="45" stroke="#333333" stroke-width="2"/>
+  <line x1="100" y1="28" x2="100" y2="45" stroke="#333333" stroke-width="2"/>
+  <rect x="55" y="100" width="10" height="22" rx="2" fill="#777777"/>
+  <rect x="55" y="150" width="10" height="22" rx="2" fill="#777777"/>
+</svg>

--- a/templates/sign/construction_sign.svg
+++ b/templates/sign/construction_sign.svg
@@ -1,6 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 200 250" fill="none">
-  <rect x="55" y="130" width="12" height="110" rx="2" fill="#888888"/>
-  <rect x="133" y="130" width="12" height="110" rx="2" fill="#888888"/>
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 200 130" fill="none">
   <polygon points="100,10 190,130 10,130" fill="#FFD700" stroke="#CC9900" stroke-width="4"/>
   <polygon points="100,35 170,125 30,125" fill="none" stroke="#333333" stroke-width="3"/>
   <rect x="88" y="65" width="24" height="40" rx="3" fill="#333333"/>

--- a/templates/sign/crosswalk_sign.svg
+++ b/templates/sign/crosswalk_sign.svg
@@ -1,9 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 135" fill="none">
-  <polygon points="60,5 115,40 115,100 60,135 5,100 5,40" fill="#2266CC"/>
-  <polygon points="60,15 105,44 105,96 60,125 15,96 15,44" fill="none" stroke="white" stroke-width="2"/>
-  <line x1="40" y1="95" x2="40" y2="55" stroke="white" stroke-width="4"/>
-  <line x1="50" y1="95" x2="50" y2="55" stroke="white" stroke-width="4"/>
-  <line x1="60" y1="95" x2="60" y2="55" stroke="white" stroke-width="4"/>
-  <line x1="70" y1="95" x2="70" y2="55" stroke="white" stroke-width="4"/>
-  <line x1="80" y1="95" x2="80" y2="55" stroke="white" stroke-width="4"/>
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <!-- Vienna Convention E12a: 青正方形 + 白三角 + 黒歩行者 + ゼブラ -->
+  <rect x="6" y="6" width="108" height="108" rx="3" fill="#1E4FAA"/>
+  <polygon points="60,18 102,96 18,96" fill="#FFFFFF"/>
+  <!-- 歩行者 (黒、進行方向右) -->
+  <circle cx="55" cy="40" r="4" fill="#111111"/>
+  <path d="M55 45 L51 58 L51 74 L55 74 L55 62 L60 62 L60 74 L65 74 L65 58 L69 60 L72 56 L63 49 L60 45 Z" fill="#111111"/>
+  <!-- ゼブラ (黒線 4 本) -->
+  <g fill="#111111">
+    <rect x="48" y="80" width="3" height="10"/>
+    <rect x="54" y="80" width="3" height="10"/>
+    <rect x="60" y="80" width="3" height="10"/>
+    <rect x="66" y="80" width="3" height="10"/>
+  </g>
 </svg>

--- a/templates/sign/crosswalk_sign.svg
+++ b/templates/sign/crosswalk_sign.svg
@@ -1,5 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 260" fill="none">
-  <rect x="52" y="120" width="16" height="130" rx="3" fill="#888888"/>
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 135" fill="none">
   <polygon points="60,5 115,40 115,100 60,135 5,100 5,40" fill="#2266CC"/>
   <polygon points="60,15 105,44 105,96 60,125 15,96 15,44" fill="none" stroke="white" stroke-width="2"/>
   <line x1="40" y1="95" x2="40" y2="55" stroke="white" stroke-width="4"/>

--- a/templates/sign/sign.svg
+++ b/templates/sign/sign.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 200 130" fill="none">
+  <rect x="20" y="10" width="160" height="120" rx="8" fill="#3366CC" stroke="#222222" stroke-width="4"/>
+  <rect x="30" y="20" width="140" height="100" rx="4" fill="none" stroke="white" stroke-width="2"/>
+</svg>

--- a/templates/sign/sign_airport.svg
+++ b/templates/sign/sign_airport.svg
@@ -1,6 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <rect x="10" y="10" width="100" height="100" rx="6" fill="#1E4FAA" stroke="#17408A" stroke-width="3"/>
-  <g fill="#FFFFFF">
-    <path d="M60 28 L66 50 L94 60 L66 70 L66 86 L74 92 L74 96 L60 92 L46 96 L46 92 L54 86 L54 70 L26 60 L54 50 Z"/>
+  <!-- 飛行機シルエット (上昇中、回転で角度付ける) -->
+  <g fill="#FFFFFF" transform="rotate(-30 60 60)">
+    <path d="M60 22 L65 56 L96 70 L65 70 L60 96 L72 96 L60 106 L48 96 L60 96 L55 70 L24 70 L55 56 Z"/>
   </g>
 </svg>

--- a/templates/sign/sign_airport.svg
+++ b/templates/sign/sign_airport.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <rect x="10" y="10" width="100" height="100" rx="6" fill="#1E4FAA" stroke="#17408A" stroke-width="3"/>
+  <g fill="#FFFFFF">
+    <path d="M60 28 L66 50 L94 60 L66 70 L66 86 L74 92 L74 96 L60 92 L46 96 L46 92 L54 86 L54 70 L26 60 L54 50 Z"/>
+  </g>
+</svg>

--- a/templates/sign/sign_animal_crossing.svg
+++ b/templates/sign/sign_animal_crossing.svg
@@ -1,12 +1,25 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <!-- 跳ねる鹿のシルエット (右向き) -->
   <g fill="#111111">
-    <!-- pad -->
-    <ellipse cx="60" cy="84" rx="22" ry="14"/>
-    <!-- toes (4) -->
-    <ellipse cx="38" cy="62" rx="7" ry="9"/>
-    <ellipse cx="52" cy="50" rx="7" ry="9"/>
-    <ellipse cx="68" cy="50" rx="7" ry="9"/>
-    <ellipse cx="82" cy="62" rx="7" ry="9"/>
+    <!-- 体 (楕円) -->
+    <ellipse cx="55" cy="76" rx="14" ry="6"/>
+    <!-- 後脚 (左、跳ねるようにやや傾ける) -->
+    <path d="M44 80 L40 94 L44 94 L48 82 Z"/>
+    <!-- 後脚 second -->
+    <path d="M50 80 L48 94 L52 94 L54 82 Z"/>
+    <!-- 前脚 (右) -->
+    <path d="M60 80 L60 94 L64 94 L64 82 Z"/>
+    <path d="M65 80 L66 94 L70 94 L68 82 Z"/>
+    <!-- 首 (上方右へ) -->
+    <path d="M67 72 L74 62 L78 64 L74 72 Z"/>
+    <!-- 頭 -->
+    <ellipse cx="78" cy="62" rx="6" ry="4"/>
+    <!-- 角 (枝分かれ簡易) -->
+    <path d="M76 58 L74 50 L77 54 Z"/>
+    <path d="M80 58 L82 50 L80 55 Z"/>
+    <path d="M78 56 L78 48 L80 52 Z"/>
+    <!-- 尾 (後ろ上向き、白でなく黒い小三角) -->
+    <path d="M42 74 L38 70 L42 76 Z"/>
   </g>
 </svg>

--- a/templates/sign/sign_animal_crossing.svg
+++ b/templates/sign/sign_animal_crossing.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <g fill="#111111">
+    <!-- pad -->
+    <ellipse cx="60" cy="84" rx="22" ry="14"/>
+    <!-- toes (4) -->
+    <ellipse cx="38" cy="62" rx="7" ry="9"/>
+    <ellipse cx="52" cy="50" rx="7" ry="9"/>
+    <ellipse cx="68" cy="50" rx="7" ry="9"/>
+    <ellipse cx="82" cy="62" rx="7" ry="9"/>
+  </g>
+</svg>

--- a/templates/sign/sign_au_kangaroo.svg
+++ b/templates/sign/sign_au_kangaroo.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,10 112,62 60,114 8,62" fill="#FFD500" stroke="#111111" stroke-width="3"/>
+  <g fill="#111111">
+    <!-- ears -->
+    <path d="M52 36 L50 28 L54 34 Z"/>
+    <path d="M58 34 L60 28 L62 34 Z"/>
+    <!-- head + body merged silhouette -->
+    <path d="
+      M 56 40
+      Q 50 44 52 52
+      Q 48 56 50 64
+      Q 46 70 48 80
+      L 50 88
+      L 54 88
+      L 54 80
+      Q 56 76 60 76
+      L 60 88
+      Q 60 92 64 94
+      L 70 96
+      L 68 92
+      L 64 86
+      L 64 76
+      Q 70 70 70 62
+      Q 70 54 66 50
+      Q 68 44 64 40
+      Q 60 36 56 40
+      Z
+    "/>
+    <!-- big tail extending down/back -->
+    <path d="M 50 76 Q 38 84 36 96 L 44 96 Q 46 88 56 84 Z"/>
+    <!-- foot at base -->
+    <rect x="44" y="94" width="22" height="3"/>
+  </g>
+</svg>

--- a/templates/sign/sign_au_roundabout_ahead.svg
+++ b/templates/sign/sign_au_roundabout_ahead.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,8 112,60 60,112 8,60" fill="#FFD500" stroke="#111111" stroke-width="3"/>
+  <circle cx="60" cy="60" r="18" fill="none" stroke="#111111" stroke-width="4" stroke-dasharray="5 4"/>
+  <polygon points="42,48 34,58 44,58" fill="#111111"/>
+  <polygon points="74,74 84,72 76,82" fill="#111111"/>
+</svg>

--- a/templates/sign/sign_au_sharp_turn.svg
+++ b/templates/sign/sign_au_sharp_turn.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <polygon points="60,8 112,60 60,112 8,60" fill="#FFD500" stroke="#111111" stroke-width="3"/>
-  <path d="M40 94 L40 60 Q40 48 56 48 L74 48" fill="none" stroke="#111111" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
-  <polygon points="88,48 68,38 68,58" fill="#111111"/>
+  <path d="M50 88 L50 64 Q50 54 62 54 L72 54" fill="none" stroke="#111111" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <polygon points="84,54 68,46 68,62" fill="#111111"/>
 </svg>

--- a/templates/sign/sign_au_sharp_turn.svg
+++ b/templates/sign/sign_au_sharp_turn.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,8 112,60 60,112 8,60" fill="#FFD500" stroke="#111111" stroke-width="3"/>
+  <path d="M40 94 L40 60 Q40 48 56 48 L74 48" fill="none" stroke="#111111" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+  <polygon points="88,48 68,38 68,58" fill="#111111"/>
+</svg>

--- a/templates/sign/sign_au_wombat.svg
+++ b/templates/sign/sign_au_wombat.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,8 112,60 60,112 8,60" fill="#FFD500" stroke="#111111" stroke-width="3"/>
+  <g fill="#111111">
+    <ellipse cx="60" cy="70" rx="22" ry="12"/>
+    <circle cx="82" cy="64" r="7"/>
+    <circle cx="84" cy="60" r="2" fill="#FFD500"/>
+    <rect x="44" y="78" width="4" height="10"/>
+    <rect x="52" y="78" width="4" height="10"/>
+    <rect x="66" y="78" width="4" height="10"/>
+    <rect x="74" y="78" width="4" height="10"/>
+  </g>
+</svg>

--- a/templates/sign/sign_bike_lane.svg
+++ b/templates/sign/sign_bike_lane.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <rect x="10" y="10" width="100" height="100" rx="6" fill="#1E4FAA" stroke="#17408A" stroke-width="3"/>
+  <circle cx="38" cy="82" r="16" fill="none" stroke="#FFFFFF" stroke-width="4"/>
+  <circle cx="82" cy="82" r="16" fill="none" stroke="#FFFFFF" stroke-width="4"/>
+  <path d="M38 82 L56 52 L72 52" stroke="#FFFFFF" stroke-width="4" fill="none" stroke-linejoin="round" stroke-linecap="round"/>
+  <path d="M56 52 L66 82 L82 82" stroke="#FFFFFF" stroke-width="4" fill="none" stroke-linejoin="round" stroke-linecap="round"/>
+  <path d="M44 44 L58 44" stroke="#FFFFFF" stroke-width="4" stroke-linecap="round"/>
+  <rect x="68" y="46" width="8" height="6" fill="#FFFFFF"/>
+</svg>

--- a/templates/sign/sign_bus_lane.svg
+++ b/templates/sign/sign_bus_lane.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <rect x="10" y="10" width="100" height="100" rx="6" fill="#1E4FAA" stroke="#17408A" stroke-width="3"/>
+  <rect x="25" y="30" width="70" height="50" rx="6" fill="#FFFFFF"/>
+  <rect x="30" y="37" width="28" height="20" rx="2" fill="#1E4FAA"/>
+  <rect x="62" y="37" width="28" height="20" rx="2" fill="#1E4FAA"/>
+  <rect x="25" y="62" width="70" height="4" fill="#1E4FAA"/>
+  <circle cx="38" cy="85" r="7" fill="#111111"/>
+  <circle cx="38" cy="85" r="3" fill="#FFFFFF"/>
+  <circle cx="82" cy="85" r="7" fill="#111111"/>
+  <circle cx="82" cy="85" r="3" fill="#FFFFFF"/>
+</svg>

--- a/templates/sign/sign_camping.svg
+++ b/templates/sign/sign_camping.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <rect x="10" y="10" width="100" height="100" rx="6" fill="#1E5DAB" stroke="#111111" stroke-width="3"/>
+  <polygon points="60,28 28,90 92,90" fill="#FFFFFF"/>
+  <line x1="60" y1="28" x2="60" y2="90" stroke="#1E5DAB" stroke-width="2"/>
+</svg>

--- a/templates/sign/sign_cn_children.svg
+++ b/templates/sign/sign_cn_children.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,10 115,110 5,110" fill="#FFD500" stroke="#111111" stroke-width="6"/>
+  <circle cx="48" cy="44" r="5" fill="#111111"/>
+  <path d="M48 51 L42 69 L42 89 L48 89 L48 74 L52 74 L52 89 L58 89 L58 67 L64 71 L68 67 L57 57 L52 51 Z" fill="#111111"/>
+  <circle cx="74" cy="56" r="4" fill="#111111"/>
+  <path d="M74 62 L70 76 L70 94 L75 94 L75 84 L78 84 L78 94 L83 94 L83 77 L87 81 L90 78 L81 69 L78 62 Z" fill="#111111"/>
+</svg>

--- a/templates/sign/sign_cn_go_straight.svg
+++ b/templates/sign/sign_cn_go_straight.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#1E4FAA" stroke="#17408A" stroke-width="3"/>
+  <polygon points="50,92 50,48 38,48 60,26 82,48 70,48 70,92" fill="#FFFFFF"/>
+</svg>

--- a/templates/sign/sign_cn_no_entry.svg
+++ b/templates/sign/sign_cn_no_entry.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,8 112,60 60,112 8,60" fill="#FFD500" stroke="#111111" stroke-width="3"/>
+  <text x="60" y="56" font-family="'Noto Sans SC','PingFang SC','Hiragino Sans',sans-serif" font-size="20" font-weight="900" fill="#111111" text-anchor="middle">注意</text>
+  <text x="60" y="86" font-family="'Noto Sans SC','PingFang SC','Hiragino Sans',sans-serif" font-size="20" font-weight="900" fill="#111111" text-anchor="middle">前方</text>
+</svg>

--- a/templates/sign/sign_cn_no_entry.svg
+++ b/templates/sign/sign_cn_no_entry.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
-  <polygon points="60,8 112,60 60,112 8,60" fill="#FFD500" stroke="#111111" stroke-width="3"/>
-  <text x="60" y="56" font-family="'Noto Sans SC','PingFang SC','Hiragino Sans',sans-serif" font-size="20" font-weight="900" fill="#111111" text-anchor="middle">注意</text>
-  <text x="60" y="86" font-family="'Noto Sans SC','PingFang SC','Hiragino Sans',sans-serif" font-size="20" font-weight="900" fill="#111111" text-anchor="middle">前方</text>
+  <!-- 中国式 no entry: 赤円 + 白横棒 (Vienna 共通) -->
+  <circle cx="60" cy="60" r="55" fill="#DD0000" stroke="#AA0000" stroke-width="3"/>
+  <rect x="20" y="52" width="80" height="16" rx="2" fill="#FFFFFF"/>
 </svg>

--- a/templates/sign/sign_cn_no_parking.svg
+++ b/templates/sign/sign_cn_no_parking.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#1E4FAA" stroke="#DD0000" stroke-width="8"/>
+  <line x1="22" y1="22" x2="98" y2="98" stroke="#DD0000" stroke-width="8" stroke-linecap="round"/>
+  <text x="60" y="80" font-family="'Noto Sans SC','PingFang SC','Hiragino Sans',sans-serif" font-size="48" font-weight="900" fill="#FFFFFF" text-anchor="middle">停</text>
+</svg>

--- a/templates/sign/sign_cn_no_parking.svg
+++ b/templates/sign/sign_cn_no_parking.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <circle cx="60" cy="60" r="55" fill="#1E4FAA" stroke="#DD0000" stroke-width="8"/>
-  <line x1="22" y1="22" x2="98" y2="98" stroke="#DD0000" stroke-width="8" stroke-linecap="round"/>
-  <text x="60" y="80" font-family="'Noto Sans SC','PingFang SC','Hiragino Sans',sans-serif" font-size="48" font-weight="900" fill="#FFFFFF" text-anchor="middle">停</text>
+  <line x1="26" y1="26" x2="94" y2="94" stroke="#DD0000" stroke-width="8" stroke-linecap="round"/>
+  <text x="60" y="78" font-family="'Noto Sans SC','PingFang SC','Hiragino Sans',sans-serif" font-size="14" font-weight="900" fill="#FFFFFF" text-anchor="middle">禁止停车</text>
 </svg>

--- a/templates/sign/sign_cn_no_thoroughfare.svg
+++ b/templates/sign/sign_cn_no_thoroughfare.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#DD0000" stroke-width="10"/>
+  <text x="60" y="78" font-family="'Noto Sans SC','PingFang SC','Hiragino Sans',sans-serif" font-size="22" font-weight="900" fill="#111111" text-anchor="middle">禁止通行</text>
+</svg>

--- a/templates/sign/sign_cn_pedestrian_warning.svg
+++ b/templates/sign/sign_cn_pedestrian_warning.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,10 115,110 5,110" fill="#FFD500" stroke="#111111" stroke-width="6"/>
+  <circle cx="55" cy="42" r="5" fill="#111111"/>
+  <path d="M55 49 L49 67 L49 88 L55 88 L55 72 L60 72 L60 88 L66 88 L66 66 L72 70 L76 66 L65 56 L60 49 Z" fill="#111111"/>
+</svg>

--- a/templates/sign/sign_cn_slow.svg
+++ b/templates/sign/sign_cn_slow.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,10 115,110 5,110" fill="#FFD500" stroke="#111111" stroke-width="6"/>
+  <text x="60" y="90" font-family="'Noto Sans SC','PingFang SC','Hiragino Sans',sans-serif" font-size="40" font-weight="900" fill="#111111" text-anchor="middle">慢</text>
+</svg>

--- a/templates/sign/sign_cn_stop.svg
+++ b/templates/sign/sign_cn_stop.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="39,9.2 81,9.2 110.8,39 110.8,81 81,110.8 39,110.8 9.2,81 9.2,39" fill="#DD0000" stroke="#AA0000" stroke-width="3"/>
+  <text x="60" y="80" font-family="'Noto Sans SC','PingFang SC','Hiragino Sans',sans-serif" font-size="56" font-weight="900" fill="#FFFFFF" text-anchor="middle">停</text>
+</svg>

--- a/templates/sign/sign_cn_turn_left.svg
+++ b/templates/sign/sign_cn_turn_left.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#1E4FAA" stroke="#17408A" stroke-width="3"/>
+  <polygon points="92,50 52,50 52,38 30,60 52,82 52,70 92,70" fill="#FFFFFF"/>
+</svg>

--- a/templates/sign/sign_cn_turn_left.svg
+++ b/templates/sign/sign_cn_turn_left.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
-  <circle cx="60" cy="60" r="55" fill="#1E4FAA" stroke="#17408A" stroke-width="3"/>
-  <polygon points="92,50 52,50 52,38 30,60 52,82 52,70 92,70" fill="#FFFFFF"/>
-</svg>

--- a/templates/sign/sign_cn_turn_right.svg
+++ b/templates/sign/sign_cn_turn_right.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#1E4FAA" stroke="#17408A" stroke-width="3"/>
+  <polygon points="28,50 68,50 68,38 90,60 68,82 68,70 28,70" fill="#FFFFFF"/>
+</svg>

--- a/templates/sign/sign_cn_turn_right.svg
+++ b/templates/sign/sign_cn_turn_right.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
-  <circle cx="60" cy="60" r="55" fill="#1E4FAA" stroke="#17408A" stroke-width="3"/>
-  <polygon points="28,50 68,50 68,38 90,60 68,82 68,70 28,70" fill="#FFFFFF"/>
-</svg>

--- a/templates/sign/sign_curve_ahead.svg
+++ b/templates/sign/sign_curve_ahead.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
-  <path d="M42 100 L42 80 Q42 55 60 55 L72 55" fill="none" stroke="#111111" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
-  <polygon points="88,55 66,43 66,67" fill="#111111"/>
+  <path d="M52 92 L52 72 Q52 58 62 58 L70 58" fill="none" stroke="#111111" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <polygon points="82,58 66,50 66,66" fill="#111111"/>
 </svg>

--- a/templates/sign/sign_curve_ahead.svg
+++ b/templates/sign/sign_curve_ahead.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <path d="M42 100 L42 80 Q42 55 60 55 L72 55" fill="none" stroke="#111111" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+  <polygon points="88,55 66,43 66,67" fill="#111111"/>
+</svg>

--- a/templates/sign/sign_de_30_zone.svg
+++ b/templates/sign/sign_de_30_zone.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <rect x="8" y="8" width="104" height="104" rx="4" fill="#FFFFFF" stroke="#111111" stroke-width="3"/>
+  <text x="60" y="32" font-family="Arial, sans-serif" font-size="14" font-weight="800" fill="#111111" text-anchor="middle">ZONE</text>
+  <circle cx="60" cy="70" r="26" fill="#FFFFFF" stroke="#DD0000" stroke-width="5"/>
+  <text x="60" y="80" font-family="Arial, sans-serif" font-size="26" font-weight="900" fill="#111111" text-anchor="middle">30</text>
+</svg>

--- a/templates/sign/sign_de_end_restrictions.svg
+++ b/templates/sign/sign_de_end_restrictions.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#888888" stroke-width="5"/>
   <g stroke="#222222" stroke-width="4" stroke-linecap="round">
-    <line x1="24" y1="96" x2="96" y2="24"/>
-    <line x1="20" y1="88" x2="88" y2="20"/>
-    <line x1="32" y1="100" x2="100" y2="32"/>
+    <line x1="29" y1="91" x2="91" y2="29"/>
+    <line x1="25" y1="83" x2="83" y2="25"/>
+    <line x1="37" y1="95" x2="95" y2="37"/>
   </g>
 </svg>

--- a/templates/sign/sign_de_end_restrictions.svg
+++ b/templates/sign/sign_de_end_restrictions.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#888888" stroke-width="5"/>
+  <g stroke="#222222" stroke-width="4" stroke-linecap="round">
+    <line x1="24" y1="96" x2="96" y2="24"/>
+    <line x1="20" y1="88" x2="88" y2="20"/>
+    <line x1="32" y1="100" x2="100" y2="32"/>
+  </g>
+</svg>

--- a/templates/sign/sign_de_no_vehicles.svg
+++ b/templates/sign/sign_de_no_vehicles.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#DD0000" stroke-width="10"/>
+</svg>

--- a/templates/sign/sign_de_play_street.svg
+++ b/templates/sign/sign_de_play_street.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <rect x="10" y="10" width="100" height="100" rx="3" fill="#1E5DAB" stroke="#111111" stroke-width="3"/>
+  <g fill="#FFFFFF">
+    <rect x="18" y="48" width="24" height="22"/>
+    <polygon points="14,48 30,34 46,48"/>
+    <rect x="26" y="56" width="8" height="14" fill="#1E5DAB"/>
+    <circle cx="66" cy="36" r="5"/>
+    <rect x="62" y="42" width="8" height="16"/>
+    <rect x="62" y="58" width="3" height="12"/>
+    <rect x="67" y="58" width="3" height="12"/>
+    <circle cx="90" cy="56" r="5"/>
+    <rect x="28" y="82" width="54" height="10" rx="2"/>
+    <rect x="38" y="76" width="34" height="8" rx="1"/>
+    <rect x="44" y="80" width="8" height="4" fill="#1E5DAB"/>
+    <rect x="58" y="80" width="8" height="4" fill="#1E5DAB"/>
+    <circle cx="38" cy="94" r="4"/>
+    <circle cx="74" cy="94" r="4"/>
+  </g>
+</svg>

--- a/templates/sign/sign_de_priority.svg
+++ b/templates/sign/sign_de_priority.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,8 112,60 60,112 8,60" fill="#FFD500" stroke="#111111" stroke-width="3"/>
+  <polygon points="60,22 98,60 60,98 22,60" fill="none" stroke="#FFFFFF" stroke-width="6"/>
+</svg>

--- a/templates/sign/sign_do_not_enter.svg
+++ b/templates/sign/sign_do_not_enter.svg
@@ -1,4 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
-  <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
-  <line x1="23" y1="23" x2="97" y2="97" stroke="#DD0000" stroke-width="8" stroke-linecap="round"/>
+  <!-- US MUTCD R5-1: 白い正方形 + 中央に赤円 + 白横棒 + 上下に DO NOT / ENTER -->
+  <rect x="6" y="6" width="108" height="108" rx="3" fill="#FFFFFF" stroke="#111111" stroke-width="2"/>
+  <circle cx="60" cy="60" r="46" fill="#DD0000"/>
+  <text x="60" y="46" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="800" fill="#FFFFFF" text-anchor="middle">DO NOT</text>
+  <rect x="22" y="52" width="76" height="14" fill="#FFFFFF"/>
+  <text x="60" y="83" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="800" fill="#FFFFFF" text-anchor="middle">ENTER</text>
 </svg>

--- a/templates/sign/sign_do_not_enter.svg
+++ b/templates/sign/sign_do_not_enter.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <line x1="23" y1="23" x2="97" y2="97" stroke="#DD0000" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/templates/sign/sign_end_motorway.svg
+++ b/templates/sign/sign_end_motorway.svg
@@ -2,5 +2,5 @@
   <rect x="10" y="10" width="100" height="100" rx="6" fill="#1E5DAB" stroke="#111111" stroke-width="3"/>
   <path d="M30 96 Q40 60 60 60 Q80 60 90 96" stroke="#FFFFFF" stroke-width="6" fill="none" stroke-linecap="round"/>
   <polygon points="60,30 48,52 72,52" fill="#FFFFFF"/>
-  <line x1="22" y1="98" x2="98" y2="22" stroke="#FF3333" stroke-width="6" stroke-linecap="round"/>
+  <line x1="26" y1="94" x2="94" y2="26" stroke="#FF3333" stroke-width="6" stroke-linecap="round"/>
 </svg>

--- a/templates/sign/sign_end_motorway.svg
+++ b/templates/sign/sign_end_motorway.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <rect x="10" y="10" width="100" height="100" rx="6" fill="#1E5DAB" stroke="#111111" stroke-width="3"/>
+  <path d="M30 96 Q40 60 60 60 Q80 60 90 96" stroke="#FFFFFF" stroke-width="6" fill="none" stroke-linecap="round"/>
+  <polygon points="60,30 48,52 72,52" fill="#FFFFFF"/>
+  <line x1="22" y1="98" x2="98" y2="22" stroke="#FF3333" stroke-width="6" stroke-linecap="round"/>
+</svg>

--- a/templates/sign/sign_end_no_overtaking.svg
+++ b/templates/sign/sign_end_no_overtaking.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#888888" stroke-width="6"/>
+  <g opacity="0.7">
+    <rect x="22" y="60" width="36" height="22" rx="3" fill="#666666"/>
+    <path d="M28 60 L34 50 L52 50 L58 60 Z" fill="#666666"/>
+    <circle cx="32" cy="84" r="5" fill="#444444"/>
+    <circle cx="50" cy="84" r="5" fill="#444444"/>
+    <rect x="62" y="42" width="36" height="22" rx="3" fill="#444444"/>
+    <path d="M68 42 L74 32 L92 32 L98 42 Z" fill="#444444"/>
+    <circle cx="72" cy="66" r="5" fill="#444444"/>
+    <circle cx="90" cy="66" r="5" fill="#444444"/>
+  </g>
+  <g stroke="#222222" stroke-width="4" stroke-linecap="round">
+    <line x1="22" y1="98" x2="98" y2="22"/>
+    <line x1="20" y1="92" x2="92" y2="20"/>
+    <line x1="28" y1="100" x2="100" y2="28"/>
+  </g>
+</svg>

--- a/templates/sign/sign_end_no_overtaking.svg
+++ b/templates/sign/sign_end_no_overtaking.svg
@@ -1,18 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#888888" stroke-width="6"/>
   <g opacity="0.7">
-    <rect x="22" y="60" width="36" height="22" rx="3" fill="#666666"/>
-    <path d="M28 60 L34 50 L52 50 L58 60 Z" fill="#666666"/>
-    <circle cx="32" cy="84" r="5" fill="#444444"/>
-    <circle cx="50" cy="84" r="5" fill="#444444"/>
-    <rect x="62" y="42" width="36" height="22" rx="3" fill="#444444"/>
-    <path d="M68 42 L74 32 L92 32 L98 42 Z" fill="#444444"/>
-    <circle cx="72" cy="66" r="5" fill="#444444"/>
-    <circle cx="90" cy="66" r="5" fill="#444444"/>
+    <!-- 左: 赤車 (彩度低) -->
+    <rect x="22" y="48" width="32" height="18" rx="3" fill="#aa6666"/>
+    <path d="M26 48 L32 40 L44 40 L50 48 Z" fill="#aa6666"/>
+    <circle cx="30" cy="68" r="4" fill="#444444"/>
+    <circle cx="46" cy="68" r="4" fill="#444444"/>
+    <!-- 右: 黒車 -->
+    <rect x="66" y="58" width="32" height="18" rx="3" fill="#666666"/>
+    <path d="M70 58 L76 50 L88 50 L94 58 Z" fill="#666666"/>
+    <circle cx="74" cy="78" r="4" fill="#444444"/>
+    <circle cx="90" cy="78" r="4" fill="#444444"/>
   </g>
-  <g stroke="#222222" stroke-width="4" stroke-linecap="round">
-    <line x1="22" y1="98" x2="98" y2="22"/>
-    <line x1="20" y1="92" x2="92" y2="20"/>
-    <line x1="28" y1="100" x2="100" y2="28"/>
+  <!-- 抹消用斜線 (4 本平行) -->
+  <g stroke="#222222" stroke-width="3" stroke-linecap="round">
+    <line x1="29" y1="91" x2="91" y2="29"/>
+    <line x1="25" y1="83" x2="83" y2="25"/>
+    <line x1="37" y1="95" x2="95" y2="37"/>
   </g>
 </svg>

--- a/templates/sign/sign_end_priority_road.svg
+++ b/templates/sign/sign_end_priority_road.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,8 112,60 60,112 8,60" fill="#FFD500" stroke="#111111" stroke-width="3"/>
+  <polygon points="60,22 98,60 60,98 22,60" fill="none" stroke="#FFFFFF" stroke-width="6"/>
+  <line x1="22" y1="98" x2="98" y2="22" stroke="#111111" stroke-width="6" stroke-linecap="round"/>
+</svg>

--- a/templates/sign/sign_end_priority_road.svg
+++ b/templates/sign/sign_end_priority_road.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <polygon points="60,8 112,60 60,112 8,60" fill="#FFD500" stroke="#111111" stroke-width="3"/>
   <polygon points="60,22 98,60 60,98 22,60" fill="none" stroke="#FFFFFF" stroke-width="6"/>
-  <line x1="22" y1="98" x2="98" y2="22" stroke="#111111" stroke-width="6" stroke-linecap="round"/>
+  <line x1="38" y1="82" x2="82" y2="38" stroke="#111111" stroke-width="6" stroke-linecap="round"/>
 </svg>

--- a/templates/sign/sign_end_speed_limit.svg
+++ b/templates/sign/sign_end_speed_limit.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#888888" stroke-width="6"/>
+  <text x="60" y="78" font-family="Arial, sans-serif" font-size="44" font-weight="700" fill="#888888" text-anchor="middle">50</text>
+  <line x1="22" y1="98" x2="98" y2="22" stroke="#222222" stroke-width="5" stroke-linecap="round"/>
+</svg>

--- a/templates/sign/sign_end_speed_limit.svg
+++ b/templates/sign/sign_end_speed_limit.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#888888" stroke-width="6"/>
   <text x="60" y="78" font-family="Arial, sans-serif" font-size="44" font-weight="700" fill="#888888" text-anchor="middle">50</text>
-  <line x1="22" y1="98" x2="98" y2="22" stroke="#222222" stroke-width="5" stroke-linecap="round"/>
+  <line x1="28" y1="92" x2="92" y2="28" stroke="#222222" stroke-width="5" stroke-linecap="round"/>
 </svg>

--- a/templates/sign/sign_eu_falling_rocks.svg
+++ b/templates/sign/sign_eu_falling_rocks.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
   <!-- cliff stroke -->
-  <path d="M32 96 L32 72 L44 60 L58 60" stroke="#222222" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M48 90 L48 70 L56 62 L66 62" stroke="#222222" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
   <!-- rocks -->
-  <polygon points="58,66 66,74 56,78" fill="#444444"/>
-  <polygon points="66,82 78,86 72,96 60,94" fill="#666666"/>
+  <polygon points="62,68 68,74 60,78" fill="#444444"/>
+  <polygon points="64,82 72,86 68,92 60,90" fill="#666666"/>
 </svg>

--- a/templates/sign/sign_eu_falling_rocks.svg
+++ b/templates/sign/sign_eu_falling_rocks.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <!-- cliff stroke -->
+  <path d="M32 96 L32 72 L44 60 L58 60" stroke="#222222" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- rocks -->
+  <polygon points="58,66 66,74 56,78" fill="#444444"/>
+  <polygon points="66,82 78,86 72,96 60,94" fill="#666666"/>
+</svg>

--- a/templates/sign/sign_eu_priority_over_oncoming.svg
+++ b/templates/sign/sign_eu_priority_over_oncoming.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <rect x="10" y="10" width="100" height="100" rx="3" fill="#1E5DAB" stroke="#111111" stroke-width="3"/>
+  <g fill="#DD0000">
+    <rect x="42" y="38" width="10" height="60"/>
+    <polygon points="47,22 32,42 62,42"/>
+  </g>
+  <g fill="#FFFFFF">
+    <rect x="68" y="22" width="10" height="60"/>
+    <polygon points="73,98 58,78 88,78"/>
+  </g>
+</svg>

--- a/templates/sign/sign_eu_priority_to_oncoming.svg
+++ b/templates/sign/sign_eu_priority_to_oncoming.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <g fill="#DD0000">
+    <rect x="42" y="38" width="10" height="60"/>
+    <polygon points="47,22 32,42 62,42"/>
+  </g>
+  <g fill="#222222">
+    <rect x="68" y="22" width="10" height="60"/>
+    <polygon points="73,98 58,78 88,78"/>
+  </g>
+</svg>

--- a/templates/sign/sign_eu_traffic_jam.svg
+++ b/templates/sign/sign_eu_traffic_jam.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <g fill="#DD0000">
+    <!-- top car -->
+    <rect x="50" y="46" width="22" height="10" rx="1.5"/>
+    <rect x="48" y="54" width="26" height="6" rx="1"/>
+    <!-- middle car -->
+    <rect x="48" y="66" width="26" height="10" rx="1.5"/>
+    <rect x="46" y="74" width="30" height="6" rx="1"/>
+    <!-- bottom car -->
+    <rect x="44" y="86" width="32" height="10" rx="1.5"/>
+    <rect x="42" y="94" width="36" height="6" rx="1"/>
+  </g>
+</svg>

--- a/templates/sign/sign_eu_uneven_road.svg
+++ b/templates/sign/sign_eu_uneven_road.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <path d="M32 86 Q42 72 52 86 T72 86 T92 86" stroke="#222222" stroke-width="5" fill="none" stroke-linecap="round"/>
+  <path d="M32 98 Q42 84 52 98 T72 98 T92 98" stroke="#222222" stroke-width="5" fill="none" stroke-linecap="round"/>
+</svg>

--- a/templates/sign/sign_eu_uneven_road.svg
+++ b/templates/sign/sign_eu_uneven_road.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
-  <path d="M32 86 Q42 72 52 86 T72 86 T92 86" stroke="#222222" stroke-width="5" fill="none" stroke-linecap="round"/>
-  <path d="M32 98 Q42 84 52 98 T72 98 T92 98" stroke="#222222" stroke-width="5" fill="none" stroke-linecap="round"/>
+  <path d="M44 76 Q52 68 60 76 T76 76" stroke="#222222" stroke-width="5" fill="none" stroke-linecap="round"/>
+  <path d="M50 94 Q56 88 62 94 T74 94" stroke="#222222" stroke-width="5" fill="none" stroke-linecap="round"/>
 </svg>

--- a/templates/sign/sign_food.svg
+++ b/templates/sign/sign_food.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <rect x="10" y="10" width="100" height="100" rx="6" fill="#1E5DAB" stroke="#111111" stroke-width="3"/>
+  <g fill="#FFFFFF">
+    <!-- fork -->
+    <rect x="42" y="30" width="4" height="28"/>
+    <rect x="48" y="30" width="4" height="28"/>
+    <rect x="54" y="30" width="4" height="28"/>
+    <rect x="42" y="56" width="16" height="6" rx="1"/>
+    <rect x="48" y="60" width="4" height="30"/>
+    <!-- knife -->
+    <path d="M74 30 L78 30 L78 60 L82 62 L78 66 L78 90 L74 90 Z"/>
+  </g>
+</svg>

--- a/templates/sign/sign_gas_station.svg
+++ b/templates/sign/sign_gas_station.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <rect x="10" y="10" width="100" height="100" rx="6" fill="#1E4FAA" stroke="#17408A" stroke-width="3"/>
+  <g fill="#FFFFFF">
+    <rect x="38" y="28" width="34" height="60" rx="3"/>
+    <rect x="44" y="34" width="22" height="14" fill="#1E4FAA"/>
+    <rect x="38" y="84" width="34" height="6"/>
+    <path d="M72 36 L78 36 L82 40 L82 64 Q82 70 78 70 L78 76" stroke="#FFFFFF" stroke-width="4" fill="none" stroke-linecap="round"/>
+    <circle cx="78" cy="78" r="4"/>
+  </g>
+</svg>

--- a/templates/sign/sign_hospital.svg
+++ b/templates/sign/sign_hospital.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <rect x="10" y="10" width="100" height="100" rx="6" fill="#1E4FAA" stroke="#17408A" stroke-width="3"/>
+  <text x="60" y="90" font-family="Arial, Helvetica, sans-serif" font-size="82" font-weight="700" fill="#FFFFFF" text-anchor="middle">H</text>
+</svg>

--- a/templates/sign/sign_in_cattle_crossing.svg
+++ b/templates/sign/sign_in_cattle_crossing.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <g fill="#111111">
+    <ellipse cx="60" cy="82" rx="20" ry="9"/>
+    <path d="M42 84 L38 96 L44 96 L48 86 Z"/>
+    <path d="M78 84 L82 96 L76 96 L74 86 Z"/>
+    <rect x="48" y="88" width="4" height="10"/>
+    <rect x="54" y="88" width="4" height="10"/>
+    <rect x="64" y="88" width="4" height="10"/>
+    <rect x="70" y="88" width="4" height="10"/>
+    <!-- head moved more inside -->
+    <path d="M76 76 L82 68 L86 70 L84 78 L80 82 Z"/>
+    <!-- horns small, inside triangle (y=64 x range 30..90) -->
+    <path d="M82 68 L80 62 L84 66 Z"/>
+    <path d="M86 68 L88 62 L86 66 Z"/>
+  </g>
+</svg>

--- a/templates/sign/sign_in_cattle_crossing.svg
+++ b/templates/sign/sign_in_cattle_crossing.svg
@@ -1,17 +1,15 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
   <g fill="#111111">
-    <ellipse cx="60" cy="82" rx="20" ry="9"/>
-    <path d="M42 84 L38 96 L44 96 L48 86 Z"/>
-    <path d="M78 84 L82 96 L76 96 L74 86 Z"/>
-    <rect x="48" y="88" width="4" height="10"/>
-    <rect x="54" y="88" width="4" height="10"/>
-    <rect x="64" y="88" width="4" height="10"/>
-    <rect x="70" y="88" width="4" height="10"/>
-    <!-- head moved more inside -->
-    <path d="M76 76 L82 68 L86 70 L84 78 L80 82 Z"/>
-    <!-- horns small, inside triangle (y=64 x range 30..90) -->
-    <path d="M82 68 L80 62 L84 66 Z"/>
-    <path d="M86 68 L88 62 L86 66 Z"/>
+    <ellipse cx="56" cy="76" rx="14" ry="7"/>
+    <rect x="46" y="82" width="3" height="10"/>
+    <rect x="51" y="82" width="3" height="10"/>
+    <rect x="60" y="82" width="3" height="10"/>
+    <rect x="65" y="82" width="3" height="10"/>
+    <!-- head -->
+    <path d="M68 72 L74 67 L76 70 L74 76 L70 78 Z"/>
+    <!-- small horns -->
+    <path d="M72 67 L70 62 L74 66 Z"/>
+    <path d="M75 67 L78 63 L76 66 Z"/>
   </g>
 </svg>

--- a/templates/sign/sign_in_give_way.svg
+++ b/templates/sign/sign_in_give_way.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,110 5,15 115,15" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <text x="60" y="44" font-family="'Noto Sans Devanagari',sans-serif" font-size="13" font-weight="800" fill="#111111" text-anchor="middle">रास्ता</text>
+  <text x="60" y="64" font-family="Arial, sans-serif" font-size="11" font-weight="800" fill="#111111" text-anchor="middle">GIVE WAY</text>
+</svg>

--- a/templates/sign/sign_in_give_way.svg
+++ b/templates/sign/sign_in_give_way.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <polygon points="60,110 5,15 115,15" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
-  <text x="60" y="44" font-family="'Noto Sans Devanagari',sans-serif" font-size="13" font-weight="800" fill="#111111" text-anchor="middle">रास्ता</text>
-  <text x="60" y="64" font-family="Arial, sans-serif" font-size="11" font-weight="800" fill="#111111" text-anchor="middle">GIVE WAY</text>
+  <text x="60" y="44" font-family="'Noto Sans Devanagari',sans-serif" font-size="11" font-weight="800" fill="#111111" text-anchor="middle">रास्ता दीजिए</text>
+  <text x="60" y="62" font-family="Arial, sans-serif" font-size="11" font-weight="800" fill="#111111" text-anchor="middle">GIVE WAY</text>
 </svg>

--- a/templates/sign/sign_in_horn_prohibited.svg
+++ b/templates/sign/sign_in_horn_prohibited.svg
@@ -1,10 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 150" fill="none">
   <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
-  <path d="M30 50 L48 50 L66 36 L66 84 L48 70 L30 70 Z" fill="#222222"/>
-  <rect x="62" y="56" width="6" height="8" fill="#222222"/>
-  <path d="M74 48 Q80 60 74 72" stroke="#222222" stroke-width="3" fill="none" stroke-linecap="round"/>
-  <path d="M82 40 Q92 60 82 80" stroke="#222222" stroke-width="3" fill="none" stroke-linecap="round"/>
-  <line x1="22" y1="98" x2="98" y2="22" stroke="#DD0000" stroke-width="8" stroke-linecap="round"/>
+  <path d="M40 52 L54 52 L70 40 L70 80 L54 68 L40 68 Z" fill="#222222"/>
+  <rect x="68" y="58" width="5" height="6" fill="#222222"/>
+  <path d="M78 50 Q83 60 78 70" stroke="#222222" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <line x1="26" y1="94" x2="94" y2="26" stroke="#DD0000" stroke-width="8" stroke-linecap="round"/>
   <rect x="4" y="122" width="112" height="24" rx="3" fill="#FFFFFF" stroke="#DD0000" stroke-width="2"/>
   <text x="60" y="140" font-family="Arial, sans-serif" font-size="12" font-weight="800" fill="#DD0000" text-anchor="middle">HORN PROHIBITED</text>
 </svg>

--- a/templates/sign/sign_in_horn_prohibited.svg
+++ b/templates/sign/sign_in_horn_prohibited.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 150" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <path d="M30 50 L48 50 L66 36 L66 84 L48 70 L30 70 Z" fill="#222222"/>
+  <rect x="62" y="56" width="6" height="8" fill="#222222"/>
+  <path d="M74 48 Q80 60 74 72" stroke="#222222" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <path d="M82 40 Q92 60 82 80" stroke="#222222" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <line x1="22" y1="98" x2="98" y2="22" stroke="#DD0000" stroke-width="8" stroke-linecap="round"/>
+  <rect x="4" y="122" width="112" height="24" rx="3" fill="#FFFFFF" stroke="#DD0000" stroke-width="2"/>
+  <text x="60" y="140" font-family="Arial, sans-serif" font-size="12" font-weight="800" fill="#DD0000" text-anchor="middle">HORN PROHIBITED</text>
+</svg>

--- a/templates/sign/sign_in_school_ahead.svg
+++ b/templates/sign/sign_in_school_ahead.svg
@@ -1,7 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
-  <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
-  <circle cx="48" cy="44" r="5" fill="#111111"/>
-  <path d="M48 51 L42 69 L42 89 L48 89 L48 74 L52 74 L52 89 L58 89 L58 67 L64 71 L68 67 L57 57 L52 51 Z" fill="#111111"/>
-  <circle cx="74" cy="56" r="4" fill="#111111"/>
-  <path d="M74 62 L70 76 L70 94 L75 94 L75 84 L78 84 L78 94 L83 94 L83 77 L87 81 L90 78 L81 69 L78 62 Z" fill="#111111"/>
-</svg>

--- a/templates/sign/sign_in_school_ahead.svg
+++ b/templates/sign/sign_in_school_ahead.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <circle cx="48" cy="44" r="5" fill="#111111"/>
+  <path d="M48 51 L42 69 L42 89 L48 89 L48 74 L52 74 L52 89 L58 89 L58 67 L64 71 L68 67 L57 57 L52 51 Z" fill="#111111"/>
+  <circle cx="74" cy="56" r="4" fill="#111111"/>
+  <path d="M74 62 L70 76 L70 94 L75 94 L75 84 L78 84 L78 94 L83 94 L83 77 L87 81 L90 78 L81 69 L78 62 Z" fill="#111111"/>
+</svg>

--- a/templates/sign/sign_in_stop.svg
+++ b/templates/sign/sign_in_stop.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="39.0,9.2 81.0,9.2 110.8,39.0 110.8,81.0 81.0,110.8 39.0,110.8 9.2,81.0 9.2,39.0" fill="#DD0000" stroke="#AA0000" stroke-width="3"/>
+  <text x="60" y="55" font-family="'Noto Sans Devanagari','Mangal','Arial Unicode MS',sans-serif" font-size="16" font-weight="700" fill="white" text-anchor="middle">रुकें</text>
+  <text x="60" y="85" font-family="Arial, sans-serif" font-size="22" font-weight="700" fill="white" text-anchor="middle">STOP</text>
+</svg>

--- a/templates/sign/sign_information.svg
+++ b/templates/sign/sign_information.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <rect x="10" y="10" width="100" height="100" rx="6" fill="#1E4FAA" stroke="#17408A" stroke-width="3"/>
+  <circle cx="60" cy="36" r="7" fill="#FFFFFF"/>
+  <rect x="52" y="48" width="16" height="46" rx="2" fill="#FFFFFF"/>
+</svg>

--- a/templates/sign/sign_it_merge_right.svg
+++ b/templates/sign/sign_it_merge_right.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <path d="M60 96 L60 52" stroke="#111111" stroke-width="7" stroke-linecap="round"/>
+  <path d="M86 80 Q86 60 60 52" stroke="#111111" stroke-width="7" fill="none" stroke-linecap="round"/>
+  <polygon points="60,34 50,54 70,54" fill="#111111"/>
+</svg>

--- a/templates/sign/sign_it_ztl.svg
+++ b/templates/sign/sign_it_ztl.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#DD0000" stroke-width="10"/>
+  <text x="60" y="72" font-family="Arial, sans-serif" font-size="28" font-weight="900" fill="#111111" text-anchor="middle">ZTL</text>
+</svg>

--- a/templates/sign/sign_jp_no_entry.svg
+++ b/templates/sign/sign_jp_no_entry.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#DD0000" stroke="#AA0000" stroke-width="3"/>
+  <rect x="20" y="52" width="80" height="16" rx="2" fill="#FFFFFF"/>
+  <text x="60" y="98" font-family="'Hiragino Sans','Yu Gothic','Meiryo',sans-serif" font-size="12" font-weight="700" fill="#FFFFFF" text-anchor="middle">進入禁止</text>
+</svg>

--- a/templates/sign/sign_jp_no_parking.svg
+++ b/templates/sign/sign_jp_no_parking.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#1E4FAA" stroke="#DD0000" stroke-width="8"/>
+  <line x1="22" y1="98" x2="98" y2="22" stroke="#DD0000" stroke-width="8" stroke-linecap="round"/>
+  <text x="60" y="80" font-family="'Hiragino Sans','Yu Gothic','Meiryo',sans-serif" font-size="48" font-weight="900" fill="#FFFFFF" text-anchor="middle">駐</text>
+</svg>

--- a/templates/sign/sign_jp_no_stopping.svg
+++ b/templates/sign/sign_jp_no_stopping.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#1E4FAA" stroke="#DD0000" stroke-width="8"/>
+  <line x1="22" y1="98" x2="98" y2="22" stroke="#DD0000" stroke-width="6" stroke-linecap="round"/>
+  <line x1="22" y1="22" x2="98" y2="98" stroke="#DD0000" stroke-width="6" stroke-linecap="round"/>
+  <text x="60" y="80" font-family="'Hiragino Sans','Yu Gothic','Meiryo',sans-serif" font-size="44" font-weight="900" fill="#FFFFFF" text-anchor="middle">駐</text>
+</svg>

--- a/templates/sign/sign_jp_no_thoroughfare.svg
+++ b/templates/sign/sign_jp_no_thoroughfare.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <line x1="22" y1="22" x2="98" y2="98" stroke="#DD0000" stroke-width="10" stroke-linecap="round"/>
+  <line x1="98" y1="22" x2="22" y2="98" stroke="#DD0000" stroke-width="10" stroke-linecap="round"/>
+</svg>

--- a/templates/sign/sign_jp_one_way.svg
+++ b/templates/sign/sign_jp_one_way.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 160 80" fill="none">
+  <rect x="6" y="6" width="148" height="68" rx="3" fill="#1E4FAA" stroke="#17408A" stroke-width="3"/>
+  <polygon points="28,36 104,36 104,24 142,40 104,56 104,44 28,44" fill="#FFFFFF"/>
+  <text x="80" y="68" font-family="'Hiragino Sans','Yu Gothic','Meiryo',sans-serif" font-size="10" font-weight="700" fill="#FFFFFF" text-anchor="middle">一方通行</text>
+</svg>

--- a/templates/sign/sign_jp_slow.svg
+++ b/templates/sign/sign_jp_slow.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,110 5,15 115,15" fill="#DD0000" stroke="#AA0000" stroke-width="3"/>
+  <text x="60" y="50" font-family="'Hiragino Sans','Yu Gothic','Meiryo',sans-serif" font-size="20" font-weight="900" fill="#FFFFFF" text-anchor="middle">徐行</text>
+  <text x="60" y="78" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#FFFFFF" text-anchor="middle">SLOW</text>
+</svg>

--- a/templates/sign/sign_jp_stop.svg
+++ b/templates/sign/sign_jp_stop.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,110 5,15 115,15" fill="#DD0000" stroke="#AA0000" stroke-width="3"/>
+  <text x="60" y="42" font-family="'Hiragino Sans','Yu Gothic','Meiryo',sans-serif" font-size="22" font-weight="900" fill="#FFFFFF" text-anchor="middle">止</text>
+  <text x="60" y="64" font-family="'Hiragino Sans','Yu Gothic','Meiryo',sans-serif" font-size="22" font-weight="900" fill="#FFFFFF" text-anchor="middle">ま</text>
+  <text x="60" y="86" font-family="'Hiragino Sans','Yu Gothic','Meiryo',sans-serif" font-size="22" font-weight="900" fill="#FFFFFF" text-anchor="middle">れ</text>
+</svg>

--- a/templates/sign/sign_jp_warning_curve.svg
+++ b/templates/sign/sign_jp_warning_curve.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <polygon points="60,8 112,60 60,112 8,60" fill="#FFD500" stroke="#111111" stroke-width="3"/>
-  <path d="M40 92 L40 78 Q40 56 60 56 L78 56" fill="none" stroke="#111111" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
-  <polygon points="92,56 70,46 70,66" fill="#111111"/>
+  <path d="M50 88 L50 64 Q50 54 62 54 L72 54" fill="none" stroke="#111111" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <polygon points="84,54 68,46 68,62" fill="#111111"/>
 </svg>

--- a/templates/sign/sign_jp_warning_curve.svg
+++ b/templates/sign/sign_jp_warning_curve.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,8 112,60 60,112 8,60" fill="#FFD500" stroke="#111111" stroke-width="3"/>
+  <path d="M40 92 L40 78 Q40 56 60 56 L78 56" fill="none" stroke="#111111" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <polygon points="92,56 70,46 70,66" fill="#111111"/>
+</svg>

--- a/templates/sign/sign_jp_warning_pedestrian.svg
+++ b/templates/sign/sign_jp_warning_pedestrian.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,8 112,60 60,112 8,60" fill="#FFD500" stroke="#111111" stroke-width="3"/>
+  <circle cx="56" cy="40" r="5" fill="#111111"/>
+  <path d="M56 47 L50 65 L50 86 L56 86 L56 70 L62 70 L62 86 L68 86 L68 62 L74 66 L78 62 L66 52 L62 47 Z" fill="#111111"/>
+</svg>

--- a/templates/sign/sign_jp_warning_school.svg
+++ b/templates/sign/sign_jp_warning_school.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,8 112,60 60,112 8,60" fill="#FFD500" stroke="#111111" stroke-width="3"/>
+  <circle cx="48" cy="42" r="5" fill="#111111"/>
+  <path d="M48 49 L42 65 L42 84 L48 84 L48 70 L52 70 L52 84 L58 84 L58 64 L64 68 L68 64 L57 54 L52 49 Z" fill="#111111"/>
+  <circle cx="74" cy="52" r="4" fill="#111111"/>
+  <path d="M74 58 L70 70 L70 86 L75 86 L75 76 L78 76 L78 86 L83 86 L83 70 L87 73 L90 70 L82 63 L78 58 Z" fill="#111111"/>
+</svg>

--- a/templates/sign/sign_keep_left.svg
+++ b/templates/sign/sign_keep_left.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#1E4FAA" stroke="#17408A" stroke-width="3"/>
+  <polygon points="90,50 50,50 50,38 28,60 50,82 50,70 90,70" fill="#FFFFFF"/>
+</svg>

--- a/templates/sign/sign_keep_right.svg
+++ b/templates/sign/sign_keep_right.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#1E4FAA" stroke="#17408A" stroke-width="3"/>
+  <polygon points="30,50 70,50 70,38 92,60 70,82 70,70 30,70" fill="#FFFFFF"/>
+</svg>

--- a/templates/sign/sign_lodging.svg
+++ b/templates/sign/sign_lodging.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <rect x="10" y="10" width="100" height="100" rx="6" fill="#1E5DAB" stroke="#111111" stroke-width="3"/>
+  <text x="60" y="86" font-family="Arial, sans-serif" font-size="76" font-weight="900" fill="#FFFFFF" text-anchor="middle">H</text>
+  <rect x="36" y="84" width="48" height="6" fill="#1E5DAB"/>
+  <rect x="36" y="84" width="48" height="2" fill="#FFFFFF"/>
+</svg>

--- a/templates/sign/sign_minimum_speed.svg
+++ b/templates/sign/sign_minimum_speed.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#1E4FAA" stroke="#17408A" stroke-width="3"/>
+  <text x="60" y="80" font-family="Arial, sans-serif" font-size="44" font-weight="900" fill="#FFFFFF" text-anchor="middle">30</text>
+</svg>

--- a/templates/sign/sign_motorway.svg
+++ b/templates/sign/sign_motorway.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <rect x="10" y="10" width="100" height="100" rx="6" fill="#1E5DAB" stroke="#111111" stroke-width="3"/>
+  <path d="M30 96 Q40 60 60 60 Q80 60 90 96" stroke="#FFFFFF" stroke-width="6" fill="none" stroke-linecap="round"/>
+  <polygon points="60,30 48,52 72,52" fill="#FFFFFF"/>
+</svg>

--- a/templates/sign/sign_no_bicycle.svg
+++ b/templates/sign/sign_no_bicycle.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <circle cx="36" cy="74" r="14" fill="none" stroke="#222222" stroke-width="4"/>
+  <circle cx="84" cy="74" r="14" fill="none" stroke="#222222" stroke-width="4"/>
+  <path d="M36 74 L54 46 L70 46 L84 74" stroke="#222222" stroke-width="4" fill="none" stroke-linejoin="round"/>
+  <path d="M54 46 L64 74" stroke="#222222" stroke-width="4"/>
+  <line x1="22" y1="98" x2="98" y2="22" stroke="#DD0000" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/templates/sign/sign_no_entry.svg
+++ b/templates/sign/sign_no_entry.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#DD0000" stroke="#AA0000" stroke-width="3"/>
+  <rect x="20" y="52" width="80" height="16" rx="2" fill="#FFFFFF"/>
+</svg>

--- a/templates/sign/sign_no_horn.svg
+++ b/templates/sign/sign_no_horn.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <!-- megaphone body -->
+  <path d="M30 50 L48 50 L66 36 L66 84 L48 70 L30 70 Z" fill="#222222"/>
+  <!-- handle -->
+  <rect x="62" y="56" width="6" height="8" fill="#222222"/>
+  <!-- sound waves -->
+  <path d="M74 48 Q80 60 74 72" stroke="#222222" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <path d="M82 40 Q92 60 82 80" stroke="#222222" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <line x1="22" y1="98" x2="98" y2="22" stroke="#DD0000" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/templates/sign/sign_no_horn.svg
+++ b/templates/sign/sign_no_horn.svg
@@ -1,11 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
-  <!-- megaphone body -->
-  <path d="M30 50 L48 50 L66 36 L66 84 L48 70 L30 70 Z" fill="#222222"/>
-  <!-- handle -->
-  <rect x="62" y="56" width="6" height="8" fill="#222222"/>
-  <!-- sound waves -->
-  <path d="M74 48 Q80 60 74 72" stroke="#222222" stroke-width="3" fill="none" stroke-linecap="round"/>
-  <path d="M82 40 Q92 60 82 80" stroke="#222222" stroke-width="3" fill="none" stroke-linecap="round"/>
-  <line x1="22" y1="98" x2="98" y2="22" stroke="#DD0000" stroke-width="8" stroke-linecap="round"/>
+  <!-- megaphone body, kept inside inner radius (~47) -->
+  <path d="M40 52 L54 52 L70 40 L70 80 L54 68 L40 68 Z" fill="#222222"/>
+  <rect x="68" y="58" width="5" height="6" fill="#222222"/>
+  <path d="M78 50 Q83 60 78 70" stroke="#222222" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <line x1="26" y1="94" x2="94" y2="26" stroke="#DD0000" stroke-width="8" stroke-linecap="round"/>
 </svg>

--- a/templates/sign/sign_no_left_turn.svg
+++ b/templates/sign/sign_no_left_turn.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <path d="M84 78 L84 60 Q84 40 64 40 L42 40" stroke="#222222" stroke-width="7" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <polygon points="28,40 50,30 50,50" fill="#222222"/>
+  <line x1="22" y1="98" x2="98" y2="22" stroke="#DD0000" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/templates/sign/sign_no_overtaking.svg
+++ b/templates/sign/sign_no_overtaking.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <g>
+    <rect x="22" y="60" width="36" height="22" rx="3" fill="#DD0000"/>
+    <path d="M28 60 L34 50 L52 50 L58 60 Z" fill="#DD0000"/>
+    <circle cx="32" cy="84" r="5" fill="#222222"/>
+    <circle cx="50" cy="84" r="5" fill="#222222"/>
+  </g>
+  <g>
+    <rect x="62" y="42" width="36" height="22" rx="3" fill="#222222"/>
+    <path d="M68 42 L74 32 L92 32 L98 42 Z" fill="#222222"/>
+    <circle cx="72" cy="66" r="5" fill="#222222"/>
+    <circle cx="90" cy="66" r="5" fill="#222222"/>
+  </g>
+</svg>

--- a/templates/sign/sign_no_overtaking.svg
+++ b/templates/sign/sign_no_overtaking.svg
@@ -1,15 +1,17 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <!-- 左: 赤車 -->
   <g>
-    <rect x="22" y="60" width="36" height="22" rx="3" fill="#DD0000"/>
-    <path d="M28 60 L34 50 L52 50 L58 60 Z" fill="#DD0000"/>
-    <circle cx="32" cy="84" r="5" fill="#222222"/>
-    <circle cx="50" cy="84" r="5" fill="#222222"/>
+    <rect x="22" y="48" width="32" height="18" rx="3" fill="#DD0000"/>
+    <path d="M26 48 L32 40 L44 40 L50 48 Z" fill="#DD0000"/>
+    <circle cx="30" cy="68" r="4" fill="#222222"/>
+    <circle cx="46" cy="68" r="4" fill="#222222"/>
   </g>
+  <!-- 右: 黒車 -->
   <g>
-    <rect x="62" y="42" width="36" height="22" rx="3" fill="#222222"/>
-    <path d="M68 42 L74 32 L92 32 L98 42 Z" fill="#222222"/>
-    <circle cx="72" cy="66" r="5" fill="#222222"/>
-    <circle cx="90" cy="66" r="5" fill="#222222"/>
+    <rect x="66" y="58" width="32" height="18" rx="3" fill="#222222"/>
+    <path d="M70 58 L76 50 L88 50 L94 58 Z" fill="#222222"/>
+    <circle cx="74" cy="78" r="4" fill="#222222"/>
+    <circle cx="90" cy="78" r="4" fill="#222222"/>
   </g>
 </svg>

--- a/templates/sign/sign_no_parking.svg
+++ b/templates/sign/sign_no_parking.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#1E4FAA" stroke="#DD0000" stroke-width="8"/>
+  <text x="60" y="83" font-family="Arial, Helvetica, sans-serif" font-size="72" font-weight="700" fill="#FFFFFF" text-anchor="middle">P</text>
+  <line x1="22" y1="22" x2="98" y2="98" stroke="#DD0000" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/templates/sign/sign_no_parking.svg
+++ b/templates/sign/sign_no_parking.svg
@@ -1,5 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <circle cx="60" cy="60" r="55" fill="#1E4FAA" stroke="#DD0000" stroke-width="8"/>
-  <text x="60" y="83" font-family="Arial, Helvetica, sans-serif" font-size="72" font-weight="700" fill="#FFFFFF" text-anchor="middle">P</text>
-  <line x1="22" y1="22" x2="98" y2="98" stroke="#DD0000" stroke-width="8" stroke-linecap="round"/>
+  <line x1="26" y1="26" x2="94" y2="94" stroke="#DD0000" stroke-width="8" stroke-linecap="round"/>
 </svg>

--- a/templates/sign/sign_no_pedestrian.svg
+++ b/templates/sign/sign_no_pedestrian.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <circle cx="56" cy="38" r="5" fill="#222222"/>
+  <path d="M56 45 L50 63 L50 84 L56 84 L56 68 L62 68 L62 84 L68 84 L68 60 L74 64 L78 60 L66 50 L62 45 Z" fill="#222222"/>
+  <line x1="22" y1="98" x2="98" y2="22" stroke="#DD0000" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/templates/sign/sign_no_right_turn.svg
+++ b/templates/sign/sign_no_right_turn.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <path d="M36 78 L36 60 Q36 40 56 40 L78 40" stroke="#222222" stroke-width="7" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <polygon points="92,40 70,30 70,50" fill="#222222"/>
+  <line x1="22" y1="98" x2="98" y2="22" stroke="#DD0000" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/templates/sign/sign_no_truck.svg
+++ b/templates/sign/sign_no_truck.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <rect x="22" y="50" width="44" height="32" rx="2" fill="#222222"/>
+  <rect x="66" y="58" width="28" height="24" rx="2" fill="#222222"/>
+  <circle cx="34" cy="86" r="6" fill="#222222"/>
+  <circle cx="58" cy="86" r="6" fill="#222222"/>
+  <circle cx="82" cy="86" r="6" fill="#222222"/>
+</svg>

--- a/templates/sign/sign_no_truck.svg
+++ b/templates/sign/sign_no_truck.svg
@@ -1,8 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
-  <rect x="22" y="50" width="44" height="32" rx="2" fill="#222222"/>
-  <rect x="66" y="58" width="28" height="24" rx="2" fill="#222222"/>
-  <circle cx="34" cy="86" r="6" fill="#222222"/>
-  <circle cx="58" cy="86" r="6" fill="#222222"/>
-  <circle cx="82" cy="86" r="6" fill="#222222"/>
+  <!-- 貨物部 (左、大きめ) -->
+  <rect x="22" y="46" width="44" height="34" rx="2" fill="#222222"/>
+  <!-- キャブ部 (右、小さめ + 前傾) -->
+  <rect x="66" y="56" width="28" height="24" rx="2" fill="#222222"/>
+  <rect x="92" y="62" width="6" height="14" fill="#222222"/>
+  <!-- 車輪 3 つ -->
+  <circle cx="34" cy="84" r="5" fill="#222222"/>
+  <circle cx="56" cy="84" r="5" fill="#222222"/>
+  <circle cx="82" cy="84" r="5" fill="#222222"/>
 </svg>

--- a/templates/sign/sign_one_way.svg
+++ b/templates/sign/sign_one_way.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 160 80" fill="none">
+  <rect x="10" y="10" width="140" height="60" rx="4" fill="#222222" stroke="#111111" stroke-width="3"/>
+  <polygon points="25,45 110,45 110,35 140,50 110,65 110,55 25,55" fill="#FFFFFF"/>
+</svg>

--- a/templates/sign/sign_one_way.svg
+++ b/templates/sign/sign_one_way.svg
@@ -1,4 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 160 80" fill="none">
-  <rect x="10" y="10" width="140" height="60" rx="4" fill="#222222" stroke="#111111" stroke-width="3"/>
-  <polygon points="25,45 110,45 110,35 140,50 110,65 110,55 25,55" fill="#FFFFFF"/>
+  <rect x="6" y="6" width="148" height="68" rx="3" fill="#222222" stroke="#FFFFFF" stroke-width="2"/>
+  <!-- 白矢印 (右向き) -->
+  <polygon points="18,42 90,42 90,32 122,40 90,48 90,38" fill="#FFFFFF"/>
+  <!-- "ONE WAY" 白文字 -->
+  <text x="80" y="65" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="800" fill="#FFFFFF" text-anchor="middle" letter-spacing="0.5">ONE WAY</text>
 </svg>

--- a/templates/sign/sign_parking.svg
+++ b/templates/sign/sign_parking.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <rect x="10" y="10" width="100" height="100" rx="6" fill="#1E4FAA" stroke="#17408A" stroke-width="3"/>
+  <text x="60" y="90" font-family="Arial, Helvetica, sans-serif" font-size="88" font-weight="700" fill="#FFFFFF" text-anchor="middle">P</text>
+</svg>

--- a/templates/sign/sign_pedestrian_crossing.svg
+++ b/templates/sign/sign_pedestrian_crossing.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <circle cx="55" cy="42" r="5" fill="#111111"/>
+  <path d="M55 49 L49 67 L49 88 L55 88 L55 72 L60 72 L60 88 L66 88 L66 66 L72 70 L76 66 L65 56 L60 49 Z" fill="#111111"/>
+  <g stroke="#111111" stroke-width="2.5" stroke-linecap="round">
+    <line x1="36" y1="101" x2="42" y2="93"/>
+    <line x1="48" y1="101" x2="54" y2="93"/>
+    <line x1="60" y1="101" x2="66" y2="93"/>
+    <line x1="72" y1="101" x2="78" y2="93"/>
+  </g>
+</svg>

--- a/templates/sign/sign_pedestrian_crossing.svg
+++ b/templates/sign/sign_pedestrian_crossing.svg
@@ -1,11 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
-  <circle cx="55" cy="42" r="5" fill="#111111"/>
-  <path d="M55 49 L49 67 L49 88 L55 88 L55 72 L60 72 L60 88 L66 88 L66 66 L72 70 L76 66 L65 56 L60 49 Z" fill="#111111"/>
+  <circle cx="58" cy="44" r="5" fill="#111111"/>
+  <path d="M58 51 L52 66 L52 82 L58 82 L58 70 L62 70 L62 82 L68 82 L68 66 L72 68 L75 64 L66 56 L62 51 Z" fill="#111111"/>
   <g stroke="#111111" stroke-width="2.5" stroke-linecap="round">
-    <line x1="36" y1="101" x2="42" y2="93"/>
-    <line x1="48" y1="101" x2="54" y2="93"/>
-    <line x1="60" y1="101" x2="66" y2="93"/>
-    <line x1="72" y1="101" x2="78" y2="93"/>
+    <line x1="52" y1="94" x2="55" y2="89"/>
+    <line x1="58" y1="94" x2="61" y2="89"/>
+    <line x1="64" y1="94" x2="67" y2="89"/>
   </g>
 </svg>

--- a/templates/sign/sign_pedestrian_zone.svg
+++ b/templates/sign/sign_pedestrian_zone.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <rect x="10" y="10" width="100" height="100" rx="3" fill="#1E5DAB" stroke="#111111" stroke-width="3"/>
+  <circle cx="48" cy="38" r="6" fill="#FFFFFF"/>
+  <path d="M48 46 L40 70 L40 92 L46 92 L48 76 L52 76 L56 92 L62 92 L60 70 L60 60 L68 64 L72 60 L62 50 Z" fill="#FFFFFF"/>
+  <circle cx="78" cy="50" r="4" fill="#FFFFFF"/>
+  <path d="M78 56 L74 70 L74 88 L78 88 L78 78 L82 78 L82 88 L86 88 L86 70 L90 73 L93 70 L84 63 L80 56 Z" fill="#FFFFFF"/>
+</svg>

--- a/templates/sign/sign_priority_road.svg
+++ b/templates/sign/sign_priority_road.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,8 112,60 60,112 8,60" fill="#FFD500" stroke="#111111" stroke-width="3"/>
+  <polygon points="60,22 98,60 60,98 22,60" fill="none" stroke="#FFFFFF" stroke-width="6"/>
+</svg>

--- a/templates/sign/sign_railway_crossing.svg
+++ b/templates/sign/sign_railway_crossing.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 160 120" fill="none">
-  <rect x="10" y="50" width="140" height="22" rx="3" fill="#FFFFFF" stroke="#DD0000" stroke-width="4" transform="rotate(-30 80 61)"/>
-  <rect x="10" y="50" width="140" height="22" rx="3" fill="#FFFFFF" stroke="#DD0000" stroke-width="4" transform="rotate(30 80 61)"/>
+  <rect x="14" y="50" width="132" height="20" rx="3" fill="#FFFFFF" stroke="#DD0000" stroke-width="4" transform="rotate(-22 80 60)"/>
+  <rect x="14" y="50" width="132" height="20" rx="3" fill="#FFFFFF" stroke="#DD0000" stroke-width="4" transform="rotate(22 80 60)"/>
 </svg>

--- a/templates/sign/sign_railway_crossing.svg
+++ b/templates/sign/sign_railway_crossing.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 160 120" fill="none">
+  <rect x="10" y="50" width="140" height="22" rx="3" fill="#FFFFFF" stroke="#DD0000" stroke-width="4" transform="rotate(-30 80 61)"/>
+  <rect x="10" y="50" width="140" height="22" rx="3" fill="#FFFFFF" stroke="#DD0000" stroke-width="4" transform="rotate(30 80 61)"/>
+</svg>

--- a/templates/sign/sign_residential_area.svg
+++ b/templates/sign/sign_residential_area.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <rect x="10" y="10" width="100" height="100" rx="3" fill="#1E5DAB" stroke="#111111" stroke-width="3"/>
+  <rect x="36" y="44" width="48" height="50" rx="2" fill="#FFFFFF"/>
+  <polygon points="30,46 60,22 90,46" fill="#FFFFFF"/>
+  <rect x="54" y="68" width="12" height="26" fill="#1E5DAB"/>
+  <rect x="42" y="56" width="10" height="10" fill="#1E5DAB"/>
+  <rect x="68" y="56" width="10" height="10" fill="#1E5DAB"/>
+  <circle cx="62" cy="84" r="1.5" fill="#FFFFFF"/>
+</svg>

--- a/templates/sign/sign_road_narrows.svg
+++ b/templates/sign/sign_road_narrows.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <path d="M30 100 Q40 75 52 60 L52 30" stroke="#222222" stroke-width="6" fill="none" stroke-linecap="round"/>
+  <path d="M90 100 Q80 75 68 60 L68 30" stroke="#222222" stroke-width="6" fill="none" stroke-linecap="round"/>
+</svg>

--- a/templates/sign/sign_roundabout.svg
+++ b/templates/sign/sign_roundabout.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#1E4FAA" stroke="#17408A" stroke-width="3"/>
+  <path d="M 43.15 45.86 A 22 22 0 0 1 76.85 45.86" fill="none" stroke="#FFFFFF" stroke-width="5" stroke-linecap="round"/>
+  <polygon points="82.64,52.75 81.45,42.00 72.26,49.72" fill="#FFFFFF"/>
+  <path d="M 80.67 52.48 A 22 22 0 0 1 63.82 81.67" fill="none" stroke="#FFFFFF" stroke-width="5" stroke-linecap="round"/>
+  <polygon points="54.96,83.23 64.86,87.57 62.78,75.76" fill="#FFFFFF"/>
+  <path d="M 56.18 81.67 A 22 22 0 0 1 39.33 52.48" fill="none" stroke="#FFFFFF" stroke-width="5" stroke-linecap="round"/>
+  <polygon points="42.40,44.02 33.69,50.42 44.96,54.53" fill="#FFFFFF"/>
+</svg>

--- a/templates/sign/sign_roundabout_ahead.svg
+++ b/templates/sign/sign_roundabout_ahead.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
-  <path d="M 43.15 45.86 A 22 22 0 0 1 76.85 45.86" fill="none" stroke="#111111" stroke-width="5" stroke-linecap="round"/>
-  <polygon points="82.64,52.75 81.45,42.00 72.26,49.72" fill="#111111"/>
-  <path d="M 80.67 52.48 A 22 22 0 0 1 63.82 81.67" fill="none" stroke="#111111" stroke-width="5" stroke-linecap="round"/>
-  <polygon points="54.96,83.23 64.86,87.57 62.78,75.76" fill="#111111"/>
-  <path d="M 56.18 81.67 A 22 22 0 0 1 39.33 52.48" fill="none" stroke="#111111" stroke-width="5" stroke-linecap="round"/>
-  <polygon points="42.40,44.02 33.69,50.42 44.96,54.53" fill="#111111"/>
+  <path d="M 43.15 57.86 A 22 22 0 0 1 76.85 57.86" fill="none" stroke="#111111" stroke-width="5" stroke-linecap="round"/>
+  <polygon points="82.64,64.75 81.45,54.0 72.26,61.72" fill="#111111"/>
+  <path d="M 80.67 64.47999999999999 A 22 22 0 0 1 63.82 93.67" fill="none" stroke="#111111" stroke-width="5" stroke-linecap="round"/>
+  <polygon points="54.96,95.23 64.86,99.57 62.78,87.76" fill="#111111"/>
+  <path d="M 56.18 93.67 A 22 22 0 0 1 39.33 64.47999999999999" fill="none" stroke="#111111" stroke-width="5" stroke-linecap="round"/>
+  <polygon points="42.40,56.02 33.69,62.42 44.96,66.53" fill="#111111"/>
 </svg>

--- a/templates/sign/sign_roundabout_ahead.svg
+++ b/templates/sign/sign_roundabout_ahead.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <path d="M 43.15 45.86 A 22 22 0 0 1 76.85 45.86" fill="none" stroke="#111111" stroke-width="5" stroke-linecap="round"/>
+  <polygon points="82.64,52.75 81.45,42.00 72.26,49.72" fill="#111111"/>
+  <path d="M 80.67 52.48 A 22 22 0 0 1 63.82 81.67" fill="none" stroke="#111111" stroke-width="5" stroke-linecap="round"/>
+  <polygon points="54.96,83.23 64.86,87.57 62.78,75.76" fill="#111111"/>
+  <path d="M 56.18 81.67 A 22 22 0 0 1 39.33 52.48" fill="none" stroke="#111111" stroke-width="5" stroke-linecap="round"/>
+  <polygon points="42.40,44.02 33.69,50.42 44.96,54.53" fill="#111111"/>
+</svg>

--- a/templates/sign/sign_school_zone.svg
+++ b/templates/sign/sign_school_zone.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <circle cx="48" cy="44" r="5.5" fill="#111111"/>
+  <path d="M48 51 L42 69 L42 89 L48 89 L48 74 L52 74 L52 89 L58 89 L58 67 L64 71 L68 67 L57 57 L52 51 Z" fill="#111111"/>
+  <circle cx="74" cy="56" r="4.5" fill="#111111"/>
+  <path d="M74 62 L70 76 L70 94 L75 94 L75 84 L78 84 L78 94 L83 94 L83 77 L87 81 L90 78 L81 69 L78 62 Z" fill="#111111"/>
+</svg>

--- a/templates/sign/sign_signal_ahead.svg
+++ b/templates/sign/sign_signal_ahead.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <rect x="50" y="40" width="20" height="48" rx="3" fill="#222222"/>
+  <circle cx="60" cy="50" r="5" fill="#FF3333"/>
+  <circle cx="60" cy="64" r="5" fill="#FFCC22"/>
+  <circle cx="60" cy="78" r="5" fill="#33CC44"/>
+</svg>

--- a/templates/sign/sign_slippery_road.svg
+++ b/templates/sign/sign_slippery_road.svg
@@ -1,15 +1,15 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
   <!-- car body -->
-  <rect x="32" y="56" width="56" height="14" rx="3" fill="#111111"/>
-  <path d="M40 56 L48 46 L72 46 L80 56 Z" fill="#111111"/>
+  <rect x="40" y="58" width="40" height="12" rx="3" fill="#111111"/>
+  <path d="M46 58 L52 50 L68 50 L74 58 Z" fill="#111111"/>
   <!-- windows -->
-  <rect x="50" y="48" width="8" height="6" fill="#FFFFFF"/>
-  <rect x="62" y="48" width="8" height="6" fill="#FFFFFF"/>
+  <rect x="52" y="52" width="6" height="5" fill="#FFFFFF"/>
+  <rect x="62" y="52" width="6" height="5" fill="#FFFFFF"/>
   <!-- wheels -->
-  <circle cx="44" cy="72" r="5" fill="#111111"/>
-  <circle cx="76" cy="72" r="5" fill="#111111"/>
+  <circle cx="48" cy="72" r="4" fill="#111111"/>
+  <circle cx="72" cy="72" r="4" fill="#111111"/>
   <!-- skid marks -->
-  <path d="M22 90 Q34 82 46 90 T70 90 T98 90" stroke="#111111" stroke-width="3" fill="none" stroke-linecap="round"/>
-  <path d="M22 100 Q34 92 46 100 T70 100 T98 100" stroke="#111111" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <path d="M44 84 Q52 80 58 84 T70 84 T76 84" stroke="#111111" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <path d="M48 94 Q54 91 58 94 T68 94 T74 94" stroke="#111111" stroke-width="3" fill="none" stroke-linecap="round"/>
 </svg>

--- a/templates/sign/sign_slippery_road.svg
+++ b/templates/sign/sign_slippery_road.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <!-- car body -->
+  <rect x="32" y="56" width="56" height="14" rx="3" fill="#111111"/>
+  <path d="M40 56 L48 46 L72 46 L80 56 Z" fill="#111111"/>
+  <!-- windows -->
+  <rect x="50" y="48" width="8" height="6" fill="#FFFFFF"/>
+  <rect x="62" y="48" width="8" height="6" fill="#FFFFFF"/>
+  <!-- wheels -->
+  <circle cx="44" cy="72" r="5" fill="#111111"/>
+  <circle cx="76" cy="72" r="5" fill="#111111"/>
+  <!-- skid marks -->
+  <path d="M22 90 Q34 82 46 90 T70 90 T98 90" stroke="#111111" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <path d="M22 100 Q34 92 46 100 T70 100 T98 100" stroke="#111111" stroke-width="3" fill="none" stroke-linecap="round"/>
+</svg>

--- a/templates/sign/sign_speed_limit.svg
+++ b/templates/sign/sign_speed_limit.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <text x="60" y="79" font-family="Arial, Helvetica, sans-serif" font-size="48" font-weight="700" fill="#111111" text-anchor="middle">50</text>
+</svg>

--- a/templates/sign/sign_two_way_traffic.svg
+++ b/templates/sign/sign_two_way_traffic.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <g fill="#111111">
+    <rect x="46" y="46" width="8" height="50"/>
+    <polygon points="50,32 38,52 62,52"/>
+    <rect x="66" y="46" width="8" height="50"/>
+    <polygon points="70,104 58,84 82,84"/>
+  </g>
+</svg>

--- a/templates/sign/sign_uk_national_speed_limit.svg
+++ b/templates/sign/sign_uk_national_speed_limit.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#111111" stroke-width="5"/>
+  <line x1="22" y1="98" x2="98" y2="22" stroke="#111111" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/templates/sign/sign_uk_national_speed_limit.svg
+++ b/templates/sign/sign_uk_national_speed_limit.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#111111" stroke-width="5"/>
-  <line x1="22" y1="98" x2="98" y2="22" stroke="#111111" stroke-width="8" stroke-linecap="round"/>
+  <line x1="30" y1="90" x2="90" y2="30" stroke="#111111" stroke-width="8" stroke-linecap="round"/>
 </svg>

--- a/templates/sign/sign_uk_roundabout.svg
+++ b/templates/sign/sign_uk_roundabout.svg
@@ -1,11 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
-  <g fill="none" stroke="#111111" stroke-width="5" stroke-linecap="round">
-    <path d="M 76.85 39.32 A 22 22 0 0 1 80.67 61.52"/>
-    <path d="M 76.85 74.14 A 22 22 0 0 1 43.15 74.14"/>
-    <path d="M 39.33 61.52 A 22 22 0 0 1 43.15 39.32"/>
+  <g transform="translate(60 76) scale(0.65) translate(-60 -60)">
+    <g fill="none" stroke="#111111" stroke-width="6" stroke-linecap="round">
+      <path d="M 76.85 39.32 A 22 22 0 0 1 80.67 61.52"/>
+      <path d="M 76.85 74.14 A 22 22 0 0 1 43.15 74.14"/>
+      <path d="M 39.33 61.52 A 22 22 0 0 1 43.15 39.32"/>
+    </g>
+    <polygon fill="#111111" points="77.94,66.47 85.18,60.53 76.16,57.51"/>
+    <polygon fill="#111111" points="38.00,68.01 39.47,77.23 46.82,71.06"/>
+    <polygon fill="#111111" points="64.06,30.18 55.35,33.61 57.01,43.06"/>
   </g>
-  <polygon fill="#111111" points="77.94,66.47 85.18,60.53 76.16,57.51"/>
-  <polygon fill="#111111" points="38.00,68.01 39.47,77.23 46.82,71.06"/>
-  <polygon fill="#111111" points="64.06,30.18 55.35,33.61 57.01,43.06"/>
 </svg>

--- a/templates/sign/sign_uk_roundabout.svg
+++ b/templates/sign/sign_uk_roundabout.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <g fill="none" stroke="#111111" stroke-width="5" stroke-linecap="round">
+    <path d="M 76.85 39.32 A 22 22 0 0 1 80.67 61.52"/>
+    <path d="M 76.85 74.14 A 22 22 0 0 1 43.15 74.14"/>
+    <path d="M 39.33 61.52 A 22 22 0 0 1 43.15 39.32"/>
+  </g>
+  <polygon fill="#111111" points="77.94,66.47 85.18,60.53 76.16,57.51"/>
+  <polygon fill="#111111" points="38.00,68.01 39.47,77.23 46.82,71.06"/>
+  <polygon fill="#111111" points="64.06,30.18 55.35,33.61 57.01,43.06"/>
+</svg>

--- a/templates/sign/sign_uk_roundabout.svg
+++ b/templates/sign/sign_uk_roundabout.svg
@@ -1,13 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
-  <g transform="translate(60 76) scale(0.65) translate(-60 -60)">
-    <g fill="none" stroke="#111111" stroke-width="6" stroke-linecap="round">
-      <path d="M 76.85 39.32 A 22 22 0 0 1 80.67 61.52"/>
-      <path d="M 76.85 74.14 A 22 22 0 0 1 43.15 74.14"/>
-      <path d="M 39.33 61.52 A 22 22 0 0 1 43.15 39.32"/>
+  <!-- 時計回りラウンドアバウト: 100° 弧 + 矢印頭 を 120° ごとに 3 本 -->
+  <g transform="translate(60 76)">
+    <g>
+      <path d="M -12.124 -7 A 14 14 0 0 1 12.124 -7" fill="none" stroke="#111111" stroke-width="4" stroke-linecap="round"/>
+      <polygon fill="#111111" points="12.124,-7 19,-9 16,-1"/>
     </g>
-    <polygon fill="#111111" points="77.94,66.47 85.18,60.53 76.16,57.51"/>
-    <polygon fill="#111111" points="38.00,68.01 39.47,77.23 46.82,71.06"/>
-    <polygon fill="#111111" points="64.06,30.18 55.35,33.61 57.01,43.06"/>
+    <g transform="rotate(120)">
+      <path d="M -12.124 -7 A 14 14 0 0 1 12.124 -7" fill="none" stroke="#111111" stroke-width="4" stroke-linecap="round"/>
+      <polygon fill="#111111" points="12.124,-7 19,-9 16,-1"/>
+    </g>
+    <g transform="rotate(240)">
+      <path d="M -12.124 -7 A 14 14 0 0 1 12.124 -7" fill="none" stroke="#111111" stroke-width="4" stroke-linecap="round"/>
+      <polygon fill="#111111" points="12.124,-7 19,-9 16,-1"/>
+    </g>
   </g>
 </svg>

--- a/templates/sign/sign_uk_school_children.svg
+++ b/templates/sign/sign_uk_school_children.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <circle cx="48" cy="44" r="5" fill="#111111"/>
+  <path d="M48 51 L42 69 L42 89 L48 89 L48 74 L52 74 L52 89 L58 89 L58 67 L64 71 L68 67 L57 57 L52 51 Z" fill="#111111"/>
+  <circle cx="74" cy="56" r="4" fill="#111111"/>
+  <path d="M74 62 L70 76 L70 94 L75 94 L75 84 L78 84 L78 94 L83 94 L83 77 L87 81 L90 78 L81 69 L78 62 Z" fill="#111111"/>
+</svg>

--- a/templates/sign/sign_us_deer_crossing.svg
+++ b/templates/sign/sign_us_deer_crossing.svg
@@ -2,19 +2,16 @@
   <polygon points="60,8 112,60 60,112 8,60" fill="#FFD500" stroke="#111111" stroke-width="3"/>
   <g fill="#111111">
     <!-- body -->
-    <ellipse cx="58" cy="76" rx="20" ry="8"/>
-    <!-- flanks -->
-    <path d="M40 78 L38 90 L42 90 L46 80 Z"/>
-    <path d="M74 78 L78 90 L74 90 L72 82 Z"/>
+    <ellipse cx="56" cy="74" rx="16" ry="7"/>
     <!-- legs -->
-    <rect x="44" y="84" width="4" height="10"/>
-    <rect x="52" y="84" width="4" height="10"/>
-    <rect x="66" y="84" width="4" height="10"/>
-    <rect x="72" y="84" width="4" height="10"/>
-    <!-- neck + head (moved to stay inside diamond) -->
-    <path d="M72 72 L82 60 L84 62 L80 70 Z"/>
-    <!-- small antlers inside diamond at y~48..56 where bound is x ~48..72 -->
-    <path d="M80 58 L78 52 L82 54 Z"/>
-    <path d="M83 58 L84 50 L85 54 Z"/>
+    <rect x="46" y="80" width="3" height="9"/>
+    <rect x="52" y="80" width="3" height="9"/>
+    <rect x="62" y="80" width="3" height="9"/>
+    <rect x="68" y="80" width="3" height="9"/>
+    <!-- neck + head -->
+    <path d="M68 70 L76 60 L78 62 L74 70 Z"/>
+    <!-- small antlers -->
+    <path d="M74 58 L72 52 L76 55 Z"/>
+    <path d="M77 58 L78 50 L80 55 Z"/>
   </g>
 </svg>

--- a/templates/sign/sign_us_deer_crossing.svg
+++ b/templates/sign/sign_us_deer_crossing.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,8 112,60 60,112 8,60" fill="#FFD500" stroke="#111111" stroke-width="3"/>
+  <g fill="#111111">
+    <!-- body -->
+    <ellipse cx="58" cy="76" rx="20" ry="8"/>
+    <!-- flanks -->
+    <path d="M40 78 L38 90 L42 90 L46 80 Z"/>
+    <path d="M74 78 L78 90 L74 90 L72 82 Z"/>
+    <!-- legs -->
+    <rect x="44" y="84" width="4" height="10"/>
+    <rect x="52" y="84" width="4" height="10"/>
+    <rect x="66" y="84" width="4" height="10"/>
+    <rect x="72" y="84" width="4" height="10"/>
+    <!-- neck + head (moved to stay inside diamond) -->
+    <path d="M72 72 L82 60 L84 62 L80 70 Z"/>
+    <!-- small antlers inside diamond at y~48..56 where bound is x ~48..72 -->
+    <path d="M80 58 L78 52 L82 54 Z"/>
+    <path d="M83 58 L84 50 L85 54 Z"/>
+  </g>
+</svg>

--- a/templates/sign/sign_us_divided_highway.svg
+++ b/templates/sign/sign_us_divided_highway.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,8 112,60 60,112 8,60" fill="#FFD500" stroke="#111111" stroke-width="3"/>
+  <g fill="#111111">
+    <rect x="44" y="34" width="8" height="48"/>
+    <polygon points="48,28 38,42 58,42"/>
+    <rect x="68" y="34" width="8" height="48"/>
+    <polygon points="72,88 62,74 82,74"/>
+    <ellipse cx="60" cy="60" rx="4" ry="14"/>
+  </g>
+</svg>

--- a/templates/sign/sign_us_do_not_pass.svg
+++ b/templates/sign/sign_us_do_not_pass.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,8 112,60 60,112 8,60" fill="#FFD500" stroke="#111111" stroke-width="3"/>
+  <text x="60" y="48" font-family="Arial, sans-serif" font-size="14" font-weight="800" fill="#111111" text-anchor="middle">DO NOT</text>
+  <text x="60" y="70" font-family="Arial, sans-serif" font-size="18" font-weight="800" fill="#111111" text-anchor="middle">PASS</text>
+</svg>

--- a/templates/sign/sign_us_merge.svg
+++ b/templates/sign/sign_us_merge.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,8 112,60 60,112 8,60" fill="#FFD500" stroke="#111111" stroke-width="3"/>
+  <path d="M60 96 L60 50" stroke="#111111" stroke-width="6" stroke-linecap="round"/>
+  <path d="M40 80 Q40 60 60 50" stroke="#111111" stroke-width="6" fill="none" stroke-linecap="round"/>
+  <polygon points="60,32 50,50 70,50" fill="#111111"/>
+</svg>

--- a/templates/sign/sign_us_no_turn_on_red.svg
+++ b/templates/sign/sign_us_no_turn_on_red.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 160" fill="none">
+  <rect x="6" y="6" width="108" height="148" rx="3" fill="#FFFFFF" stroke="#111111" stroke-width="5"/>
+  <text x="60" y="34" font-family="Arial, sans-serif" font-size="18" font-weight="900" fill="#111111" text-anchor="middle">NO</text>
+  <text x="60" y="58" font-family="Arial, sans-serif" font-size="18" font-weight="900" fill="#111111" text-anchor="middle">TURN</text>
+  <text x="60" y="82" font-family="Arial, sans-serif" font-size="18" font-weight="900" fill="#111111" text-anchor="middle">ON</text>
+  <circle cx="60" cy="118" r="22" fill="#DD0000"/>
+  <text x="60" y="126" font-family="Arial, sans-serif" font-size="18" font-weight="900" fill="#FFFFFF" text-anchor="middle">RED</text>
+</svg>

--- a/templates/sign/sign_us_no_uturn.svg
+++ b/templates/sign/sign_us_no_uturn.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <path d="M40 78 L40 56 Q40 40 60 40 Q80 40 80 56 L80 70" fill="none" stroke="#222222" stroke-width="7" stroke-linecap="round"/>
+  <polygon points="40,82 30,68 50,68" fill="#222222"/>
+  <line x1="22" y1="98" x2="98" y2="22" stroke="#DD0000" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/templates/sign/sign_us_pedestrian_crossing.svg
+++ b/templates/sign/sign_us_pedestrian_crossing.svg
@@ -1,11 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <polygon points="60,10 112,62 60,114 8,62" fill="#FFD500" stroke="#111111" stroke-width="3"/>
-  <circle cx="55" cy="42" r="5" fill="#111111"/>
-  <path d="M55 49 L49 67 L49 88 L55 88 L55 72 L60 72 L60 88 L66 88 L66 66 L72 70 L76 66 L65 56 L60 49 Z" fill="#111111"/>
+  <circle cx="58" cy="40" r="5" fill="#111111"/>
+  <path d="M58 47 L52 64 L52 82 L58 82 L58 70 L62 70 L62 82 L68 82 L68 64 L72 66 L75 62 L66 54 L62 47 Z" fill="#111111"/>
   <g stroke="#111111" stroke-width="2.5" stroke-linecap="round">
-    <line x1="36" y1="100" x2="42" y2="92"/>
-    <line x1="48" y1="100" x2="54" y2="92"/>
-    <line x1="60" y1="100" x2="66" y2="92"/>
-    <line x1="72" y1="100" x2="78" y2="92"/>
+    <line x1="52" y1="98" x2="56" y2="92"/>
+    <line x1="58" y1="98" x2="62" y2="92"/>
+    <line x1="64" y1="98" x2="68" y2="92"/>
   </g>
 </svg>

--- a/templates/sign/sign_us_pedestrian_crossing.svg
+++ b/templates/sign/sign_us_pedestrian_crossing.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,10 112,62 60,114 8,62" fill="#FFD500" stroke="#111111" stroke-width="3"/>
+  <circle cx="55" cy="42" r="5" fill="#111111"/>
+  <path d="M55 49 L49 67 L49 88 L55 88 L55 72 L60 72 L60 88 L66 88 L66 66 L72 70 L76 66 L65 56 L60 49 Z" fill="#111111"/>
+  <g stroke="#111111" stroke-width="2.5" stroke-linecap="round">
+    <line x1="36" y1="100" x2="42" y2="92"/>
+    <line x1="48" y1="100" x2="54" y2="92"/>
+    <line x1="60" y1="100" x2="66" y2="92"/>
+    <line x1="72" y1="100" x2="78" y2="92"/>
+  </g>
+</svg>

--- a/templates/sign/sign_us_railroad.svg
+++ b/templates/sign/sign_us_railroad.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="#FFD500" stroke="#111111" stroke-width="4"/>
+  <line x1="20" y1="20" x2="100" y2="100" stroke="#111111" stroke-width="6" stroke-linecap="round"/>
+  <line x1="100" y1="20" x2="20" y2="100" stroke="#111111" stroke-width="6" stroke-linecap="round"/>
+  <text x="42" y="56" font-family="Arial, sans-serif" font-size="22" font-weight="900" fill="#111111">R</text>
+  <text x="64" y="80" font-family="Arial, sans-serif" font-size="22" font-weight="900" fill="#111111">R</text>
+</svg>

--- a/templates/sign/sign_us_road_work.svg
+++ b/templates/sign/sign_us_road_work.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,8 112,60 60,112 8,60" fill="#F58220" stroke="#111111" stroke-width="3"/>
+  <g fill="#111111">
+    <circle cx="55" cy="38" r="5"/>
+    <path d="M55 45 L48 60 L48 80 L54 80 L54 66 L60 66 L60 80 L66 80 L66 60 L72 64 L76 60 L64 50 L60 45 Z"/>
+    <path d="M74 66 L90 82 L86 86 L70 70 Z"/>
+    <ellipse cx="88" cy="84" rx="6" ry="3"/>
+  </g>
+</svg>

--- a/templates/sign/sign_us_road_work.svg
+++ b/templates/sign/sign_us_road_work.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <polygon points="60,8 112,60 60,112 8,60" fill="#F58220" stroke="#111111" stroke-width="3"/>
   <g fill="#111111">
-    <circle cx="55" cy="38" r="5"/>
-    <path d="M55 45 L48 60 L48 80 L54 80 L54 66 L60 66 L60 80 L66 80 L66 60 L72 64 L76 60 L64 50 L60 45 Z"/>
-    <path d="M74 66 L90 82 L86 86 L70 70 Z"/>
-    <ellipse cx="88" cy="84" rx="6" ry="3"/>
+    <circle cx="54" cy="40" r="5"/>
+    <path d="M54 47 L48 60 L48 76 L54 76 L54 66 L60 66 L60 76 L66 76 L66 60 L70 63 L74 59 L63 51 L60 47 Z"/>
+    <path d="M70 64 L82 76 L78 80 L66 68 Z"/>
+    <ellipse cx="80" cy="78" rx="5" ry="2.5"/>
   </g>
 </svg>

--- a/templates/sign/sign_us_school_xing.svg
+++ b/templates/sign/sign_us_school_xing.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 130" fill="none">
-  <polygon points="60,8 112,30 112,80 60,122 8,80 8,30" fill="#9ACD32" stroke="#111111" stroke-width="3"/>
+  <polygon points="60,8 112,46 95,118 25,118 8,46" fill="#9ACD32" stroke="#111111" stroke-width="3"/>
   <circle cx="48" cy="40" r="5" fill="#111111"/>
   <path d="M48 47 L42 63 L42 80 L48 80 L48 68 L52 68 L52 80 L58 80 L58 62 L64 66 L68 62 L57 52 L52 47 Z" fill="#111111"/>
   <circle cx="72" cy="50" r="4" fill="#111111"/>

--- a/templates/sign/sign_us_school_xing.svg
+++ b/templates/sign/sign_us_school_xing.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 130" fill="none">
+  <polygon points="60,8 112,30 112,80 60,122 8,80 8,30" fill="#9ACD32" stroke="#111111" stroke-width="3"/>
+  <circle cx="48" cy="40" r="5" fill="#111111"/>
+  <path d="M48 47 L42 63 L42 80 L48 80 L48 68 L52 68 L52 80 L58 80 L58 62 L64 66 L68 62 L57 52 L52 47 Z" fill="#111111"/>
+  <circle cx="72" cy="50" r="4" fill="#111111"/>
+  <path d="M72 56 L68 68 L68 84 L72 84 L72 74 L76 74 L76 84 L80 84 L80 68 L84 71 L87 68 L80 61 L76 56 Z" fill="#111111"/>
+</svg>

--- a/templates/sign/sign_us_signal_ahead.svg
+++ b/templates/sign/sign_us_signal_ahead.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,8 112,60 60,112 8,60" fill="#FFD500" stroke="#111111" stroke-width="3"/>
+  <rect x="50" y="36" width="20" height="48" rx="3" fill="#222222"/>
+  <circle cx="60" cy="46" r="5" fill="#FF3333"/>
+  <circle cx="60" cy="60" r="5" fill="#FFCC22"/>
+  <circle cx="60" cy="74" r="5" fill="#33CC44"/>
+</svg>

--- a/templates/sign/sign_us_slippery.svg
+++ b/templates/sign/sign_us_slippery.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
   <polygon points="60,8 112,60 60,112 8,60" fill="#FFD500" stroke="#111111" stroke-width="3"/>
-  <rect x="34" y="52" width="52" height="12" rx="2" fill="#111111"/>
-  <path d="M42 52 L50 42 L70 42 L78 52 Z" fill="#111111"/>
-  <circle cx="46" cy="66" r="5" fill="#111111"/>
-  <circle cx="74" cy="66" r="5" fill="#111111"/>
-  <path d="M30 82 Q42 76 54 82 T78 82 T100 82" stroke="#111111" stroke-width="3" fill="none" stroke-linecap="round"/>
-  <path d="M30 94 Q42 88 54 94 T78 94 T100 94" stroke="#111111" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <rect x="40" y="54" width="40" height="12" rx="2" fill="#111111"/>
+  <path d="M46 54 L52 44 L68 44 L74 54 Z" fill="#111111"/>
+  <circle cx="48" cy="68" r="4" fill="#111111"/>
+  <circle cx="72" cy="68" r="4" fill="#111111"/>
+  <path d="M42 84 Q50 80 58 84 T74 84" stroke="#111111" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <path d="M48 96 Q54 93 60 96 T72 96" stroke="#111111" stroke-width="3" fill="none" stroke-linecap="round"/>
 </svg>

--- a/templates/sign/sign_us_slippery.svg
+++ b/templates/sign/sign_us_slippery.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,8 112,60 60,112 8,60" fill="#FFD500" stroke="#111111" stroke-width="3"/>
+  <rect x="34" y="52" width="52" height="12" rx="2" fill="#111111"/>
+  <path d="M42 52 L50 42 L70 42 L78 52 Z" fill="#111111"/>
+  <circle cx="46" cy="66" r="5" fill="#111111"/>
+  <circle cx="74" cy="66" r="5" fill="#111111"/>
+  <path d="M30 82 Q42 76 54 82 T78 82 T100 82" stroke="#111111" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <path d="M30 94 Q42 88 54 94 T78 94 T100 94" stroke="#111111" stroke-width="3" fill="none" stroke-linecap="round"/>
+</svg>

--- a/templates/sign/sign_us_speed_limit.svg
+++ b/templates/sign/sign_us_speed_limit.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 160" fill="none">
+  <rect x="6" y="6" width="108" height="148" rx="6" fill="#FFFFFF" stroke="#111111" stroke-width="5"/>
+  <text x="60" y="36" font-family="Arial, sans-serif" font-size="18" font-weight="700" fill="#111111" text-anchor="middle">SPEED</text>
+  <text x="60" y="56" font-family="Arial, sans-serif" font-size="18" font-weight="700" fill="#111111" text-anchor="middle">LIMIT</text>
+  <text x="60" y="128" font-family="Arial, sans-serif" font-size="72" font-weight="900" fill="#111111" text-anchor="middle">55</text>
+</svg>

--- a/templates/sign/sign_us_truck_route.svg
+++ b/templates/sign/sign_us_truck_route.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <rect x="10" y="10" width="100" height="100" rx="3" fill="#1E5DAB" stroke="#111111" stroke-width="3"/>
+  <text x="60" y="50" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#FFFFFF" text-anchor="middle">TRUCK</text>
+  <text x="60" y="78" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#FFFFFF" text-anchor="middle">ROUTE</text>
+</svg>

--- a/templates/sign/sign_us_wrong_way.svg
+++ b/templates/sign/sign_us_wrong_way.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 160 80" fill="none">
+  <rect x="6" y="6" width="148" height="68" rx="3" fill="#DD0000" stroke="#AA0000" stroke-width="3"/>
+  <text x="80" y="34" font-family="Arial, sans-serif" font-size="20" font-weight="900" fill="#FFFFFF" text-anchor="middle">WRONG</text>
+  <text x="80" y="60" font-family="Arial, sans-serif" font-size="20" font-weight="900" fill="#FFFFFF" text-anchor="middle">WAY</text>
+</svg>

--- a/templates/sign/sign_warning_generic.svg
+++ b/templates/sign/sign_warning_generic.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <rect x="56" y="48" width="8" height="40" rx="2" fill="#111111"/>
+  <circle cx="60" cy="98" r="4.5" fill="#111111"/>
+</svg>

--- a/templates/sign/sign_yield.svg
+++ b/templates/sign/sign_yield.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
-  <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
-  <polygon points="60,26 100,102 20,102" fill="none" stroke="#DD0000" stroke-width="4"/>
+  <polygon points="5,15 115,15 60,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <polygon points="20,28 100,28 60,95" fill="none" stroke="#DD0000" stroke-width="3"/>
 </svg>

--- a/templates/sign/sign_yield.svg
+++ b/templates/sign/sign_yield.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,10 115,110 5,110" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <polygon points="60,26 100,102 20,102" fill="none" stroke="#DD0000" stroke-width="4"/>
+</svg>

--- a/templates/sign/sign_yield_give_way.svg
+++ b/templates/sign/sign_yield_give_way.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="60,110 5,15 115,15" fill="#FFFFFF" stroke="#DD0000" stroke-width="8"/>
+  <text x="60" y="50" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="800" fill="#111111" text-anchor="middle">GIVE</text>
+  <text x="60" y="72" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="800" fill="#111111" text-anchor="middle">WAY</text>
+</svg>

--- a/templates/sign/speed_sign.svg
+++ b/templates/sign/speed_sign.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="55" fill="white" stroke="#DD0000" stroke-width="8"/>
+  <circle cx="60" cy="60" r="40" fill="white"/>
+</svg>

--- a/templates/sign/stop_sign.svg
+++ b/templates/sign/stop_sign.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 120 120" fill="none">
+  <polygon points="39,9.2 81,9.2 110.8,39 110.8,81 81,110.8 39,110.8 9.2,81 9.2,39" fill="#DD0000" stroke="#AA0000" stroke-width="3"/>
+  <polygon points="43.2,19.3 76.8,19.3 100.7,43.2 100.7,76.8 76.8,100.7 43.2,100.7 19.3,76.8 19.3,43.2" fill="none" stroke="white" stroke-width="2"/>
+  <text x="60" y="73" font-family="Arial, Helvetica, sans-serif" font-size="28" font-weight="700" fill="white" text-anchor="middle" letter-spacing="1">STOP</text>
+</svg>


### PR DESCRIPTION
## Summary

<img width="1453" height="736" alt="image" src="https://github.com/user-attachments/assets/dd7f59e3-0c4c-45be-8813-853e96dc5b73" />

- Introduce a dedicated `sign` category with 111 traffic sign SVGs spanning multiple regions (International, US, Japan, China, Europe, Germany, UK, Italy, Australia, India).
- Move the existing legacy sign SVGs from `templates/other/` to `templates/sign/` so signs live in one place.
- Add per-template `region` metadata in `manifest.json` for grouped UI presentation.
