### PR TITLE
feat(sdk): add exporter module for OpenDRIVE / OpenSCENARIO

### DIFF
--- a/packages/drawtonomy-sdk/README.md
+++ b/packages/drawtonomy-sdk/README.md
@@ -120,6 +120,33 @@ http://localhost:3000/?ext=http://localhost:3001/manifest.json
 | `getBoundingBox(points)` | Get bounding box |
 | `distanceToSegment(point, a, b)` | Point-to-segment distance |
 
+### Exporter Module
+
+Convert a `DrawtonomySnapshot` into target-format strings (OpenDRIVE,
+OpenSCENARIO) without depending on the editor runtime — useful for headless
+tooling, server-side pipelines, or browser extensions.
+
+```typescript
+import { exporter, createSnapshot } from '@drawtonomy/sdk'
+
+const snapshot = createSnapshot(myShapes)
+const xodr = exporter.exportToOpenDrive(snapshot)
+const xosc = exporter.exportToOpenScenario(snapshot, { xodrFilename: 'scene.xodr' })
+
+// Bundle both into a single .zip ready for esmini.
+const { blob, baseName } = exporter.buildEsminiZip(snapshot, { baseName: 'my-scene' })
+```
+
+| Function | Description |
+|----------|-------------|
+| `exporter.exportToOpenDrive(snapshot)` | OpenDRIVE 1.8 (.xodr) XML |
+| `exporter.exportToOpenScenario(snapshot, options?)` | OpenSCENARIO 1.3 (.xosc) XML |
+| `exporter.buildEsminiZip(snapshot, options?)` | One-shot zip bundling .xodr + .xosc |
+| `exporter.buildPathTrajectory(input)` | Path → time-stamped vertex sequence |
+| `exporter.computeCenterlineWithWidth(left, right)` | Lane centerline + width samples |
+| `exporter.buildZip(entries)` | Pure ZIP builder (store mode, no deps) |
+| `exporter.sanitizeFileBaseName(input)` | OS-safe base-name sanitizer |
+
 ## Deployment
 
 Extensions can be deployed to any HTTPS hosting service.

--- a/packages/drawtonomy-sdk/__tests__/exporter/laneCenterline.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/laneCenterline.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import {
+  computeCenterlineWithWidth,
+  sampleAtParam,
+  computeHeadings,
+} from '../../src/exporter/laneCenterline'
+
+describe('sampleAtParam', () => {
+  it('returns first point at t=0', () => {
+    const pts = [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 20, y: 0 }]
+    expect(sampleAtParam(pts, 0)).toEqual({ x: 0, y: 0 })
+  })
+
+  it('returns last point at t=1', () => {
+    const pts = [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 20, y: 0 }]
+    expect(sampleAtParam(pts, 1)).toEqual({ x: 20, y: 0 })
+  })
+
+  it('linearly interpolates by arc length', () => {
+    const pts = [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 20, y: 0 }]
+    const p = sampleAtParam(pts, 0.5)
+    expect(p.x).toBeCloseTo(10)
+    expect(p.y).toBeCloseTo(0)
+  })
+
+  it('handles non-uniform segment lengths', () => {
+    // Total length = 30 (10 + 20). t=0.5 → arc length 15 → middle of second segment.
+    const pts = [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 30, y: 0 }]
+    const p = sampleAtParam(pts, 0.5)
+    expect(p.x).toBeCloseTo(15)
+  })
+})
+
+describe('computeCenterlineWithWidth', () => {
+  it('produces midpoint and constant width for parallel straight boundaries', () => {
+    const left = [{ x: 0, y: -5 }, { x: 100, y: -5 }]
+    const right = [{ x: 0, y: 5 }, { x: 100, y: 5 }]
+    const samples = computeCenterlineWithWidth(left, right, 5)
+    expect(samples).toHaveLength(5)
+    samples.forEach((s) => {
+      expect(s.y).toBeCloseTo(0)
+      expect(s.width).toBeCloseTo(10)
+    })
+    expect(samples[0].x).toBeCloseTo(0)
+    expect(samples[4].x).toBeCloseTo(100)
+  })
+
+  it('returns empty array when boundaries have fewer than 2 points', () => {
+    expect(computeCenterlineWithWidth([{ x: 0, y: 0 }], [{ x: 0, y: 1 }, { x: 1, y: 1 }])).toEqual([])
+  })
+
+  it('width reflects diverging boundaries', () => {
+    const left = [{ x: 0, y: -5 }, { x: 100, y: -10 }]
+    const right = [{ x: 0, y: 5 }, { x: 100, y: 10 }]
+    const samples = computeCenterlineWithWidth(left, right, 3)
+    expect(samples[0].width).toBeCloseTo(10)
+    expect(samples[2].width).toBeCloseTo(20)
+  })
+})
+
+describe('computeHeadings', () => {
+  it('returns 0 radians for x-axis aligned line', () => {
+    const samples = [
+      { x: 0, y: 0, width: 10, s: 0 },
+      { x: 10, y: 0, width: 10, s: 10 },
+      { x: 20, y: 0, width: 10, s: 20 },
+    ]
+    const h = computeHeadings(samples)
+    expect(h).toHaveLength(3)
+    h.forEach((angle) => expect(angle).toBeCloseTo(0))
+  })
+
+  it('returns pi/2 for y-axis going up', () => {
+    const samples = [
+      { x: 0, y: 0, width: 10, s: 0 },
+      { x: 0, y: 10, width: 10, s: 10 },
+    ]
+    const h = computeHeadings(samples)
+    expect(h[0]).toBeCloseTo(Math.PI / 2)
+  })
+})

--- a/packages/drawtonomy-sdk/__tests__/exporter/opendrive.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/opendrive.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect } from 'vitest'
+import { exportToOpenDrive } from '../../src/exporter/opendrive'
+import type { DrawtonomySnapshot } from '../../src/types'
+
+function snapshot(shapes: any[]): DrawtonomySnapshot {
+  return { version: '1.1', timestamp: new Date().toISOString(), shapes }
+}
+
+function point(id: string, x: number, y: number) {
+  return { id, type: 'point', x, y, rotation: 0, zIndex: 0, props: { color: 'black', visible: true, osmId: '' } }
+}
+
+function linestring(id: string, pointIds: string[]) {
+  return {
+    id,
+    type: 'linestring',
+    x: 0,
+    y: 0,
+    rotation: 0,
+    zIndex: 0,
+    props: { pointIds, color: 'black', strokeWidth: 2, attributes: {}, osmId: '' },
+  }
+}
+
+function lane(id: string, leftId: string, rightId: string, opts: any = {}) {
+  return {
+    id,
+    type: 'lane',
+    x: 0,
+    y: 0,
+    rotation: 0,
+    zIndex: 0,
+    props: {
+      leftBoundaryId: leftId,
+      rightBoundaryId: rightId,
+      invertLeft: false,
+      invertRight: false,
+      color: 'default',
+      size: 'm',
+      attributes: { type: 'lanelet', subtype: 'road', speed_limit: '30' },
+      next: opts.next ?? [],
+      prev: opts.prev ?? [],
+      osmId: '',
+    },
+  }
+}
+
+describe('exportToOpenDrive', () => {
+  it('emits a valid OpenDRIVE 1.8 header even with no lanes', () => {
+    const xml = exportToOpenDrive(snapshot([]))
+    expect(xml).toContain(`<?xml version="1.0" encoding="UTF-8"?>`)
+    expect(xml).toContain(`<OpenDRIVE>`)
+    expect(xml).toContain(`revMajor="1"`)
+    expect(xml).toContain(`revMinor="8"`)
+    expect(xml).toContain(`</OpenDRIVE>`)
+  })
+
+  it('emits one road per lane with planView and lanes sections', () => {
+    const shapes = [
+      point('p1', 0, -5), point('p2', 100, -5),
+      point('p3', 0, 5), point('p4', 100, 5),
+      linestring('left', ['p1', 'p2']),
+      linestring('right', ['p3', 'p4']),
+      lane('lane1', 'left', 'right'),
+    ]
+    const xml = exportToOpenDrive(snapshot(shapes))
+    expect(xml).toContain(`<road `)
+    expect(xml).toContain(`id="1"`)
+    expect(xml).toContain(`<planView>`)
+    expect(xml).toContain(`<line/>`)
+    expect(xml).toContain(`<lanes>`)
+    expect(xml).toContain(`<laneSection s="0">`)
+    expect(xml).toContain(`<center>`)
+    expect(xml).toContain(`<left>`)
+    expect(xml).toContain(`<right>`)
+  })
+
+  it('converts pixels to meters using PIXELS_PER_METER (16.67)', () => {
+    const shapes = [
+      point('p1', 0, -5), point('p2', 100, -5),
+      point('p3', 0, 5), point('p4', 100, 5),
+      linestring('left', ['p1', 'p2']),
+      linestring('right', ['p3', 'p4']),
+      lane('lane1', 'left', 'right'),
+    ]
+    const xml = exportToOpenDrive(snapshot(shapes))
+    const m = xml.match(/length="([\d.]+)"/)
+    expect(m).not.toBeNull()
+    expect(parseFloat(m![1])).toBeCloseTo(5.999, 1)
+  })
+
+  it('inverts y axis to match OpenDRIVE math coordinates', () => {
+    const shapes = [
+      point('p1', 0, 100), point('p2', 100, 100),
+      point('p3', 0, 110), point('p4', 100, 110),
+      linestring('left', ['p1', 'p2']),
+      linestring('right', ['p3', 'p4']),
+      lane('lane1', 'left', 'right'),
+    ]
+    const xml = exportToOpenDrive(snapshot(shapes))
+    const yMatch = xml.match(/y="(-?[\d.]+)"/)
+    expect(yMatch).not.toBeNull()
+    expect(parseFloat(yMatch![1])).toBeLessThan(0)
+  })
+
+  it('writes successor/predecessor links between connected lanes (road and lane level)', () => {
+    const shapes = [
+      point('p1', 0, -5), point('p2', 100, -5),
+      point('p3', 0, 5), point('p4', 100, 5),
+      linestring('l1l', ['p1', 'p2']),
+      linestring('l1r', ['p3', 'p4']),
+      lane('lane1', 'l1l', 'l1r', { next: ['lane2'] }),
+      point('p5', 100, -5), point('p6', 200, -5),
+      point('p7', 100, 5), point('p8', 200, 5),
+      linestring('l2l', ['p5', 'p6']),
+      linestring('l2r', ['p7', 'p8']),
+      lane('lane2', 'l2l', 'l2r', { prev: ['lane1'] }),
+    ]
+    const xml = exportToOpenDrive(snapshot(shapes))
+    expect(xml).toContain(`<successor elementType="road" elementId="2"`)
+    expect(xml).toContain(`<predecessor elementType="road" elementId="1"`)
+    expect(xml).toContain(`<successor id="1"/>`)
+    expect(xml).toContain(`<successor id="-1"/>`)
+    expect(xml).toContain(`<predecessor id="1"/>`)
+    expect(xml).toContain(`<predecessor id="-1"/>`)
+  })
+
+  it('exports a TrafficLight near a lane as <signal>', () => {
+    const shapes = [
+      point('p1', 0, -5), point('p2', 100, -5),
+      point('p3', 0, 5), point('p4', 100, 5),
+      linestring('left', ['p1', 'p2']),
+      linestring('right', ['p3', 'p4']),
+      lane('lane1', 'left', 'right'),
+      {
+        id: 'tl1',
+        type: 'traffic_light',
+        x: 100, y: -20, rotation: 0, zIndex: 0,
+        props: { w: 30, h: 60, color: 'black', style: 'pedestrian', activeLight: 'all', size: 'm', attributes: {}, osmId: '' },
+      },
+    ]
+    const xml = exportToOpenDrive(snapshot(shapes))
+    expect(xml).toContain('<signals>')
+    expect(xml).toContain('<signal ')
+    expect(xml).toContain('type="1000002"') // pedestrian signal
+    expect(xml).toContain('dynamic="yes"')
+  })
+
+  it('exports a Polygon near a lane as <object type="patch"> with outline', () => {
+    const shapes = [
+      point('p1', 0, -5), point('p2', 100, -5),
+      point('p3', 0, 5), point('p4', 100, 5),
+      linestring('left', ['p1', 'p2']),
+      linestring('right', ['p3', 'p4']),
+      lane('lane1', 'left', 'right'),
+      point('pp1', 40, -10), point('pp2', 60, -10),
+      point('pp3', 60, 10), point('pp4', 40, 10),
+      {
+        id: 'poly1',
+        type: 'polygon',
+        x: 0, y: 0, rotation: 0, zIndex: 0,
+        props: {
+          pointIds: ['pp1', 'pp2', 'pp3', 'pp4'],
+          color: 'grey-500',
+          strokeWidth: 2,
+          fillOpacity: null,
+          attributes: { type: 'polygon' },
+          osmId: '',
+        },
+      },
+    ]
+    const xml = exportToOpenDrive(snapshot(shapes))
+    expect(xml).toContain('<objects>')
+    expect(xml).toContain('type="patch"')
+    expect(xml).toContain('<outlines>')
+    expect(xml).toContain('<outline ')
+    expect(xml).toContain('<cornerLocal ')
+    const cornerCount = (xml.match(/<cornerLocal /g) || []).length
+    expect(cornerCount).toBe(4)
+  })
+
+  it('exports a Crosswalk near a lane as <object type="crosswalk">', () => {
+    const shapes = [
+      point('p1', 0, -5), point('p2', 100, -5),
+      point('p3', 0, 5), point('p4', 100, 5),
+      linestring('left', ['p1', 'p2']),
+      linestring('right', ['p3', 'p4']),
+      lane('lane1', 'left', 'right'),
+      {
+        id: 'cw1',
+        type: 'crosswalk',
+        x: 50, y: 0, rotation: 0, zIndex: 0,
+        props: {
+          startX: 0, startY: -10, endX: 0, endY: 10,
+          stripeWidth: 5, stripeSpacing: 5, crosswalkWidth: 40,
+          color: 'white', attributes: { type: 'crosswalk', subtype: 'zebra' }, osmId: '',
+        },
+      },
+    ]
+    const xml = exportToOpenDrive(snapshot(shapes))
+    expect(xml).toContain('<objects>')
+    expect(xml).toContain('<object ')
+    expect(xml).toContain('type="crosswalk"')
+  })
+
+  it('emits empty <link/> for lanes without next/prev', () => {
+    const shapes = [
+      point('p1', 0, -5), point('p2', 100, -5),
+      point('p3', 0, 5), point('p4', 100, 5),
+      linestring('left', ['p1', 'p2']),
+      linestring('right', ['p3', 'p4']),
+      lane('lane1', 'left', 'right'),
+    ]
+    const xml = exportToOpenDrive(snapshot(shapes))
+    expect(xml).not.toContain(`<successor id=`)
+    expect(xml).not.toContain(`<predecessor id=`)
+  })
+
+  it('skips lanes with missing boundary references', () => {
+    const shapes = [
+      lane('lane1', 'missingL', 'missingR'),
+    ]
+    const xml = exportToOpenDrive(snapshot(shapes))
+    expect(xml).not.toContain(`<road `)
+    expect(xml).toContain(`</OpenDRIVE>`)
+  })
+})

