### PR TITLE
Use a compact 200x140 viewBox for speed_limit template

### DIFF
--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -2121,9 +2121,9 @@
       "id": "marking_speed_limit",
       "name": "Speed Limit",
       "svg": "road_marking/marking_speed_limit.svg",
-      "w": 24,
-      "h": 60,
-      "viewBox": [200, 500],
+      "w": 30,
+      "h": 22,
+      "viewBox": [200, 140],
       "replaceColor": "#000000",
       "defaultColor": "white"
     },

--- a/templates/road_marking/marking_speed_limit.svg
+++ b/templates/road_marking/marking_speed_limit.svg
@@ -1,7 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" viewBox="0 0 200 500" fill="none">
-  <!-- Placeholder used only when this SVG is loaded as an icon (template
-       picker, runtime registry preview, etc). The drawtonomy app renders
-       the actual on-canvas marking with a dedicated React component so the
-       digits stay sharp at any aspect ratio. -->
-  <text x="100" y="305" font-family="Arial, Helvetica, sans-serif" font-size="200" font-weight="900" fill="#000000" text-anchor="middle" textLength="160" lengthAdjust="spacingAndGlyphs">50</text>
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" viewBox="0 0 200 140" fill="none">
+  <text x="100" y="70" font-family="Arial, Helvetica, sans-serif" font-size="140" font-weight="900" fill="#000000" text-anchor="middle" dominant-baseline="central" textLength="180" lengthAdjust="spacingAndGlyphs">50</text>
 </svg>


### PR DESCRIPTION
Switches the `marking_speed_limit` template to a wider, shorter aspect ratio so the digits no longer look stretched vertically when placed on the canvas.

- viewBox: 200x500 -> 200x140
- default w/h: 24x60 -> 30x22
- text positioned at the centre with dominant-baseline=central