--- a/packages/drawtonomy-sdk/__tests__/exporter/openscenario.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/openscenario.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from 'vitest'
+import {
+  exportToOpenScenario,
+  templateIdToVehicleCategory,
+} from '../../src/exporter/openscenario'
+import type { DrawtonomySnapshot } from '../../src/types'
+
+function snapshot(shapes: any[]): DrawtonomySnapshot {
+  return { version: '1.1', timestamp: new Date().toISOString(), shapes }
+}
+
+function vehicle(id: string, props: Partial<any> = {}, x = 0, y = 0, rotation = 0) {
+  return {
+    id,
+    type: 'vehicle',
+    x,
+    y,
+    rotation,
+    zIndex: 0,
+    props: {
+      w: 90,
+      h: 45,
+      color: 'black',
+      size: 'm',
+      attributes: {},
+      osmId: '',
+      templateId: 'sedan',
+      ...props,
+    },
+  }
+}
+
+describe('templateIdToVehicleCategory', () => {
+  it('maps vehicle templates to OpenSCENARIO categories', () => {
+    expect(templateIdToVehicleCategory('sedan')).toBe('car')
+    expect(templateIdToVehicleCategory('bus')).toBe('bus')
+    expect(templateIdToVehicleCategory('truck')).toBe('truck')
+    expect(templateIdToVehicleCategory('motorcycle')).toBe('motorbike')
+    expect(templateIdToVehicleCategory('motorcycle2')).toBe('motorbike')
+    expect(templateIdToVehicleCategory('bicycle')).toBe('bicycle')
+    expect(templateIdToVehicleCategory('bicycle2')).toBe('bicycle')
+  })
+
+  it('falls back to car for non-standard templates', () => {
+    expect(templateIdToVehicleCategory('amr')).toBe('car')
+    expect(templateIdToVehicleCategory('robovac')).toBe('car')
+    expect(templateIdToVehicleCategory('totally-unknown')).toBe('car')
+  })
+})
+
+describe('exportToOpenScenario', () => {
+  it('emits a valid OpenSCENARIO 1.3 header even with no entities', () => {
+    const xml = exportToOpenScenario(snapshot([]))
+    expect(xml).toContain(`<?xml version="1.0" encoding="UTF-8"?>`)
+    expect(xml).toContain(`<OpenSCENARIO>`)
+    expect(xml).toContain(`revMajor="1"`)
+    expect(xml).toContain(`revMinor="3"`)
+    expect(xml).toContain(`<RoadNetwork>`)
+    expect(xml).toContain(`<Entities>`)
+    expect(xml).toContain(`<Storyboard>`)
+    expect(xml).toContain(`</OpenSCENARIO>`)
+  })
+
+  it('references the provided xodr file in LogicFile', () => {
+    const xml = exportToOpenScenario(snapshot([]), { xodrFilename: 'my-scene.xodr' })
+    expect(xml).toContain(`<LogicFile filepath="my-scene.xodr"/>`)
+  })
+
+  it('emits a Vehicle ScenarioObject for sedan template with BoundingBox', () => {
+    const xml = exportToOpenScenario(snapshot([
+      vehicle('v1', { templateId: 'sedan', w: 90, h: 45 }, 100, 200),
+    ]))
+    expect(xml).toContain(`<ScenarioObject name="Vehicle_0">`)
+    expect(xml).toContain(`vehicleCategory="car"`)
+    expect(xml).toContain(`<BoundingBox>`)
+    expect(xml).toMatch(/<Dimensions width="\d+\.\d+" length="\d+\.\d+" height="\d+\.\d+"\/>/)
+    expect(xml).toContain(`<Performance `)
+    expect(xml).toContain(`<Axles>`)
+    expect(xml).toContain(`<Property name="scaleMode" value="ModelToBB"/>`)
+  })
+
+  it('uses vehicleCategory bus for bus template', () => {
+    const xml = exportToOpenScenario(snapshot([
+      vehicle('v1', { templateId: 'bus' }),
+    ]))
+    expect(xml).toContain(`vehicleCategory="bus"`)
+  })
+
+  it('emits a Pedestrian element for pedestrian templates', () => {
+    const xml = exportToOpenScenario(snapshot([
+      vehicle('p1', { templateId: 'pedestrian' }),
+    ]))
+    expect(xml).toContain(`<Pedestrian `)
+    expect(xml).toContain(`pedestrianCategory="pedestrian"`)
+    expect(xml).not.toMatch(/<Vehicle [^>]*pedestrianCategory/)
+  })
+
+  it('emits TeleportAction with WorldPosition for each entity', () => {
+    const xml = exportToOpenScenario(snapshot([
+      vehicle('v1', { templateId: 'sedan' }, 100, 200),
+      vehicle('p1', { templateId: 'pedestrian' }, 300, 400),
+    ]))
+    const teleports = xml.match(/<TeleportAction>/g) || []
+    expect(teleports.length).toBe(2)
+    expect(xml).toContain(`<Private entityRef="Vehicle_0">`)
+    expect(xml).toContain(`<Private entityRef="Pedestrian_1">`)
+  })
+
+  it('converts pixel coordinates to meters and inverts y axis', () => {
+    const xml = exportToOpenScenario(snapshot([
+      vehicle('v1', { templateId: 'sedan' }, 100, 200),
+    ]))
+    const m = xml.match(/<WorldPosition x="([\d.\-]+)" y="([\d.\-]+)"/)
+    expect(m).not.toBeNull()
+    expect(parseFloat(m![1])).toBeCloseTo(6.0, 0)
+    expect(parseFloat(m![2])).toBeCloseTo(-12.0, 0)
+  })
+
+  it('converts rotation degrees to ENU heading with π/2 offset (template faces -Y)', () => {
+    const xmlZero = exportToOpenScenario(snapshot([
+      vehicle('v1', { templateId: 'sedan' }, 0, 0, 0),
+    ]))
+    const m0 = xmlZero.match(/<WorldPosition [^/]*h="([\d.\-]+)"/)
+    expect(m0).not.toBeNull()
+    expect(parseFloat(m0![1])).toBeCloseTo(Math.PI / 2, 3)
+
+    const xml90 = exportToOpenScenario(snapshot([
+      vehicle('v2', { templateId: 'sedan' }, 0, 0, 90),
+    ]))
+    const m90 = xml90.match(/<WorldPosition [^/]*h="([\d.\-]+)"/)
+    expect(m90).not.toBeNull()
+    expect(parseFloat(m90![1])).toBeCloseTo(0, 3)
+  })
+
+  it('produces vehicle dimensions matching px-to-m conversion', () => {
+    const xml = exportToOpenScenario(snapshot([
+      vehicle('v1', { templateId: 'sedan', w: 100, h: 50 }),
+    ]))
+    const m = xml.match(/<Dimensions width="([\d.]+)" length="([\d.]+)"/)
+    expect(m).not.toBeNull()
+    expect(parseFloat(m![1])).toBeCloseTo(6.0, 1)
+    expect(parseFloat(m![2])).toBeCloseTo(3.0, 1)
+  })
+
+  it('emits a StopTrigger so the simulation does not run forever', () => {
+    const xml = exportToOpenScenario(snapshot([]))
+    expect(xml).toContain(`<StopTrigger>`)
+    expect(xml).toContain(`<SimulationTimeCondition `)
+  })
+
+  it('emits FollowTrajectoryAction for path with footprint vehicles', () => {
+    const v = vehicle('v1', { templateId: 'sedan' }, 100, 200)
+    const path = {
+      id: 'p1',
+      type: 'linestring',
+      x: 0, y: 0, rotation: 0, zIndex: 0,
+      props: {
+        pointIds: ['pt1', 'pt2', 'pt3'],
+        color: 'black',
+        strokeWidth: 2,
+        attributes: {},
+        osmId: '',
+        isPath: true,
+        footprint: { interval: 200, offset: 0, templateId: 'sedan' },
+        footprintIds: [v.id],
+      },
+    }
+    const pt1 = { id: 'pt1', type: 'point', x: 0, y: 0, rotation: 0, zIndex: 0, props: { color: 'black', visible: true, osmId: '' } }
+    const pt2 = { id: 'pt2', type: 'point', x: 500, y: 0, rotation: 0, zIndex: 0, props: { color: 'black', visible: true, osmId: '' } }
+    const pt3 = { id: 'pt3', type: 'point', x: 1000, y: 0, rotation: 0, zIndex: 0, props: { color: 'black', visible: true, osmId: '' } }
+    const xml = exportToOpenScenario(snapshot([v, path, pt1, pt2, pt3]))
+    expect(xml).toContain(`<Story name="MovingStory">`)
+    expect(xml).toContain(`<FollowTrajectoryAction>`)
+    expect(xml).toContain(`<Trajectory `)
+    expect(xml).toContain(`<Polyline>`)
+    expect(xml).toContain(`<EntityRef entityRef="Vehicle_0"/>`)
+  })
+
+  it('skips follower footprint vehicles, only head is exported as ScenarioObject', () => {
+    const head = vehicle('vh', { templateId: 'sedan' }, 100, 100)
+    const f1 = vehicle('vf1', { templateId: 'sedan' }, 200, 100)
+    const f2 = vehicle('vf2', { templateId: 'sedan' }, 300, 100)
+    const path = {
+      id: 'p1', type: 'linestring', x: 0, y: 0, rotation: 0, zIndex: 0,
+      props: {
+        pointIds: ['pt1', 'pt2'],
+        color: 'black', strokeWidth: 2, attributes: {}, osmId: '',
+        isPath: true,
+        footprint: { interval: 100, offset: 0, templateId: 'sedan' },
+        footprintIds: [head.id, f1.id, f2.id],
+      },
+    }
+    const pt1 = { id: 'pt1', type: 'point', x: 0, y: 100, rotation: 0, zIndex: 0, props: { color: 'black', visible: true, osmId: '' } }
+    const pt2 = { id: 'pt2', type: 'point', x: 500, y: 100, rotation: 0, zIndex: 0, props: { color: 'black', visible: true, osmId: '' } }
+    const xml = exportToOpenScenario(snapshot([head, f1, f2, path, pt1, pt2]))
+    const objCount = (xml.match(/<ScenarioObject /g) || []).length
+    expect(objCount).toBe(1)
+    expect(xml).toContain(`<ScenarioObject name="Vehicle_0">`)
+    expect(xml).not.toContain(`Vehicle_1`)
+    expect(xml).not.toContain(`Vehicle_2`)
+  })
+
+  it('aligns Init TeleportAction to path start when entity is on a trajectory', () => {
+    const v = vehicle('v1', { templateId: 'sedan' }, 0, 0)
+    const path = {
+      id: 'p1', type: 'linestring', x: 0, y: 0, rotation: 0, zIndex: 0,
+      props: {
+        pointIds: ['pt1', 'pt2'],
+        color: 'black', strokeWidth: 2, attributes: {}, osmId: '',
+        isPath: true,
+        footprint: { interval: 200, offset: 0, templateId: 'sedan' },
+        footprintIds: [v.id],
+      },
+    }
+    const pt1 = { id: 'pt1', type: 'point', x: 500, y: 0, rotation: 0, zIndex: 0, props: { color: 'black', visible: true, osmId: '' } }
+    const pt2 = { id: 'pt2', type: 'point', x: 1000, y: 0, rotation: 0, zIndex: 0, props: { color: 'black', visible: true, osmId: '' } }
+    const xml = exportToOpenScenario(snapshot([v, path, pt1, pt2]))
+    const initBlockMatch = xml.match(/<Init>([\s\S]*?)<\/Init>/)
+    expect(initBlockMatch).not.toBeNull()
+    const initBlock = initBlockMatch![1]
+    expect(initBlock).toContain(`x="29.994001"`)
+  })
+})

--- a/packages/drawtonomy-sdk/__tests__/exporter/packageEsmini.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/packageEsmini.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { buildEsminiZip } from '../../src/exporter/packageEsmini'
+import type { DrawtonomySnapshot } from '../../src/types'
+
+function makeSnapshot(): DrawtonomySnapshot {
+  return {
+    version: '1.1',
+    timestamp: new Date().toISOString(),
+    shapes: [
+      { id: 'p1', type: 'point', x: 0, y: -5, rotation: 0, zIndex: 0, props: { color: 'black', visible: true, osmId: '' } },
+      { id: 'p2', type: 'point', x: 100, y: -5, rotation: 0, zIndex: 0, props: { color: 'black', visible: true, osmId: '' } },
+      { id: 'p3', type: 'point', x: 0, y: 5, rotation: 0, zIndex: 0, props: { color: 'black', visible: true, osmId: '' } },
+      { id: 'p4', type: 'point', x: 100, y: 5, rotation: 0, zIndex: 0, props: { color: 'black', visible: true, osmId: '' } },
+      { id: 'left', type: 'linestring', x: 0, y: 0, rotation: 0, zIndex: 0, props: { pointIds: ['p1', 'p2'], color: 'black', strokeWidth: 2, attributes: {}, osmId: '' } },
+      { id: 'right', type: 'linestring', x: 0, y: 0, rotation: 0, zIndex: 0, props: { pointIds: ['p3', 'p4'], color: 'black', strokeWidth: 2, attributes: {}, osmId: '' } },
+      {
+        id: 'lane1', type: 'lane', x: 0, y: 0, rotation: 0, zIndex: 0,
+        props: {
+          leftBoundaryId: 'left', rightBoundaryId: 'right',
+          invertLeft: false, invertRight: false,
+          color: 'default', size: 'm',
+          attributes: { type: 'lanelet', subtype: 'road', speed_limit: '30' },
+          next: [], prev: [], osmId: '',
+        },
+      },
+    ],
+  }
+}
+
+describe('buildEsminiZip', () => {
+  it('returns a blob and a sanitized base name', () => {
+    const result = buildEsminiZip(makeSnapshot(), { baseName: 'My Scene/01' })
+    expect(result.blob.type).toBe('application/zip')
+    expect(result.blob.size).toBeGreaterThan(0)
+    expect(result.baseName).toBe('My Scene_01')
+  })
+
+  it('falls back to "drawtonomy" when baseName is missing or invalid', () => {
+    const r1 = buildEsminiZip(makeSnapshot())
+    expect(r1.baseName).toBe('drawtonomy')
+
+    const r2 = buildEsminiZip(makeSnapshot(), { baseName: '...' })
+    expect(r2.baseName).toBe('drawtonomy')
+  })
+})

--- a/packages/drawtonomy-sdk/__tests__/exporter/sanitize.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/sanitize.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeFileBaseName } from '../../src/exporter/sanitize'
+
+describe('sanitizeFileBaseName', () => {
+  it('passes through plain ASCII names', () => {
+    expect(sanitizeFileBaseName('my-scene')).toBe('my-scene')
+    expect(sanitizeFileBaseName('Scenario_01')).toBe('Scenario_01')
+  })
+
+  it('preserves multibyte (Japanese) characters', () => {
+    expect(sanitizeFileBaseName('交差点シナリオ')).toBe('交差点シナリオ')
+  })
+
+  it('replaces path separators and shell-unsafe characters with _', () => {
+    expect(sanitizeFileBaseName('a/b\\c:d*e?f"g<h>i|j')).toBe('a_b_c_d_e_f_g_h_i_j')
+  })
+
+  it('strips control characters', () => {
+    expect(sanitizeFileBaseName('hello\x00\x1fworld')).toBe('hello__world')
+  })
+
+  it('collapses runs of whitespace and trims edges', () => {
+    expect(sanitizeFileBaseName('  hello   world  ')).toBe('hello world')
+  })
+
+  it('removes leading/trailing dots', () => {
+    expect(sanitizeFileBaseName('...scene...')).toBe('scene')
+  })
+
+  it('returns null for empty / dot-only / whitespace-only input', () => {
+    expect(sanitizeFileBaseName('')).toBeNull()
+    expect(sanitizeFileBaseName('.')).toBeNull()
+    expect(sanitizeFileBaseName('..')).toBeNull()
+    expect(sanitizeFileBaseName('   ')).toBeNull()
+    expect(sanitizeFileBaseName('////')).toBeNull()
+  })
+
+  it('truncates excessively long names to 100 chars', () => {
+    const long = 'a'.repeat(200)
+    const out = sanitizeFileBaseName(long)
+    expect(out).not.toBeNull()
+    expect(out!.length).toBe(100)
+  })
+})

--- a/packages/drawtonomy-sdk/__tests__/exporter/trajectory.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/trajectory.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { buildPathTrajectory, DEFAULT_PATH_SPEED_MPS } from '../../src/exporter/trajectory'
+
+describe('buildPathTrajectory', () => {
+  it('returns empty array for paths with fewer than 2 points', () => {
+    expect(buildPathTrajectory({ points: [] })).toEqual([])
+    expect(buildPathTrajectory({ points: [{ x: 0, y: 0 }] })).toEqual([])
+  })
+
+  it('with interval and default speed emits points at expected times', () => {
+    const samples = buildPathTrajectory({
+      points: [{ x: 0, y: 0 }, { x: 1000, y: 0 }],
+      interval: 200,
+      offset: 0,
+    })
+    expect(samples.length).toBeGreaterThan(0)
+    for (let i = 1; i < samples.length; i++) {
+      expect(samples[i].time).toBeGreaterThan(samples[i - 1].time)
+    }
+  })
+
+  it('time = distance / speed for interval mode', () => {
+    const samples = buildPathTrajectory({
+      points: [{ x: 0, y: 0 }, { x: 1000, y: 0 }],
+      interval: 1000,
+      offset: 0,
+    })
+    expect(samples.length).toBeGreaterThanOrEqual(2)
+    const last = samples[samples.length - 1]
+    const totalLenM = 1000 / 16.67
+    expect(last.time).toBeCloseTo(totalLenM / DEFAULT_PATH_SPEED_MPS, 1)
+  })
+
+  it('uses tValues when provided and distributes them across totalDuration', () => {
+    const samples = buildPathTrajectory({
+      points: [{ x: 0, y: 0 }, { x: 1000, y: 0 }],
+      tValues: [0, 0.25, 0.5, 0.75, 1.0],
+    })
+    expect(samples.length).toBe(5)
+    const totalLenM = 1000 / 16.67
+    const totalDuration = totalLenM / DEFAULT_PATH_SPEED_MPS
+    const dt = totalDuration / 4
+    expect(samples[0].time).toBeCloseTo(0, 3)
+    expect(samples[1].time).toBeCloseTo(dt, 2)
+    expect(samples[4].time).toBeCloseTo(totalDuration, 1)
+    expect(samples[0].x).toBeCloseTo(0, 1)
+    expect(samples[2].x).toBeCloseTo(totalLenM / 2, 1)
+    expect(samples[4].x).toBeCloseTo(totalLenM, 1)
+  })
+
+  it('inverts y axis from canvas (down +) to ENU (up +)', () => {
+    const samples = buildPathTrajectory({
+      points: [{ x: 0, y: 100 }, { x: 1000, y: 100 }],
+      tValues: [0, 1.0],
+    })
+    expect(samples[0].y).toBeCloseTo(-6, 1)
+    expect(samples[1].y).toBeCloseTo(-6, 1)
+  })
+
+  it('heading is 0 (east) for path going +X', () => {
+    const samples = buildPathTrajectory({
+      points: [{ x: 0, y: 0 }, { x: 1000, y: 0 }],
+      tValues: [0, 1.0],
+    })
+    expect(samples[0].heading).toBeCloseTo(0, 3)
+  })
+
+  it('heading is π/2 (north) for path going -Y on canvas (screen up)', () => {
+    const samples = buildPathTrajectory({
+      points: [{ x: 0, y: 100 }, { x: 0, y: 0 }],
+      tValues: [0, 1.0],
+    })
+    expect(samples[0].heading).toBeCloseTo(Math.PI / 2, 3)
+  })
+
+  it('falls back to control points when no footprint info', () => {
+    const samples = buildPathTrajectory({
+      points: [{ x: 0, y: 0 }, { x: 500, y: 0 }, { x: 1000, y: 0 }],
+    })
+    expect(samples.length).toBe(3)
+    expect(samples[0].time).toBeCloseTo(0, 3)
+    const totalLenM = 1000 / 16.67
+    expect(samples[2].time).toBeCloseTo(totalLenM / DEFAULT_PATH_SPEED_MPS, 1)
+  })
+
+  it('time monotonically increases even with zero-length segments', () => {
+    const samples = buildPathTrajectory({
+      points: [{ x: 0, y: 0 }, { x: 0, y: 0 }, { x: 100, y: 0 }],
+      tValues: [0, 0, 1.0],
+    })
+    for (let i = 1; i < samples.length; i++) {
+      expect(samples[i].time).toBeGreaterThan(samples[i - 1].time)
+    }
+  })
+})

--- a/packages/drawtonomy-sdk/__tests__/exporter/zip.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/zip.test.ts
@@ -1,0 +1,85 @@
+// @ts-nocheck
+// vitest runs on Node so fs / path / child_process are available, but this
+// test file is type-checked alongside the SDK source. We use @ts-nocheck
+// instead of pulling in @types/node.
+import { describe, it, expect } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { execFileSync } from 'child_process'
+import { buildZip, _crc32ForTest } from '../../src/exporter/zip'
+
+describe('crc32', () => {
+  it('matches standard CRC-32 value for "123456789"', () => {
+    const data = new TextEncoder().encode('123456789')
+    expect(_crc32ForTest(data) >>> 0).toBe(0xcbf43926)
+  })
+
+  it('returns 0 for empty input', () => {
+    expect(_crc32ForTest(new Uint8Array())).toBe(0)
+  })
+})
+
+describe('buildZip', () => {
+  it('produces a Blob with application/zip mime type', async () => {
+    const blob = buildZip([{ path: 'a.txt', data: 'hello' }])
+    expect(blob.type).toBe('application/zip')
+    expect(blob.size).toBeGreaterThan(0)
+  })
+
+  it('writes Local File Header signature and EOCD signature', async () => {
+    const blob = buildZip([{ path: 'a.txt', data: 'hello' }])
+    const ab = await blob.arrayBuffer()
+    const u8 = new Uint8Array(ab)
+    // Local File Header at offset 0: 0x04034b50 (little-endian).
+    expect(u8[0]).toBe(0x50)
+    expect(u8[1]).toBe(0x4b)
+    expect(u8[2]).toBe(0x03)
+    expect(u8[3]).toBe(0x04)
+    // EOCD signature 0x06054b50 must appear near the end.
+    let foundEocd = false
+    for (let i = u8.length - 22; i >= 0; i--) {
+      if (
+        u8[i] === 0x50 && u8[i + 1] === 0x4b &&
+        u8[i + 2] === 0x05 && u8[i + 3] === 0x06
+      ) {
+        foundEocd = true
+        break
+      }
+    }
+    expect(foundEocd).toBe(true)
+  })
+
+  it('produces an archive that the system unzip can list and extract', async () => {
+    const blob = buildZip([
+      { path: 'pkg/scene.xodr', data: '<OpenDRIVE>x</OpenDRIVE>' },
+      { path: 'pkg/scene.xosc', data: '<OpenSCENARIO>y</OpenSCENARIO>' },
+    ])
+    const ab = await blob.arrayBuffer()
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'drawtonomy-zip-'))
+    const zipPath = path.join(tmp, 'out.zip')
+    fs.writeFileSync(zipPath, Buffer.from(ab))
+
+    const listing = execFileSync('unzip', ['-l', zipPath], { encoding: 'utf-8' })
+    expect(listing).toContain('pkg/scene.xodr')
+    expect(listing).toContain('pkg/scene.xosc')
+
+    execFileSync('unzip', ['-q', zipPath, '-d', tmp])
+    expect(fs.readFileSync(path.join(tmp, 'pkg/scene.xodr'), 'utf-8')).toBe('<OpenDRIVE>x</OpenDRIVE>')
+    expect(fs.readFileSync(path.join(tmp, 'pkg/scene.xosc'), 'utf-8')).toBe('<OpenSCENARIO>y</OpenSCENARIO>')
+
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+
+  it('preserves multi-byte UTF-8 content', async () => {
+    const blob = buildZip([{ path: 'note.txt', data: 'こんにちは' }])
+    const ab = await blob.arrayBuffer()
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'drawtonomy-zip-utf-'))
+    const zipPath = path.join(tmp, 'utf.zip')
+    fs.writeFileSync(zipPath, Buffer.from(ab))
+
+    execFileSync('unzip', ['-q', zipPath, '-d', tmp])
+    expect(fs.readFileSync(path.join(tmp, 'note.txt'), 'utf-8')).toBe('こんにちは')
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+})

--- a/packages/drawtonomy-sdk/src/exporter/index.ts
+++ b/packages/drawtonomy-sdk/src/exporter/index.ts
@@ -1,0 +1,31 @@
+// drawtonomy SDK — exporter modules.
+//
+// These exporters convert a `DrawtonomySnapshot` into target-format strings
+// (OpenDRIVE / OpenSCENARIO) without depending on the editor runtime, so
+// they can be used in headless tooling, server-side pipelines, or browser
+// extensions.
+
+export { exportToOpenDrive } from './opendrive'
+export {
+  exportToOpenScenario,
+  templateIdToVehicleCategory,
+  type OpenScenarioExportOptions,
+  type TemplateResolver,
+} from './openscenario'
+export {
+  buildPathTrajectory,
+  DEFAULT_PATH_SPEED_MPS,
+  type PathSamplePoint,
+  type PathTrajectoryInput,
+} from './trajectory'
+export {
+  computeCenterlineWithWidth,
+  sampleAtParam,
+  computeHeadings,
+  type Point2D,
+  type CenterlineSample,
+} from './laneCenterline'
+export { buildEsminiZip, type EsminiPackageOptions, type EsminiPackageResult } from './packageEsmini'
+export { buildZip, type ZipEntry } from './zip'
+export { sanitizeFileBaseName } from './sanitize'
+export { PIXELS_PER_METER } from './units'

--- a/packages/drawtonomy-sdk/src/exporter/laneCenterline.ts
+++ b/packages/drawtonomy-sdk/src/exporter/laneCenterline.ts
@@ -1,0 +1,112 @@
+// Lane centerline + width sample utilities. Computes a centerline and
+// per-sample lane width from two boundary point sequences. Used by the
+// OpenDRIVE exporter to emit reference lines and lane widths.
+
+export interface Point2D {
+  x: number
+  y: number
+}
+
+export interface CenterlineSample {
+  x: number
+  y: number
+  width: number
+  s: number
+}
+
+/**
+ * Build a centerline + lane-width sample sequence from two boundary point
+ * sequences.
+ *
+ * Approach:
+ * - Sample both boundaries at the same normalized arc-length parameter t (0..1)
+ * - Take the midpoint of the two sampled points as the centerline
+ * - Take the distance between the two as the lane width at that sample
+ *
+ * Stable for boundaries with different point counts or lengths.
+ *
+ * @param left - left boundary point sequence (in travel direction)
+ * @param right - right boundary point sequence (same direction)
+ * @param numSamples - number of output samples; 0 = max(left.length, right.length)
+ */
+export function computeCenterlineWithWidth(
+  left: Point2D[],
+  right: Point2D[],
+  numSamples: number = 0
+): CenterlineSample[] {
+  if (left.length < 2 || right.length < 2) return []
+
+  const n = numSamples > 0 ? numSamples : Math.max(left.length, right.length)
+  const samples: CenterlineSample[] = []
+
+  let s = 0
+  let prev: Point2D | null = null
+
+  for (let i = 0; i < n; i++) {
+    const t = i / (n - 1)
+    const lp = sampleAtParam(left, t)
+    const rp = sampleAtParam(right, t)
+    const cx = (lp.x + rp.x) / 2
+    const cy = (lp.y + rp.y) / 2
+    const width = Math.hypot(lp.x - rp.x, lp.y - rp.y)
+
+    if (prev) s += Math.hypot(cx - prev.x, cy - prev.y)
+    samples.push({ x: cx, y: cy, width, s })
+    prev = { x: cx, y: cy }
+  }
+
+  return samples
+}
+
+/**
+ * Linearly interpolate a point on a polyline at normalized arc-length
+ * parameter t in [0, 1].
+ */
+export function sampleAtParam(points: Point2D[], t: number): Point2D {
+  if (points.length === 0) return { x: 0, y: 0 }
+  if (points.length === 1) return { x: points[0].x, y: points[0].y }
+  if (t <= 0) return { x: points[0].x, y: points[0].y }
+  if (t >= 1) {
+    const last = points[points.length - 1]
+    return { x: last.x, y: last.y }
+  }
+
+  // Cumulative arc length.
+  const lens: number[] = [0]
+  for (let i = 1; i < points.length; i++) {
+    lens.push(lens[i - 1] + Math.hypot(points[i].x - points[i - 1].x, points[i].y - points[i - 1].y))
+  }
+  const total = lens[lens.length - 1]
+  if (total === 0) return { x: points[0].x, y: points[0].y }
+
+  const target = t * total
+  for (let i = 1; i < points.length; i++) {
+    if (lens[i] >= target) {
+      const segLen = lens[i] - lens[i - 1]
+      const localT = segLen === 0 ? 0 : (target - lens[i - 1]) / segLen
+      return {
+        x: points[i - 1].x + (points[i].x - points[i - 1].x) * localT,
+        y: points[i - 1].y + (points[i].y - points[i - 1].y) * localT,
+      }
+    }
+  }
+  const last = points[points.length - 1]
+  return { x: last.x, y: last.y }
+}
+
+/**
+ * Compute per-sample heading (tangent direction, radians) for a centerline.
+ * heading[i] is the direction from sample[i] to sample[i+1]; the last entry
+ * repeats the previous one.
+ */
+export function computeHeadings(samples: CenterlineSample[]): number[] {
+  if (samples.length === 0) return []
+  const headings: number[] = []
+  for (let i = 0; i < samples.length - 1; i++) {
+    const dx = samples[i + 1].x - samples[i].x
+    const dy = samples[i + 1].y - samples[i].y
+    headings.push(Math.atan2(dy, dx))
+  }
+  headings.push(headings[headings.length - 1] ?? 0)
+  return headings
+}

--- a/packages/drawtonomy-sdk/src/exporter/opendrive.ts
+++ b/packages/drawtonomy-sdk/src/exporter/opendrive.ts
@@ -1,0 +1,675 @@
+// OpenDRIVE 1.8 (.xodr) exporter — emits a road network from a snapshot.
+// No external library dependencies.
+//
+// Design (Phase 1):
+// - Each lane is emitted as an independent <road> (junctions are out of scope)
+// - Reference line is the midpoints of the left/right boundary samples
+// - Each segment is a <line> geometry; lane width is a per-sample <width>
+// - Lane connectivity (next/prev) is written into <link>
+// - Coordinate frame: canvas (x right, y down) → ENU (x right, y up); y is flipped
+
+import type {
+  BaseShape,
+  CrosswalkProps,
+  DrawtonomySnapshot,
+  LaneProps,
+  LinestringProps,
+  PointProps,
+  PolygonProps,
+  TrafficLightProps,
+} from '../types'
+import { computeCenterlineWithWidth, type Point2D, type CenterlineSample } from './laneCenterline'
+import { escapeXml, fmt, pxToEnuX, pxToEnuY, pxToMeter } from './units'
+
+type LaneShape = BaseShape<'lane', LaneProps>
+type LinestringShape = BaseShape<'linestring', LinestringProps>
+type PointShape = BaseShape<'point', PointProps>
+type TrafficLightShape = BaseShape<'traffic_light', TrafficLightProps>
+type CrosswalkShape = BaseShape<'crosswalk', CrosswalkProps>
+type PolygonShape = BaseShape<'polygon', PolygonProps>
+
+interface RoadGeometry {
+  laneId: string
+  samples: CenterlineSample[]
+  /** Centerline samples in OpenDRIVE meters. */
+  odrSamples: { x: number; y: number; width: number; s: number }[]
+  /** Total arc length (m). */
+  length: number
+}
+
+/** O(1) shape lookup by id. */
+function buildShapeMap(shapes: readonly BaseShape[]): Map<string, BaseShape> {
+  const map = new Map<string, BaseShape>()
+  for (const s of shapes) map.set(s.id, s)
+  return map
+}
+
+/**
+ * Build the centerline + width samples for a lane from its two boundaries.
+ * If pointOverrides is provided, those point ids are read from the override
+ * map instead of from the shape map (used for boundary alignment snapping).
+ */
+function buildRoadGeometry(
+  shapeMap: Map<string, BaseShape>,
+  lane: LaneShape,
+  pointOverrides: Map<string, Point2D>
+): RoadGeometry | null {
+  const leftId = lane.props.leftBoundaryId
+  const rightId = lane.props.rightBoundaryId
+  if (!leftId || !rightId) return null
+
+  const left = shapeMap.get(leftId) as unknown as LinestringShape | undefined
+  const right = shapeMap.get(rightId) as unknown as LinestringShape | undefined
+  if (!left || !right) return null
+
+  const leftPts = collectPoints(shapeMap, left.props.pointIds, lane.props.invertLeft, pointOverrides)
+  const rightPts = collectPoints(shapeMap, right.props.pointIds, lane.props.invertRight, pointOverrides)
+  if (leftPts.length < 2 || rightPts.length < 2) return null
+
+  const samples = computeCenterlineWithWidth(leftPts, rightPts)
+  if (samples.length < 2) return null
+
+  const odrSamples = samples.map((s) => ({
+    x: pxToEnuX(s.x),
+    y: pxToEnuY(s.y),
+    width: pxToMeter(s.width),
+    s: pxToMeter(s.s),
+  }))
+  const length = odrSamples[odrSamples.length - 1].s
+
+  return { laneId: lane.id, samples, odrSamples, length }
+}
+
+function collectPoints(
+  shapeMap: Map<string, BaseShape>,
+  pointIds: string[],
+  invert: boolean,
+  pointOverrides: Map<string, Point2D>
+): Point2D[] {
+  const ids = invert ? [...pointIds].reverse() : pointIds
+  const pts: Point2D[] = []
+  for (const id of ids) {
+    const ov = pointOverrides.get(id)
+    if (ov) {
+      pts.push({ x: ov.x, y: ov.y })
+      continue
+    }
+    const p = shapeMap.get(id) as unknown as PointShape | undefined
+    if (p) pts.push({ x: p.x, y: p.y })
+  }
+  return pts
+}
+
+/**
+ * Snap together boundary endpoints of connected lanes by clustering nearby
+ * points and using the centroid as the canonical position.
+ *
+ * Two lanes that "look" connected on the canvas may actually own separate
+ * point shapes whose coordinates drift by a few pixels. The road exporter
+ * would then emit a small visible gap between them in the player. This
+ * routine collects the boundary endpoints of lanes that participate in a
+ * next/prev relationship and snaps clusters within epsilonPx onto a single
+ * representative position.
+ */
+function buildBoundaryAlignmentOverrides(
+  shapeMap: Map<string, BaseShape>,
+  lanes: LaneShape[],
+  epsilonPx: number = 30
+): Map<string, Point2D> {
+  type Endpoint = { pointId: string; x: number; y: number }
+  const endpoints: Endpoint[] = []
+  const laneIds = new Set(lanes.map((l) => l.id))
+
+  const collectEndpoints = (lane: LaneShape, side: 'start' | 'end') => {
+    for (const sideKey of ['leftBoundaryId', 'rightBoundaryId'] as const) {
+      const lsId = lane.props[sideKey]
+      if (!lsId) continue
+      const ls = shapeMap.get(lsId) as unknown as LinestringShape | undefined
+      if (!ls) continue
+      const invert =
+        sideKey === 'leftBoundaryId' ? lane.props.invertLeft : lane.props.invertRight
+      const ids = invert ? [...ls.props.pointIds].reverse() : ls.props.pointIds
+      if (ids.length === 0) continue
+      const pid = side === 'start' ? ids[0] : ids[ids.length - 1]
+      const pt = shapeMap.get(pid) as unknown as PointShape | undefined
+      if (!pt) continue
+      endpoints.push({ pointId: pid, x: pt.x, y: pt.y })
+    }
+  }
+
+  // Restrict to lanes that participate in a next/prev relationship.
+  for (const lane of lanes) {
+    const hasNext = (lane.props.next || []).some((id) => laneIds.has(id))
+    const hasPrev = (lane.props.prev || []).some((id) => laneIds.has(id))
+    if (hasNext) collectEndpoints(lane, 'end')
+    if (hasPrev) collectEndpoints(lane, 'start')
+  }
+
+  // Greedy clustering: group points within epsilon of each other.
+  const clusters: Endpoint[][] = []
+  const eps2 = epsilonPx * epsilonPx
+  for (const ep of endpoints) {
+    let placed = false
+    for (const cluster of clusters) {
+      const c0 = cluster[0]
+      const dx = ep.x - c0.x
+      const dy = ep.y - c0.y
+      if (dx * dx + dy * dy <= eps2) {
+        cluster.push(ep)
+        placed = true
+        break
+      }
+    }
+    if (!placed) clusters.push([ep])
+  }
+
+  // Use each cluster centroid as the snapped position.
+  const overrides = new Map<string, Point2D>()
+  for (const cluster of clusters) {
+    if (cluster.length < 2) continue // Solitary points need no snapping.
+    let sx = 0
+    let sy = 0
+    for (const ep of cluster) {
+      sx += ep.x
+      sy += ep.y
+    }
+    const cx = sx / cluster.length
+    const cy = sy / cluster.length
+    for (const ep of cluster) {
+      // Last write wins if the same point id is referenced multiple times.
+      overrides.set(ep.pointId, { x: cx, y: cy })
+    }
+  }
+  return overrides
+}
+
+function emitPlanView(geom: RoadGeometry): string {
+  const lines: string[] = []
+  lines.push(`    <planView>`)
+  for (let i = 0; i < geom.odrSamples.length - 1; i++) {
+    const a = geom.odrSamples[i]
+    const b = geom.odrSamples[i + 1]
+    const dx = b.x - a.x
+    const dy = b.y - a.y
+    const segLen = Math.hypot(dx, dy)
+    if (segLen < 1e-9) continue
+    const hdg = Math.atan2(dy, dx)
+    lines.push(
+      `      <geometry s="${fmt(a.s)}" x="${fmt(a.x)}" y="${fmt(a.y)}" hdg="${fmt(hdg)}" length="${fmt(segLen)}">`
+    )
+    lines.push(`        <line/>`)
+    lines.push(`      </geometry>`)
+  }
+  lines.push(`    </planView>`)
+  return lines.join('\n')
+}
+
+function emitLanes(geom: RoadGeometry, hasPrev: boolean, hasNext: boolean): string {
+  const lines: string[] = []
+  lines.push(`    <lanes>`)
+  lines.push(`      <laneSection s="0">`)
+  // Left side: id=+1 (OpenDRIVE numbers lanes positively to the left of the reference line).
+  lines.push(`        <left>`)
+  lines.push(`          <lane id="1" type="driving" level="false">`)
+  emitLaneLink(lines, hasPrev, hasNext, 1)
+  emitHalfWidthEntries(geom, lines)
+  lines.push(`            <roadMark sOffset="0" type="solid" weight="standard" color="white" width="0.13"/>`)
+  lines.push(`          </lane>`)
+  lines.push(`        </left>`)
+  // Center reference line.
+  lines.push(`        <center>`)
+  lines.push(`          <lane id="0" type="none" level="false">`)
+  lines.push(`            <link/>`)
+  lines.push(`            <roadMark sOffset="0" type="solid" weight="standard" color="standard" width="0.13"/>`)
+  lines.push(`          </lane>`)
+  lines.push(`        </center>`)
+  // Right side: id=-1.
+  lines.push(`        <right>`)
+  lines.push(`          <lane id="-1" type="driving" level="false">`)
+  emitLaneLink(lines, hasPrev, hasNext, -1)
+  emitHalfWidthEntries(geom, lines)
+  lines.push(`            <roadMark sOffset="0" type="solid" weight="standard" color="white" width="0.13"/>`)
+  lines.push(`          </lane>`)
+  lines.push(`        </right>`)
+  lines.push(`      </laneSection>`)
+  lines.push(`    </lanes>`)
+  return lines.join('\n')
+}
+
+function emitLaneLink(out: string[], hasPrev: boolean, hasNext: boolean, laneId: number): void {
+  if (!hasPrev && !hasNext) {
+    out.push(`            <link/>`)
+    return
+  }
+  out.push(`            <link>`)
+  if (hasPrev) {
+    out.push(`              <predecessor id="${laneId}"/>`)
+  }
+  if (hasNext) {
+    out.push(`              <successor id="${laneId}"/>`)
+  }
+  out.push(`            </link>`)
+}
+
+function emitHalfWidthEntries(geom: RoadGeometry, out: string[]): void {
+  for (let i = 0; i < geom.odrSamples.length - 1; i++) {
+    const s = geom.odrSamples[i].s
+    const halfA = geom.odrSamples[i].width / 2
+    const halfB = geom.odrSamples[i + 1].width / 2
+    const segLen = geom.odrSamples[i + 1].s - s
+    // Linear fit a + b*ds (c=d=0).
+    const a = halfA
+    const b = segLen > 1e-9 ? (halfB - halfA) / segLen : 0
+    out.push(`            <width sOffset="${fmt(s)}" a="${fmt(a)}" b="${fmt(b)}" c="0" d="0"/>`)
+  }
+}
+
+function emitLink(lane: LaneShape, laneIdToRoadId: Map<string, number>): string {
+  const lines: string[] = []
+  lines.push(`    <link>`)
+  if (lane.props.prev?.[0] && laneIdToRoadId.has(lane.props.prev[0])) {
+    const rid = laneIdToRoadId.get(lane.props.prev[0])!
+    lines.push(`      <predecessor elementType="road" elementId="${rid}" contactPoint="end"/>`)
+  }
+  if (lane.props.next?.[0] && laneIdToRoadId.has(lane.props.next[0])) {
+    const rid = laneIdToRoadId.get(lane.props.next[0])!
+    lines.push(`      <successor elementType="road" elementId="${rid}" contactPoint="start"/>`)
+  }
+  lines.push(`    </link>`)
+  return lines.join('\n')
+}
+
+function projectToRoad(geom: RoadGeometry, xG: number, yG: number): {
+  s: number
+  t: number
+  hdg: number
+  distance: number
+  clampedAtEnd: boolean
+} {
+  let bestS = 0
+  let bestT = 0
+  let bestDist = Infinity
+  let bestHdg = 0
+  let bestClamped = false
+  const samples = geom.odrSamples
+  for (let i = 0; i < samples.length - 1; i++) {
+    const a = samples[i]
+    const b = samples[i + 1]
+    const dx = b.x - a.x
+    const dy = b.y - a.y
+    const segLen = Math.hypot(dx, dy)
+    if (segLen < 1e-9) continue
+    const ux = dx / segLen
+    const uy = dy / segLen
+    const px = xG - a.x
+    const py = yG - a.y
+    let tNorm = px * ux + py * uy
+    let clamped = false
+    if (tNorm < 0) {
+      tNorm = 0
+      clamped = i === 0
+    }
+    if (tNorm > segLen) {
+      tNorm = segLen
+      clamped = i === samples.length - 2
+    }
+    const projX = a.x + ux * tNorm
+    const projY = a.y + uy * tNorm
+    const dist = Math.hypot(xG - projX, yG - projY)
+    if (dist < bestDist) {
+      bestDist = dist
+      bestS = a.s + tNorm
+      const nx = -uy
+      const ny = ux
+      bestT = px * nx + py * ny
+      bestHdg = Math.atan2(uy, ux)
+      bestClamped = clamped
+    }
+  }
+  return { s: bestS, t: bestT, hdg: bestHdg, distance: bestDist, clampedAtEnd: bestClamped }
+}
+
+interface SignalEntry {
+  id: number
+  s: number
+  t: number
+  zOffset: number
+  height: number
+  width: number
+  name: string
+  type: string
+  subtype: string
+  dynamic: 'yes' | 'no'
+  orientation: '+' | '-'
+}
+
+interface ObjectEntry {
+  id: number
+  s: number
+  t: number
+  zOffset: number
+  hdg: number
+  length: number
+  width: number
+  height: number
+  name: string
+  type: string
+  orientation: '+' | '-' | 'none'
+  outline?: { u: number; v: number }[]
+}
+
+function attachShapesToRoads(
+  trafficLights: TrafficLightShape[],
+  crosswalks: CrosswalkShape[],
+  polygons: { shape: PolygonShape; vertices: { x: number; y: number }[] }[],
+  laneToGeom: Map<string, RoadGeometry>,
+  laneIdToRoadId: Map<string, number>,
+  maxAttachDistanceMeter: number = 50
+): {
+  roadSignals: Map<number, SignalEntry[]>
+  roadObjects: Map<number, ObjectEntry[]>
+} {
+  const roadSignals = new Map<number, SignalEntry[]>()
+  const roadObjects = new Map<number, ObjectEntry[]>()
+  let signalIdCounter = 1
+  let objectIdCounter = 1
+
+  const roads: { laneId: string; geom: RoadGeometry; roadId: number }[] = []
+  laneToGeom.forEach((geom, laneId) => {
+    const roadId = laneIdToRoadId.get(laneId)
+    if (roadId !== undefined) roads.push({ laneId, geom, roadId })
+  })
+
+  for (const tl of trafficLights) {
+    const xG = pxToEnuX(tl.x)
+    const yG = pxToEnuY(tl.y)
+    let best: { roadId: number; proj: ReturnType<typeof projectToRoad> } | null = null
+    for (const r of roads) {
+      const proj = projectToRoad(r.geom, xG, yG)
+      if (!best || proj.distance < best.proj.distance) best = { roadId: r.roadId, proj }
+    }
+    if (!best || best.proj.distance > maxAttachDistanceMeter) continue
+    const style = tl.props.style ?? ''
+    const isPed = style.startsWith('pedestrian') || style.includes('ped')
+    // Conventional signal type codes: 1000001 = vehicle, 1000002 = pedestrian.
+    const sigType = isPed ? '1000002' : '1000001'
+    const heightM = pxToMeter(tl.props.h)
+    const widthM = pxToMeter(tl.props.w)
+    const list = roadSignals.get(best.roadId) ?? []
+    list.push({
+      id: signalIdCounter++,
+      s: best.proj.s,
+      t: best.proj.t,
+      zOffset: isPed ? 1.5 : 4.5,
+      height: heightM,
+      width: widthM,
+      name: style,
+      type: sigType,
+      subtype: '-1',
+      dynamic: 'yes',
+      orientation: best.proj.t >= 0 ? '+' : '-',
+    })
+    roadSignals.set(best.roadId, list)
+  }
+
+  for (const cw of crosswalks) {
+    const rotDeg = cw.rotation || 0
+    const rotRad = (rotDeg * Math.PI) / 180
+    const cosR = Math.cos(rotRad)
+    const sinR = Math.sin(rotRad)
+    const cxLocal = (cw.props.startX + cw.props.endX) / 2
+    const cyLocal = (cw.props.startY + cw.props.endY) / 2
+    const cxGlobal = cw.x + cxLocal
+    const cyGlobal = cw.y + cyLocal
+    const xG = pxToEnuX(cxGlobal)
+    const yG = pxToEnuY(cyGlobal)
+    let best: { roadId: number; proj: ReturnType<typeof projectToRoad> } | null = null
+    for (const r of roads) {
+      const proj = projectToRoad(r.geom, xG, yG)
+      if (!best || proj.distance < best.proj.distance) best = { roadId: r.roadId, proj }
+    }
+    if (!best || best.proj.distance > maxAttachDistanceMeter) continue
+    const dxLocal = cw.props.endX - cw.props.startX
+    const dyLocal = cw.props.endY - cw.props.startY
+    const lengthM = pxToMeter(Math.hypot(dxLocal, dyLocal))
+    const widthM = pxToMeter(cw.props.crosswalkWidth)
+    // Apply shape rotation to the local axis to obtain the global axis.
+    const dxPx = dxLocal * cosR - dyLocal * sinR
+    const dyPx = dxLocal * sinR + dyLocal * cosR
+    const cwEnuHdg = Math.atan2(-dyPx, dxPx)
+    let relativeHdg = cwEnuHdg - best.proj.hdg
+    while (relativeHdg > Math.PI) relativeHdg -= 2 * Math.PI
+    while (relativeHdg < -Math.PI) relativeHdg += 2 * Math.PI
+    const list = roadObjects.get(best.roadId) ?? []
+    // The OpenDRIVE crosswalk object renders perpendicular to the road when
+    // hdg = π/2 (verified empirically on east-west and north-south roads).
+    // Crosswalks are by convention placed across the road, so we always emit
+    // π/2 regardless of the user-drawn axis direction.
+    void relativeHdg
+    const crosswalkHdg = Math.PI / 2
+    list.push({
+      id: objectIdCounter++,
+      s: best.proj.s,
+      t: best.proj.t,
+      zOffset: 0,
+      hdg: crosswalkHdg,
+      length: lengthM,
+      width: widthM,
+      height: 0,
+      name: 'crosswalk',
+      type: 'crosswalk',
+      orientation: 'none',
+    })
+    roadObjects.set(best.roadId, list)
+  }
+
+  // Polygons (e.g. intersection patches) are emitted as <object type="patch">
+  // + <outlines>/<outline>/<cornerLocal>. The centroid is projected onto the
+  // nearest road; vertices are transformed into the road's local (u, v) frame.
+  for (const { shape: poly, vertices } of polygons) {
+    if (vertices.length < 3) continue
+    let cx = 0
+    let cy = 0
+    for (const v of vertices) {
+      cx += v.x
+      cy += v.y
+    }
+    cx /= vertices.length
+    cy /= vertices.length
+    const xG = pxToEnuX(cx)
+    const yG = pxToEnuY(cy)
+    let best: { roadId: number; proj: ReturnType<typeof projectToRoad> } | null = null
+    let fallback: { roadId: number; proj: ReturnType<typeof projectToRoad> } | null = null
+    for (const r of roads) {
+      const proj = projectToRoad(r.geom, xG, yG)
+      if (proj.clampedAtEnd) {
+        if (!fallback || proj.distance < fallback.proj.distance) fallback = { roadId: r.roadId, proj }
+        continue
+      }
+      if (!best || proj.distance < best.proj.distance) best = { roadId: r.roadId, proj }
+    }
+    if (!best) best = fallback
+    if (!best || best.proj.distance > maxAttachDistanceMeter) continue
+    const cosH = Math.cos(best.proj.hdg)
+    const sinH = Math.sin(best.proj.hdg)
+    const samples = laneToGeom.get([...laneToGeom.keys()].find((k) => laneIdToRoadId.get(k) === best!.roadId)!)!.odrSamples
+    const anchorPoint = best.proj.clampedAtEnd && best.proj.s >= samples[samples.length - 1].s - 1e-6
+      ? samples[samples.length - 1]
+      : samples[0]
+    const anchorEnuX = anchorPoint.x
+    const anchorEnuY = anchorPoint.y
+    const anchorS = anchorPoint.s
+    const outline: { u: number; v: number }[] = []
+    for (const v of vertices) {
+      const vxG = pxToEnuX(v.x)
+      const vyG = pxToEnuY(v.y)
+      const dx = vxG - anchorEnuX
+      const dy = vyG - anchorEnuY
+      const u = dx * cosH + dy * sinH
+      const vv = -dx * sinH + dy * cosH
+      outline.push({ u, v: vv })
+    }
+    const list = roadObjects.get(best.roadId) ?? []
+    const subtype = (poly.props.attributes as Record<string, unknown> | undefined)?.subtype
+    list.push({
+      id: objectIdCounter++,
+      s: anchorS,
+      t: 0,
+      // Lift 5 cm above the road surface to avoid z-fighting where the
+      // patch overlaps multiple roads at z=0.
+      zOffset: 0.05,
+      hdg: 0,
+      length: 0,
+      width: 0,
+      height: 0,
+      name: typeof subtype === 'string' ? subtype : 'polygon',
+      type: 'patch',
+      orientation: 'none',
+      outline,
+    })
+    roadObjects.set(best.roadId, list)
+  }
+
+  return { roadSignals, roadObjects }
+}
+
+function emitSignals(signals: SignalEntry[]): string {
+  if (!signals.length) return `    <signals/>`
+  const lines: string[] = []
+  lines.push(`    <signals>`)
+  for (const s of signals) {
+    lines.push(
+      `      <signal id="${s.id}" s="${fmt(s.s)}" t="${fmt(s.t)}" zOffset="${fmt(s.zOffset)}" name="${escapeXml(s.name)}" dynamic="${s.dynamic}" orientation="${s.orientation}" type="${s.type}" subtype="${s.subtype}" country="OpenDRIVE" value="0" height="${fmt(s.height)}" width="${fmt(s.width)}"/>`
+    )
+  }
+  lines.push(`    </signals>`)
+  return lines.join('\n')
+}
+
+function emitObjects(objects: ObjectEntry[]): string {
+  if (!objects.length) return `    <objects/>`
+  const lines: string[] = []
+  lines.push(`    <objects>`)
+  for (const o of objects) {
+    if (o.outline && o.outline.length >= 3) {
+      lines.push(
+        `      <object id="${o.id}" s="${fmt(o.s)}" t="${fmt(o.t)}" zOffset="${fmt(o.zOffset)}" hdg="${fmt(o.hdg)}" name="${escapeXml(o.name)}" type="${o.type}" orientation="${o.orientation}" length="0" width="0" height="0">`
+      )
+      lines.push(`        <outlines>`)
+      lines.push(`          <outline id="0" closed="true">`)
+      o.outline.forEach((p, i) => {
+        // height=0.001 (1 mm) gives the patch a tiny vertical thickness so
+        // its top and bottom faces sit on different z planes (avoids z-fighting).
+        lines.push(
+          `            <cornerLocal id="${i}" u="${fmt(p.u)}" v="${fmt(p.v)}" z="0" height="0.001"/>`
+        )
+      })
+      lines.push(`          </outline>`)
+      lines.push(`        </outlines>`)
+      lines.push(`      </object>`)
+    } else {
+      lines.push(
+        `      <object id="${o.id}" s="${fmt(o.s)}" t="${fmt(o.t)}" zOffset="${fmt(o.zOffset)}" hdg="${fmt(o.hdg)}" name="${escapeXml(o.name)}" type="${o.type}" orientation="${o.orientation}" length="${fmt(o.length)}" width="${fmt(o.width)}" height="${fmt(o.height)}"/>`
+      )
+    }
+  }
+  lines.push(`    </objects>`)
+  return lines.join('\n')
+}
+
+function emitRoad(
+  lane: LaneShape,
+  geom: RoadGeometry,
+  roadId: number,
+  laneIdToRoadId: Map<string, number>,
+  signals: SignalEntry[],
+  objects: ObjectEntry[]
+): string {
+  const speed = lane.props.attributes?.speed_limit
+  const name = escapeXml(lane.props.attributes?.subtype || 'road')
+  const hasPrev = !!(lane.props.prev?.[0] && laneIdToRoadId.has(lane.props.prev[0]))
+  const hasNext = !!(lane.props.next?.[0] && laneIdToRoadId.has(lane.props.next[0]))
+  const lines: string[] = []
+  lines.push(
+    `  <road name="${name}" length="${fmt(geom.length)}" id="${roadId}" junction="-1">`
+  )
+  lines.push(emitLink(lane, laneIdToRoadId))
+  if (speed) {
+    lines.push(`    <type s="0" type="town">`)
+    lines.push(`      <speed max="${escapeXml(speed)}" unit="km/h"/>`)
+    lines.push(`    </type>`)
+  }
+  lines.push(emitPlanView(geom))
+  lines.push(`    <elevationProfile/>`)
+  lines.push(`    <lateralProfile/>`)
+  lines.push(emitLanes(geom, hasPrev, hasNext))
+  lines.push(emitObjects(objects))
+  lines.push(emitSignals(signals))
+  lines.push(`  </road>`)
+  return lines.join('\n')
+}
+
+/**
+ * Build an OpenDRIVE 1.8 XML document from a snapshot.
+ */
+export function exportToOpenDrive(snapshot: DrawtonomySnapshot): string {
+  const shapes = snapshot.shapes
+  const shapeMap = buildShapeMap(shapes)
+  const lanes: LaneShape[] = []
+  const trafficLights: TrafficLightShape[] = []
+  const crosswalks: CrosswalkShape[] = []
+  const polygons: { shape: PolygonShape; vertices: { x: number; y: number }[] }[] = []
+  for (const s of shapes) {
+    if (s.type === 'lane') lanes.push(s as unknown as LaneShape)
+    else if (s.type === 'traffic_light') trafficLights.push(s as unknown as TrafficLightShape)
+    else if (s.type === 'crosswalk') crosswalks.push(s as unknown as CrosswalkShape)
+    else if (s.type === 'polygon') {
+      const poly = s as unknown as PolygonShape
+      const vertices: { x: number; y: number }[] = []
+      for (const pid of poly.props.pointIds) {
+        const p = shapeMap.get(pid) as unknown as PointShape | undefined
+        if (p) vertices.push({ x: p.x, y: p.y })
+      }
+      if (vertices.length >= 3) polygons.push({ shape: poly, vertices })
+    }
+  }
+
+  // Assign sequential road ids.
+  const laneIdToRoadId = new Map<string, number>()
+  lanes.forEach((lane, i) => laneIdToRoadId.set(lane.id, i + 1))
+
+  const dateStr = new Date().toISOString()
+  const lines: string[] = []
+  lines.push(`<?xml version="1.0" encoding="UTF-8"?>`)
+  lines.push(`<OpenDRIVE>`)
+  lines.push(
+    `  <header revMajor="1" revMinor="8" name="drawtonomy" version="1.0" date="${dateStr}" north="0" south="0" east="0" west="0" vendor="drawtonomy"/>`
+  )
+
+  const pointOverrides = buildBoundaryAlignmentOverrides(shapeMap, lanes)
+
+  const laneToGeom = new Map<string, RoadGeometry>()
+  for (const lane of lanes) {
+    const geom = buildRoadGeometry(shapeMap, lane, pointOverrides)
+    if (geom) laneToGeom.set(lane.id, geom)
+  }
+  const { roadSignals, roadObjects } = attachShapesToRoads(
+    trafficLights,
+    crosswalks,
+    polygons,
+    laneToGeom,
+    laneIdToRoadId
+  )
+
+  for (const lane of lanes) {
+    const geom = laneToGeom.get(lane.id)
+    if (!geom) continue
+    const roadId = laneIdToRoadId.get(lane.id)!
+    const signals = roadSignals.get(roadId) ?? []
+    const objects = roadObjects.get(roadId) ?? []
+    lines.push(emitRoad(lane, geom, roadId, laneIdToRoadId, signals, objects))
+  }
+
+  lines.push(`</OpenDRIVE>`)
+  return lines.join('\n')
+}

--- a/packages/drawtonomy-sdk/src/exporter/openscenario.ts
+++ b/packages/drawtonomy-sdk/src/exporter/openscenario.ts
@@ -1,0 +1,498 @@
+// OpenSCENARIO 1.3 (.xosc) exporter — emits scenario actors and trajectories
+// from a snapshot. No external library dependencies.
+//
+// Design:
+// - Each Vehicle / Pedestrian shape becomes a ScenarioObject
+// - 3D rendering is delegated to the player; we only emit BoundingBox + category
+// - Initial pose is a WorldPosition + TeleportAction
+// - The road network is referenced via <LogicFile> pointing to the paired .xodr
+// - Dynamic animations are emitted as <FollowTrajectoryAction> stories
+
+import type {
+  BaseShape,
+  DrawtonomySnapshot,
+  LinestringProps,
+  PointProps,
+  VehicleProps,
+} from '../types'
+import { buildPathTrajectory, type PathSamplePoint } from './trajectory'
+import { escapeXml, fmt, pxToEnuX, pxToEnuY, pxToMeter } from './units'
+
+type VehicleShape = BaseShape<'vehicle', VehicleProps>
+type LinestringShape = BaseShape<'linestring', LinestringProps>
+type PointShape = BaseShape<'point', PointProps>
+
+/** Map a vehicle template id to a normalized form (legacy id rewrites). */
+const LEGACY_TEMPLATE_ID_MAP: Record<string, string> = {
+  black: 'filled', // legacy "black" pedestrian template renamed to "filled"
+}
+
+/** Pedestrian template id patterns. */
+const PEDESTRIAN_PATTERNS = [/^pedestrian/, /^walk/, /^simple/, /^filled/]
+
+/**
+ * Hook for callers that want to override pedestrian / category resolution
+ * (e.g. when their host knows about custom templates not bundled with the
+ * SDK).
+ */
+export interface TemplateResolver {
+  /** Normalize a template id, applying any legacy rewrites. */
+  resolveTemplateId?: (templateId: string) => string
+  /** True if the resolved id refers to a pedestrian template. */
+  isPedestrianTemplate?: (templateId: string) => boolean
+}
+
+function defaultResolveTemplateId(id: string): string {
+  return LEGACY_TEMPLATE_ID_MAP[id] || id
+}
+
+function defaultIsPedestrianTemplate(id: string): boolean {
+  const resolved = defaultResolveTemplateId(id || '')
+  return PEDESTRIAN_PATTERNS.some((re) => re.test(resolved))
+}
+
+/**
+ * Map a vehicle template id to an OpenSCENARIO vehicleCategory.
+ * Spec values: car, van, truck, trailer, semitrailer, bus, motorbike, bicycle, train, tram.
+ */
+export function templateIdToVehicleCategory(
+  templateId: string,
+  resolver?: TemplateResolver
+): string {
+  const resolveId = resolver?.resolveTemplateId ?? defaultResolveTemplateId
+  const id = resolveId(templateId)
+  switch (id) {
+    case 'sedan': return 'car'
+    case 'bus': return 'bus'
+    case 'truck': return 'truck'
+    case 'motorcycle':
+    case 'motorcycle2':
+      return 'motorbike'
+    case 'bicycle':
+    case 'bicycle2':
+      return 'bicycle'
+    case 'amr':
+    case 'amr2':
+    case 'robovac':
+      return 'car'
+    default:
+      return 'car'
+  }
+}
+
+/**
+ * Default Performance values per category (matches esmini demo conventions).
+ */
+function defaultPerformance(category: string): { maxSpeed: number; maxAccel: number; maxDecel: number } {
+  switch (category) {
+    case 'truck':
+    case 'bus':
+      return { maxSpeed: 25, maxAccel: 2, maxDecel: 6 }
+    case 'motorbike':
+      return { maxSpeed: 60, maxAccel: 6, maxDecel: 9 }
+    case 'bicycle':
+      return { maxSpeed: 8, maxAccel: 2, maxDecel: 4 }
+    default:
+      return { maxSpeed: 50, maxAccel: 5, maxDecel: 10 }
+  }
+}
+
+function defaultAxles(length: number, width: number): {
+  front: { positionX: number; trackWidth: number }
+  rear: { positionX: number; trackWidth: number }
+} {
+  const wheelbase = Math.max(length * 0.6, 0.3)
+  const trackWidth = Math.max(width * 0.85, 0.3)
+  return {
+    front: { positionX: wheelbase, trackWidth },
+    rear: { positionX: 0, trackWidth },
+  }
+}
+
+interface VehicleEntity {
+  shape: VehicleShape
+  isPedestrian: boolean
+  /** Unique name for the ScenarioObject. */
+  name: string
+  /** Meters. */
+  width: number
+  length: number
+  height: number
+  category: string
+  worldX: number
+  worldY: number
+  /** ENU heading (rad). */
+  heading: number
+}
+
+function collectEntities(snapshot: DrawtonomySnapshot, resolver?: TemplateResolver): VehicleEntity[] {
+  const out: VehicleEntity[] = []
+  let counter = 0
+  const isPedestrian = resolver?.isPedestrianTemplate ?? defaultIsPedestrianTemplate
+  const resolveId = resolver?.resolveTemplateId ?? defaultResolveTemplateId
+
+  // Path footprints are a canvas-side "trail preview" — multiple ghost copies
+  // of the same vehicle along a path. In a 3D scene we want a single moving
+  // vehicle, so only the leading footprint (footprintIds[0]) is exported as
+  // a ScenarioObject; the rest are dropped.
+  const followerFootprintIds = new Set<string>()
+  for (const shape of snapshot.shapes) {
+    if (shape.type !== 'linestring') continue
+    const ls = shape as unknown as LinestringShape
+    if (!ls.props.isPath) continue
+    const ids = ls.props.footprintIds ?? []
+    for (let i = 1; i < ids.length; i++) followerFootprintIds.add(ids[i])
+  }
+
+  for (const shape of snapshot.shapes) {
+    if (shape.type !== 'vehicle') continue
+    if (followerFootprintIds.has(shape.id)) continue
+    const v = shape as unknown as VehicleShape
+    const id = resolveId(v.props.templateId || '')
+    const isPed = isPedestrian(v.props.templateId || '')
+
+    // Vehicle template orientation: front faces -Y in canvas space, so the
+    // shape's bbox dimensions map as length=h (front-back axis), width=w.
+    const widthM = pxToMeter(v.props.w)
+    const lengthM = pxToMeter(v.props.h)
+    const category = isPed ? 'pedestrian' : templateIdToVehicleCategory(id, resolver)
+
+    let heightM: number
+    if (isPed) heightM = 1.7
+    else if (category === 'truck' || category === 'bus') heightM = 3.0
+    else if (category === 'motorbike') heightM = 1.2
+    else if (category === 'bicycle') heightM = 1.2
+    else heightM = 1.5
+
+    out.push({
+      shape: v,
+      isPedestrian: isPed,
+      name: isPed ? `Pedestrian_${counter++}` : `Vehicle_${counter++}`,
+      width: widthM,
+      length: lengthM,
+      height: heightM,
+      category,
+      worldX: pxToEnuX(v.x),
+      worldY: pxToEnuY(v.y),
+      // SVG template orientation: front faces -Y in canvas space, so a
+      // rotation=0 vehicle points "up" on the canvas. ENU has y-up and CCW
+      // positive headings, so canvas -Y maps to ENU +Y, i.e. heading=π/2
+      // when rotation=0. The π/2 offset and sign flip account for both.
+      heading: -((v.rotation || 0) * Math.PI) / 180 + Math.PI / 2,
+    })
+  }
+  return out
+}
+
+function emitFileHeader(): string {
+  const date = new Date().toISOString()
+  return `  <FileHeader revMajor="1" revMinor="3" date="${date}" description="Generated by drawtonomy" author="drawtonomy"/>`
+}
+
+/**
+ * Map a vehicleCategory to a bundled esmini 3D model path. An explicit
+ * model3d is required, otherwise scaleMode is ignored and the BoundingBox
+ * has no effect on rendering size.
+ */
+function getModel3d(category: string): string {
+  switch (category) {
+    case 'truck': return '../models/truck_yellow.osgb'
+    case 'bus': return '../models/bus_blue.osgb'
+    case 'motorbike': return '../models/mc.osgb'
+    case 'bicycle': return '../models/cyclist.osgb'
+    case 'pedestrian': return '../models/walkman.osgb'
+    default: return '../models/car_white.osgb'
+  }
+}
+
+function emitVehicleEntity(e: VehicleEntity): string {
+  const perf = defaultPerformance(e.category)
+  const axles = defaultAxles(e.length, e.width)
+  const model3d = getModel3d(e.category)
+  const lines: string[] = []
+  lines.push(`    <ScenarioObject name="${escapeXml(e.name)}">`)
+  lines.push(
+    `      <Vehicle name="${escapeXml(e.shape.props.templateId || 'vehicle')}" vehicleCategory="${e.category}" model3d="${model3d}">`
+  )
+  lines.push(`        <BoundingBox>`)
+  lines.push(`          <Center x="${fmt(e.length / 2)}" y="0" z="${fmt(e.height / 2)}"/>`)
+  lines.push(`          <Dimensions width="${fmt(e.width)}" length="${fmt(e.length)}" height="${fmt(e.height)}"/>`)
+  lines.push(`        </BoundingBox>`)
+  lines.push(
+    `        <Performance maxSpeed="${fmt(perf.maxSpeed)}" maxAcceleration="${fmt(perf.maxAccel)}" maxDeceleration="${fmt(perf.maxDecel)}"/>`
+  )
+  lines.push(`        <Axles>`)
+  lines.push(
+    `          <FrontAxle maxSteering="0.5" wheelDiameter="0.5" trackWidth="${fmt(axles.front.trackWidth)}" positionX="${fmt(axles.front.positionX)}" positionZ="0.25"/>`
+  )
+  lines.push(
+    `          <RearAxle maxSteering="0" wheelDiameter="0.5" trackWidth="${fmt(axles.rear.trackWidth)}" positionX="${fmt(axles.rear.positionX)}" positionZ="0.25"/>`
+  )
+  lines.push(`        </Axles>`)
+  // scaleMode=ModelToBB tells the player to deform the model so it matches
+  // the BoundingBox dimensions. Without it the model is drawn at its native
+  // size and the BoundingBox has no visual effect. The name is read as
+  // "Model is fitted To BoundingBox" — the model is what gets scaled.
+  lines.push(`        <Properties>`)
+  lines.push(`          <Property name="scaleMode" value="ModelToBB"/>`)
+  lines.push(`        </Properties>`)
+  lines.push(`      </Vehicle>`)
+  lines.push(`    </ScenarioObject>`)
+  return lines.join('\n')
+}
+
+function emitPedestrianEntity(e: VehicleEntity): string {
+  const model3d = getModel3d('pedestrian')
+  const lines: string[] = []
+  lines.push(`    <ScenarioObject name="${escapeXml(e.name)}">`)
+  lines.push(
+    `      <Pedestrian name="${escapeXml(e.shape.props.templateId || 'pedestrian')}" pedestrianCategory="pedestrian" mass="80" model3d="${model3d}">`
+  )
+  lines.push(`        <BoundingBox>`)
+  lines.push(`          <Center x="0" y="0" z="${fmt(e.height / 2)}"/>`)
+  lines.push(`          <Dimensions width="${fmt(e.width)}" length="${fmt(e.length)}" height="${fmt(e.height)}"/>`)
+  lines.push(`        </BoundingBox>`)
+  lines.push(`        <Properties>`)
+  lines.push(`          <Property name="scaleMode" value="ModelToBB"/>`)
+  lines.push(`        </Properties>`)
+  lines.push(`      </Pedestrian>`)
+  lines.push(`    </ScenarioObject>`)
+  return lines.join('\n')
+}
+
+function emitInitTeleport(e: VehicleEntity): string {
+  return emitInitTeleportAt(e, e.worldX, e.worldY, e.heading)
+}
+
+function emitInitTeleportAt(
+  e: VehicleEntity,
+  x: number,
+  y: number,
+  heading: number
+): string {
+  const lines: string[] = []
+  lines.push(`        <Private entityRef="${escapeXml(e.name)}">`)
+  lines.push(`          <PrivateAction>`)
+  lines.push(`            <TeleportAction>`)
+  lines.push(`              <Position>`)
+  lines.push(
+    `                <WorldPosition x="${fmt(x)}" y="${fmt(y)}" z="0" h="${fmt(heading)}" p="0" r="0"/>`
+  )
+  lines.push(`              </Position>`)
+  lines.push(`            </TeleportAction>`)
+  lines.push(`          </PrivateAction>`)
+  lines.push(`        </Private>`)
+  return lines.join('\n')
+}
+
+export interface OpenScenarioExportOptions {
+  /** Filename of the paired .xodr (referenced by <LogicFile>). Empty if absent. */
+  xodrFilename?: string
+  /** Scenario name. */
+  scenarioName?: string
+  /** Optional template resolver hook. */
+  templateResolver?: TemplateResolver
+}
+
+interface PathTrajectoryAssignment {
+  entityName: string
+  trajectoryName: string
+  samples: PathSamplePoint[]
+}
+
+function collectPathAssignments(
+  snapshot: DrawtonomySnapshot,
+  entities: VehicleEntity[]
+): PathTrajectoryAssignment[] {
+  const out: PathTrajectoryAssignment[] = []
+  const shapeMap = new Map<string, BaseShape>()
+  for (const s of snapshot.shapes) shapeMap.set(s.id, s)
+  const shapeIdToEntityName = new Map<string, string>()
+  for (const e of entities) shapeIdToEntityName.set(e.shape.id, e.name)
+
+  let trajCounter = 0
+  for (const shape of snapshot.shapes) {
+    if (shape.type !== 'linestring') continue
+    const ls = shape as unknown as LinestringShape
+    if (!ls.props.isPath) continue
+    const footprintIds = ls.props.footprintIds ?? []
+    const fp = ls.props.footprint
+    if (footprintIds.length === 0) continue
+    const headFootprintId = footprintIds[0]
+    const entityName = shapeIdToEntityName.get(headFootprintId)
+    if (!entityName) continue
+
+    const points: { x: number; y: number }[] = []
+    for (const pid of ls.props.pointIds) {
+      const p = shapeMap.get(pid) as unknown as PointShape | undefined
+      if (p) points.push({ x: p.x, y: p.y })
+    }
+    if (points.length < 2) continue
+
+    const samples = buildPathTrajectory({
+      points,
+      tValues: (fp as { tValues?: number[] } | undefined)?.tValues,
+      interval: fp?.interval,
+      offset: fp?.offset,
+    })
+    if (samples.length < 2) continue
+
+    out.push({
+      entityName,
+      trajectoryName: `path${trajCounter++}_${entityName}`,
+      samples,
+    })
+  }
+  return out
+}
+
+function emitFollowTrajectoryStory(assignments: PathTrajectoryAssignment[]): string[] {
+  if (!assignments.length) return []
+  const lines: string[] = []
+  lines.push(`    <Story name="MovingStory">`)
+  lines.push(`      <Act name="MovingAct">`)
+  for (const a of assignments) {
+    lines.push(`        <ManeuverGroup name="MG_${escapeXml(a.entityName)}" maximumExecutionCount="1">`)
+    lines.push(`          <Actors selectTriggeringEntities="false">`)
+    lines.push(`            <EntityRef entityRef="${escapeXml(a.entityName)}"/>`)
+    lines.push(`          </Actors>`)
+    lines.push(`          <Maneuver name="MV_${escapeXml(a.entityName)}">`)
+    lines.push(`            <Event name="EV_${escapeXml(a.entityName)}" priority="override">`)
+    lines.push(`              <Action name="ACT_${escapeXml(a.entityName)}">`)
+    lines.push(`                <PrivateAction>`)
+    lines.push(`                  <RoutingAction>`)
+    lines.push(`                    <FollowTrajectoryAction>`)
+    lines.push(`                      <TrajectoryRef>`)
+    lines.push(`                        <Trajectory name="${escapeXml(a.trajectoryName)}" closed="false">`)
+    lines.push(`                          <ParameterDeclarations/>`)
+    lines.push(`                          <Shape>`)
+    lines.push(`                            <Polyline>`)
+    for (const s of a.samples) {
+      lines.push(`                              <Vertex time="${fmt(s.time)}">`)
+      lines.push(`                                <Position>`)
+      lines.push(
+        `                                  <WorldPosition x="${fmt(s.x)}" y="${fmt(s.y)}" z="0" h="${fmt(s.heading)}" p="0" r="0"/>`
+      )
+      lines.push(`                                </Position>`)
+      lines.push(`                              </Vertex>`)
+    }
+    lines.push(`                            </Polyline>`)
+    lines.push(`                          </Shape>`)
+    lines.push(`                        </Trajectory>`)
+    lines.push(`                      </TrajectoryRef>`)
+    lines.push(`                      <TimeReference>`)
+    lines.push(
+      `                        <Timing domainAbsoluteRelative="absolute" scale="1.0" offset="0.0"/>`
+    )
+    lines.push(`                      </TimeReference>`)
+    lines.push(
+      `                      <TrajectoryFollowingMode followingMode="position"/>`
+    )
+    lines.push(`                    </FollowTrajectoryAction>`)
+    lines.push(`                  </RoutingAction>`)
+    lines.push(`                </PrivateAction>`)
+    lines.push(`              </Action>`)
+    lines.push(`              <StartTrigger>`)
+    lines.push(`                <ConditionGroup>`)
+    lines.push(
+      `                  <Condition name="Start_${escapeXml(a.entityName)}" delay="0" conditionEdge="none">`
+    )
+    lines.push(`                    <ByValueCondition>`)
+    lines.push(
+      `                      <SimulationTimeCondition value="0" rule="greaterOrEqual"/>`
+    )
+    lines.push(`                    </ByValueCondition>`)
+    lines.push(`                  </Condition>`)
+    lines.push(`                </ConditionGroup>`)
+    lines.push(`              </StartTrigger>`)
+    lines.push(`            </Event>`)
+    lines.push(`          </Maneuver>`)
+    lines.push(`        </ManeuverGroup>`)
+  }
+  lines.push(`        <StartTrigger>`)
+  lines.push(`          <ConditionGroup>`)
+  lines.push(
+    `            <Condition name="ActStart" delay="0" conditionEdge="none">`
+  )
+  lines.push(`              <ByValueCondition>`)
+  lines.push(
+    `                <SimulationTimeCondition value="0" rule="greaterOrEqual"/>`
+  )
+  lines.push(`              </ByValueCondition>`)
+  lines.push(`            </Condition>`)
+  lines.push(`          </ConditionGroup>`)
+  lines.push(`        </StartTrigger>`)
+  lines.push(`      </Act>`)
+  lines.push(`    </Story>`)
+  return lines
+}
+
+/**
+ * Build an OpenSCENARIO 1.3 XML document from a snapshot.
+ */
+export function exportToOpenScenario(
+  snapshot: DrawtonomySnapshot,
+  options: OpenScenarioExportOptions = {}
+): string {
+  const xodrFilename = options.xodrFilename ?? ''
+  const entities = collectEntities(snapshot, options.templateResolver)
+
+  const lines: string[] = []
+  lines.push(`<?xml version="1.0" encoding="UTF-8"?>`)
+  lines.push(`<OpenSCENARIO>`)
+  lines.push(emitFileHeader())
+  lines.push(`  <ParameterDeclarations/>`)
+  lines.push(`  <CatalogLocations/>`)
+  lines.push(`  <RoadNetwork>`)
+  if (xodrFilename) {
+    lines.push(`    <LogicFile filepath="${escapeXml(xodrFilename)}"/>`)
+  } else {
+    lines.push(`    <LogicFile filepath=""/>`)
+  }
+  lines.push(`  </RoadNetwork>`)
+
+  lines.push(`  <Entities>`)
+  for (const e of entities) {
+    lines.push(e.isPedestrian ? emitPedestrianEntity(e) : emitVehicleEntity(e))
+  }
+  lines.push(`  </Entities>`)
+
+  // For entities bound to a trajectory, snap the Init TeleportAction to the
+  // trajectory start so the entity does not "jump" once the trajectory takes
+  // over. The path assignments are computed before Init Actions are emitted.
+  const pathAssignments = collectPathAssignments(snapshot, entities)
+  const pathStartByEntity = new Map<string, PathSamplePoint>()
+  for (const a of pathAssignments) {
+    if (a.samples.length > 0) pathStartByEntity.set(a.entityName, a.samples[0])
+  }
+
+  lines.push(`  <Storyboard>`)
+  lines.push(`    <Init>`)
+  lines.push(`      <Actions>`)
+  for (const e of entities) {
+    const pathStart = pathStartByEntity.get(e.name)
+    if (pathStart) {
+      lines.push(emitInitTeleportAt(e, pathStart.x, pathStart.y, pathStart.heading))
+    } else {
+      lines.push(emitInitTeleport(e))
+    }
+  }
+  lines.push(`      </Actions>`)
+  lines.push(`    </Init>`)
+  for (const line of emitFollowTrajectoryStory(pathAssignments)) {
+    lines.push(line)
+  }
+  lines.push(`    <StopTrigger>`)
+  lines.push(`      <ConditionGroup>`)
+  lines.push(`        <Condition name="StopCondition" delay="0" conditionEdge="rising">`)
+  lines.push(`          <ByValueCondition>`)
+  lines.push(`            <SimulationTimeCondition value="60" rule="greaterThan"/>`)
+  lines.push(`          </ByValueCondition>`)
+  lines.push(`        </Condition>`)
+  lines.push(`      </ConditionGroup>`)
+  lines.push(`    </StopTrigger>`)
+  lines.push(`  </Storyboard>`)
+
+  lines.push(`</OpenSCENARIO>`)
+  return lines.join('\n')
+}

--- a/packages/drawtonomy-sdk/src/exporter/packageEsmini.ts
+++ b/packages/drawtonomy-sdk/src/exporter/packageEsmini.ts
@@ -1,0 +1,44 @@
+// One-shot helper that builds an esmini-friendly zip from a snapshot:
+// `<baseName>.zip` containing `<baseName>/<baseName>.xodr` and
+// `<baseName>/<baseName>.xosc`. The xosc <LogicFile> reference uses the same
+// baseName so the bundle works without renames.
+
+import type { DrawtonomySnapshot } from '../types'
+import { exportToOpenDrive } from './opendrive'
+import { exportToOpenScenario, type TemplateResolver } from './openscenario'
+import { sanitizeFileBaseName } from './sanitize'
+import { buildZip } from './zip'
+
+export interface EsminiPackageOptions {
+  /**
+   * Base name (without extension). Sanitized before use; falls back to
+   * "drawtonomy" if the input is empty or only invalid characters.
+   */
+  baseName?: string
+  /** Optional template resolver hook for xosc. */
+  templateResolver?: TemplateResolver
+}
+
+export interface EsminiPackageResult {
+  blob: Blob
+  /** Sanitized base name actually used for the archive. */
+  baseName: string
+}
+
+export function buildEsminiZip(
+  snapshot: DrawtonomySnapshot,
+  options: EsminiPackageOptions = {}
+): EsminiPackageResult {
+  const sanitized = options.baseName ? sanitizeFileBaseName(options.baseName) : null
+  const baseName = sanitized ?? 'drawtonomy'
+  const xodrXml = exportToOpenDrive(snapshot)
+  const xoscXml = exportToOpenScenario(snapshot, {
+    xodrFilename: `${baseName}.xodr`,
+    templateResolver: options.templateResolver,
+  })
+  const blob = buildZip([
+    { path: `${baseName}/${baseName}.xodr`, data: xodrXml },
+    { path: `${baseName}/${baseName}.xosc`, data: xoscXml },
+  ])
+  return { blob, baseName }
+}

--- a/packages/drawtonomy-sdk/src/exporter/sanitize.ts
+++ b/packages/drawtonomy-sdk/src/exporter/sanitize.ts
@@ -1,0 +1,23 @@
+/**
+ * Strip characters that are not OS / zip safe from a file base name.
+ * - /, \, :, *, ?, ", <, >, |, NUL, control chars → "_"
+ * - Runs of whitespace collapse to one space; outer whitespace / dots trim
+ * - Empty / "." / ".." returns null (caller falls back to a default name)
+ */
+export function sanitizeFileBaseName(input: string): string | null {
+  if (!input) return null
+  let s = input
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\/\\:*?"<>|\x00-\x1f]/g, '_')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^\.+|\.+$/g, '')
+  if (!s) return null
+  if (s === '.' || s === '..') return null
+  // Reject pointless names made of only underscores / whitespace; the caller
+  // falls back to a default name in that case.
+  if (/^[_\s]+$/.test(s)) return null
+  // Cap length to stay under typical OS filename limits.
+  if (s.length > 100) s = s.slice(0, 100)
+  return s
+}

--- a/packages/drawtonomy-sdk/src/exporter/trajectory.ts
+++ b/packages/drawtonomy-sdk/src/exporter/trajectory.ts
@@ -1,0 +1,234 @@
+// Path → OpenSCENARIO Trajectory conversion utility.
+//
+// Generates the vertex sequence used by <FollowTrajectoryAction> from a path
+// (a polyline + optional footprint configuration).
+//
+// Input:
+//   - Control points in canvas coordinates (px, y-down)
+//   - Footprint config (interval/offset, or pre-computed tValues)
+//   - Default speed (m/s)
+//
+// Output:
+//   - Per-sample (x_m, y_m, heading_rad, time_sec) in ENU space (y-up)
+//
+// Modes:
+//   - When tValues are provided, each footprint position is mapped to an equal
+//     time slice over the total path duration.
+//   - Otherwise, footprints are placed at equal arc-length intervals and the
+//     time is computed assuming a constant speed.
+//
+// Coordinate systems:
+//   - Input: canvas px (x right +, y down +)
+//   - Output: ENU meters (x east +, y north +); heading 0 = +X, CCW positive
+//
+// Default speed: 10 m/s (≈ 36 km/h, residential).
+
+import { PIXELS_PER_METER } from './units'
+
+export interface PathSamplePoint {
+  /** ENU x (m) */
+  x: number
+  /** ENU y (m) */
+  y: number
+  /** ENU heading (rad), 0 = +X, CCW positive */
+  heading: number
+  /** Time since start (s) */
+  time: number
+}
+
+export interface PathTrajectoryInput {
+  /** Path control points in canvas coordinates (px) */
+  points: { x: number; y: number }[]
+  /** Optional pre-computed normalized positions [0..1] along the path */
+  tValues?: number[]
+  /** Footprint interval (px), used when tValues is not provided */
+  interval?: number
+  /** Footprint offset from the start (px), used when tValues is not provided */
+  offset?: number
+  /** Default speed (m/s); falls back to DEFAULT_PATH_SPEED_MPS */
+  speedMps?: number
+}
+
+export const DEFAULT_PATH_SPEED_MPS = 10
+
+/**
+ * Cumulative arc lengths along the polyline (in input units).
+ * Returns an array of the same length as points; cumLen[i] = sum of segment
+ * lengths from index 0 to i.
+ */
+function computeCumulativeLengths(points: { x: number; y: number }[]): number[] {
+  const lens: number[] = [0]
+  for (let i = 1; i < points.length; i++) {
+    const dx = points[i].x - points[i - 1].x
+    const dy = points[i].y - points[i - 1].y
+    lens.push(lens[i - 1] + Math.hypot(dx, dy))
+  }
+  return lens
+}
+
+/**
+ * Evaluate the polyline at normalized arc-length parameter t in [0, 1].
+ * Returns the interpolated point and tangent direction.
+ */
+function evaluateAt(
+  points: { x: number; y: number }[],
+  cumLens: number[],
+  t: number
+): { x: number; y: number; tangentDx: number; tangentDy: number } {
+  const total = cumLens[cumLens.length - 1]
+  if (total <= 0 || points.length < 2) {
+    const p = points[0] ?? { x: 0, y: 0 }
+    return { x: p.x, y: p.y, tangentDx: 1, tangentDy: 0 }
+  }
+  const target = Math.max(0, Math.min(1, t)) * total
+  for (let i = 1; i < points.length; i++) {
+    if (cumLens[i] >= target) {
+      const segLen = cumLens[i] - cumLens[i - 1]
+      const localT = segLen > 1e-9 ? (target - cumLens[i - 1]) / segLen : 0
+      const dx = points[i].x - points[i - 1].x
+      const dy = points[i].y - points[i - 1].y
+      return {
+        x: points[i - 1].x + dx * localT,
+        y: points[i - 1].y + dy * localT,
+        tangentDx: dx,
+        tangentDy: dy,
+      }
+    }
+  }
+  const last = points[points.length - 1]
+  const prev = points[points.length - 2]
+  return { x: last.x, y: last.y, tangentDx: last.x - prev.x, tangentDy: last.y - prev.y }
+}
+
+/**
+ * Canvas (px, y-down) → ENU (m, y-up).
+ */
+function pxToEnu(x: number, y: number): { x: number; y: number } {
+  return {
+    x: x / PIXELS_PER_METER,
+    y: -y / PIXELS_PER_METER,
+  }
+}
+
+/**
+ * Tangent vector (canvas px space, y-down) → ENU heading (rad, y-up).
+ * Canvas y is down (CW positive), ENU y is up (CCW positive); flip dy then atan2.
+ */
+function tangentToEnuHeading(dx: number, dy: number): number {
+  return Math.atan2(-dy, dx)
+}
+
+/**
+ * Build the sample sequence used by <FollowTrajectoryAction> from a path.
+ *
+ * - tValues mode: each value is treated as a normalized position along the path,
+ *   distributed across equal time slices over the total duration. A vertex at
+ *   t=0 is prepended when the first tValue is non-zero so the trajectory starts
+ *   from the path origin.
+ * - interval/offset mode: places samples at equal arc-length intervals and
+ *   computes time as cumulative_distance / speed.
+ *
+ * In both cases time strictly increases (small back-steps are nudged forward
+ * by 1 ms because trajectory replay rejects non-monotonic timestamps).
+ */
+export function buildPathTrajectory(input: PathTrajectoryInput): PathSamplePoint[] {
+  const { points, tValues, interval, offset, speedMps } = input
+  if (points.length < 2) return []
+  const speed = speedMps && speedMps > 0 ? speedMps : DEFAULT_PATH_SPEED_MPS
+  const cumLens = computeCumulativeLengths(points)
+  const totalLenPx = cumLens[cumLens.length - 1]
+  if (totalLenPx <= 0) return []
+  const totalLenM = totalLenPx / PIXELS_PER_METER
+  const totalDurationSec = totalLenM / speed
+
+  const samples: PathSamplePoint[] = []
+
+  if (tValues && tValues.length > 0) {
+    // Prepend the path origin if the first sample is past the start.
+    const firstT = tValues[0]
+    if (firstT > 1e-6) {
+      const start = evaluateAt(points, cumLens, 0)
+      const enu = pxToEnu(start.x, start.y)
+      samples.push({
+        x: enu.x,
+        y: enu.y,
+        heading: tangentToEnuHeading(start.tangentDx, start.tangentDy),
+        time: 0,
+      })
+    }
+    const N = tValues.length
+    const dt = N > 1 ? totalDurationSec / (N - 1) : totalDurationSec
+    for (let i = 0; i < N; i++) {
+      const t = Math.max(0, Math.min(1, tValues[i]))
+      const ev = evaluateAt(points, cumLens, t)
+      const enu = pxToEnu(ev.x, ev.y)
+      samples.push({
+        x: enu.x,
+        y: enu.y,
+        heading: tangentToEnuHeading(ev.tangentDx, ev.tangentDy),
+        time: i * dt + (firstT > 1e-6 ? dt : 0),
+      })
+    }
+  } else if (interval && interval > 0) {
+    // Equal arc-length intervals; time = cumulative_distance / speed.
+    const off = offset ?? 0
+    let dPx = off
+    if (dPx > 1e-6) {
+      const start = evaluateAt(points, cumLens, 0)
+      const enu = pxToEnu(start.x, start.y)
+      samples.push({
+        x: enu.x,
+        y: enu.y,
+        heading: tangentToEnuHeading(start.tangentDx, start.tangentDy),
+        time: 0,
+      })
+    }
+    while (dPx <= totalLenPx + 1e-6) {
+      const t = dPx / totalLenPx
+      const ev = evaluateAt(points, cumLens, t)
+      const enu = pxToEnu(ev.x, ev.y)
+      const distM = dPx / PIXELS_PER_METER
+      samples.push({
+        x: enu.x,
+        y: enu.y,
+        heading: tangentToEnuHeading(ev.tangentDx, ev.tangentDy),
+        time: distM / speed,
+      })
+      dPx += interval
+    }
+    // Force-append the path endpoint if the last interval did not reach it.
+    const lastSample = samples[samples.length - 1]
+    const endTime = totalDurationSec
+    if (Math.abs(lastSample.time - endTime) > 1e-3) {
+      const ev = evaluateAt(points, cumLens, 1)
+      const enu = pxToEnu(ev.x, ev.y)
+      samples.push({
+        x: enu.x,
+        y: enu.y,
+        heading: tangentToEnuHeading(ev.tangentDx, ev.tangentDy),
+        time: endTime,
+      })
+    }
+  } else {
+    // Fallback: traverse all control points at constant speed.
+    for (let i = 0; i < points.length; i++) {
+      const ev = evaluateAt(points, cumLens, cumLens[i] / totalLenPx)
+      const enu = pxToEnu(ev.x, ev.y)
+      samples.push({
+        x: enu.x,
+        y: enu.y,
+        heading: tangentToEnuHeading(ev.tangentDx, ev.tangentDy),
+        time: (cumLens[i] / PIXELS_PER_METER) / speed,
+      })
+    }
+  }
+
+  // Trajectory replay requires strictly increasing time; nudge tiny regressions.
+  for (let i = 1; i < samples.length; i++) {
+    if (samples[i].time <= samples[i - 1].time) {
+      samples[i].time = samples[i - 1].time + 1e-3
+    }
+  }
+
+  return samples
+}

--- a/packages/drawtonomy-sdk/src/exporter/units.ts
+++ b/packages/drawtonomy-sdk/src/exporter/units.ts
@@ -1,0 +1,42 @@
+// Coordinate / unit conversions shared by the OpenDRIVE / OpenSCENARIO
+// exporters.
+//
+// The drawtonomy canvas uses pixels with y growing downward.
+// OpenDRIVE / OpenSCENARIO both use ENU meters with y growing upward.
+
+/** Conversion factor from canvas pixels to meters. */
+export const PIXELS_PER_METER = 16.67
+
+/** Canvas pixels → meters (scalar). */
+export function pxToMeter(px: number): number {
+  return px / PIXELS_PER_METER
+}
+
+/** Canvas x → ENU x (no axis flip). */
+export function pxToEnuX(x: number): number {
+  return pxToMeter(x)
+}
+
+/** Canvas y → ENU y (axis flipped: canvas y is down, ENU y is up). */
+export function pxToEnuY(y: number): number {
+  return -pxToMeter(y)
+}
+
+/**
+ * Format a number for OpenDRIVE / OpenSCENARIO output: 6 decimal places, no
+ * exponential. Non-finite values become "0".
+ */
+export function fmt(n: number): string {
+  if (!Number.isFinite(n)) return '0'
+  return n.toFixed(6)
+}
+
+/** XML attribute / text escaping. */
+export function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}

--- a/packages/drawtonomy-sdk/src/exporter/zip.ts
+++ b/packages/drawtonomy-sdk/src/exporter/zip.ts
@@ -1,0 +1,169 @@
+// Minimal ZIP builder (store mode, no compression) with no external deps.
+//
+// PKZIP APPNOTE.TXT 6.3.10 compatible. Bundles multiple files into a single
+// zip. Compression method = 0 (store), which is fine for small XML payloads.
+// Directories are implicit via slashes in entry paths.
+
+export interface ZipEntry {
+  /** Path inside the zip, e.g. "scene/scene.xodr" */
+  path: string
+  /** Entry content; strings are UTF-8 encoded internally */
+  data: string | Uint8Array
+}
+
+const TEXT_ENCODER = new TextEncoder()
+
+/**
+ * Standard CRC-32 (IEEE 802.3, polynomial 0xEDB88320), table-driven.
+ */
+const CRC32_TABLE: Uint32Array = (() => {
+  const table = new Uint32Array(256)
+  for (let i = 0; i < 256; i++) {
+    let c = i
+    for (let k = 0; k < 8; k++) {
+      c = (c & 1) ? (0xedb88320 ^ (c >>> 1)) : (c >>> 1)
+    }
+    table[i] = c >>> 0
+  }
+  return table
+})()
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff
+  for (let i = 0; i < bytes.length; i++) {
+    crc = CRC32_TABLE[(crc ^ bytes[i]) & 0xff] ^ (crc >>> 8)
+  }
+  return (crc ^ 0xffffffff) >>> 0
+}
+
+/** Little-endian writer helpers. */
+function writeU16(buf: Uint8Array, offset: number, value: number): void {
+  buf[offset] = value & 0xff
+  buf[offset + 1] = (value >>> 8) & 0xff
+}
+function writeU32(buf: Uint8Array, offset: number, value: number): void {
+  buf[offset] = value & 0xff
+  buf[offset + 1] = (value >>> 8) & 0xff
+  buf[offset + 2] = (value >>> 16) & 0xff
+  buf[offset + 3] = (value >>> 24) & 0xff
+}
+
+interface PreparedEntry {
+  path: string
+  pathBytes: Uint8Array
+  data: Uint8Array
+  crc: number
+  /** Offset of the Local File Header within the zip. */
+  localHeaderOffset: number
+}
+
+function toBytes(d: string | Uint8Array): Uint8Array {
+  return typeof d === 'string' ? TEXT_ENCODER.encode(d) : d
+}
+
+/**
+ * Bundle ZipEntry[] into a single application/zip Blob.
+ */
+export function buildZip(entries: ZipEntry[]): Blob {
+  // 1. Emit Local File Header + data for each entry, tracking offsets.
+  const prepared: PreparedEntry[] = []
+  let cursor = 0
+  const localChunks: Uint8Array[] = []
+
+  for (const entry of entries) {
+    const pathBytes = TEXT_ENCODER.encode(entry.path)
+    const data = toBytes(entry.data)
+    const crc = crc32(data)
+    const localHeader = new Uint8Array(30 + pathBytes.length)
+    // Local File Header signature 0x04034b50.
+    writeU32(localHeader, 0, 0x04034b50)
+    writeU16(localHeader, 4, 20)        // version needed to extract (2.0)
+    writeU16(localHeader, 6, 0x0800)     // general purpose bit flag (UTF-8 filename)
+    writeU16(localHeader, 8, 0)          // compression = store
+    writeU16(localHeader, 10, 0)         // last mod time
+    writeU16(localHeader, 12, 0)         // last mod date
+    writeU32(localHeader, 14, crc)       // CRC-32
+    writeU32(localHeader, 18, data.length) // compressed size
+    writeU32(localHeader, 22, data.length) // uncompressed size
+    writeU16(localHeader, 26, pathBytes.length) // file name length
+    writeU16(localHeader, 28, 0)         // extra field length
+    localHeader.set(pathBytes, 30)
+
+    const localHeaderOffset = cursor
+    localChunks.push(localHeader)
+    localChunks.push(data)
+    cursor += localHeader.length + data.length
+
+    prepared.push({
+      path: entry.path,
+      pathBytes,
+      data,
+      crc,
+      localHeaderOffset,
+    })
+  }
+
+  const localBytes = concatBytes(localChunks)
+
+  // 2. Central Directory.
+  const cdChunks: Uint8Array[] = []
+  let cdSize = 0
+  for (const e of prepared) {
+    const cdHeader = new Uint8Array(46 + e.pathBytes.length)
+    // Central Directory File Header signature 0x02014b50.
+    writeU32(cdHeader, 0, 0x02014b50)
+    writeU16(cdHeader, 4, 20)         // version made by
+    writeU16(cdHeader, 6, 20)         // version needed to extract
+    writeU16(cdHeader, 8, 0x0800)      // general purpose bit flag
+    writeU16(cdHeader, 10, 0)          // compression = store
+    writeU16(cdHeader, 12, 0)          // last mod time
+    writeU16(cdHeader, 14, 0)          // last mod date
+    writeU32(cdHeader, 16, e.crc)
+    writeU32(cdHeader, 20, e.data.length) // compressed size
+    writeU32(cdHeader, 24, e.data.length) // uncompressed size
+    writeU16(cdHeader, 28, e.pathBytes.length)
+    writeU16(cdHeader, 30, 0)          // extra field length
+    writeU16(cdHeader, 32, 0)          // file comment length
+    writeU16(cdHeader, 34, 0)          // disk number start
+    writeU16(cdHeader, 36, 0)          // internal file attributes
+    writeU32(cdHeader, 38, 0)          // external file attributes
+    writeU32(cdHeader, 42, e.localHeaderOffset)
+    cdHeader.set(e.pathBytes, 46)
+    cdChunks.push(cdHeader)
+    cdSize += cdHeader.length
+  }
+  const cdBytes = concatBytes(cdChunks)
+
+  // 3. End Of Central Directory record (22 bytes).
+  const eocd = new Uint8Array(22)
+  writeU32(eocd, 0, 0x06054b50)        // EOCD signature
+  writeU16(eocd, 4, 0)                  // disk number
+  writeU16(eocd, 6, 0)                  // disk where CD starts
+  writeU16(eocd, 8, prepared.length)    // number of CD records on this disk
+  writeU16(eocd, 10, prepared.length)   // total number of CD records
+  writeU32(eocd, 12, cdSize)            // size of CD
+  writeU32(eocd, 16, localBytes.length) // offset of CD start
+  writeU16(eocd, 20, 0)                 // .ZIP file comment length
+
+  // Slice() exposes plain ArrayBuffer; the DOM Blob constructor type does
+  // not accept ArrayBufferLike views directly under strict TS settings.
+  return new Blob(
+    [localBytes.slice().buffer, cdBytes.slice().buffer, eocd.slice().buffer],
+    { type: 'application/zip' }
+  )
+}
+
+function concatBytes(chunks: Uint8Array[]): Uint8Array {
+  let total = 0
+  for (const c of chunks) total += c.length
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const c of chunks) {
+    out.set(c, offset)
+    offset += c.length
+  }
+  return out
+}
+
+// Exported for test use only.
+export { crc32 as _crc32ForTest }

--- a/packages/drawtonomy-sdk/src/index.ts
+++ b/packages/drawtonomy-sdk/src/index.ts
@@ -3,3 +3,5 @@ export * from './types'
 export * from './helpers'
 export * from './geometry'
 export { ExtensionClient } from './ExtensionClient'
+// Exporter sub-module is also available via "@drawtonomy/sdk/exporter".
+export * as exporter from './exporter'

--- a/packages/drawtonomy-sdk/src/types.ts
+++ b/packages/drawtonomy-sdk/src/types.ts
@@ -135,16 +135,31 @@ export interface TrafficLightProps {
   w: number
   h: number
   color: string
-  attributes: { type: 'traffic_light'; subtype?: string }
+  /** Visual style identifier (e.g. "pedestrian", "traffic_red"). */
+  style: string
+  /** Currently lit lamp index for the configured style. */
+  activeLight?: string
+  size?: string
+  attributes: { type?: string; subtype?: string } & Record<string, string>
   osmId: string
 }
 
 export interface CrosswalkProps {
-  pointIds: string[]
-  color: string
+  /** Crosswalk axis start in shape-local coordinates. */
+  startX: number
+  startY: number
+  /** Crosswalk axis end in shape-local coordinates. */
+  endX: number
+  endY: number
+  /** Stripe band thickness across the road. */
+  crosswalkWidth: number
+  /** Width of each white stripe. */
   stripeWidth?: number
-  stripeGap?: number
-  attributes: { type: 'crosswalk'; subtype?: string }
+  /** Spacing between stripes. */
+  stripeSpacing?: number
+  color: string
+  opacity?: number | null
+  attributes: { type?: string; subtype?: string } & Record<string, string>
   osmId: string
 }
 


### PR DESCRIPTION
## Summary

<img width="2344" height="1410" alt="image" src="https://github.com/user-attachments/assets/4185a3c7-7662-4d01-a3b2-73e17897c27a" />


Adds an `exporter` sub-module to `@drawtonomy/sdk` for converting a `DrawtonomySnapshot` into ASAM-format files without depending on the editor runtime. Intended as the main extension point for additional adapters (CARLA, Unity, SUMO, custom DSLs, ...).

- `exportToOpenDrive(snapshot)` — OpenDRIVE 1.8 (.xodr)
- `exportToOpenScenario(snapshot, options?)` — OpenSCENARIO 1.3 (.xosc)
- `buildEsminiZip(snapshot, options?)` — bundles .xodr + .xosc into one zip
- `buildPathTrajectory`, `computeCenterlineWithWidth`, `buildZip`, `sanitizeFileBaseName` — supporting utilities (no deps)
- Extends `TrafficLightProps` and `CrosswalkProps` with the fields the exporter consumes

## Test plan

- [x] `pnpm --filter @drawtonomy/sdk test` — 112 tests passing
- [x] `pnpm --filter @drawtonomy/sdk build` — clean tsc output