### PR TITLE
docs: add Exporter Developer Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - 💾 **Editable Save Format** - Re-edit while preserving lane connection info
 - 🗺️ **[Lanelet2](https://github.com/fzi-forschungszentrum-informatik/Lanelet2) Support** - Import OSM format maps
 - 🤖 **ROS Map Support** - Import OccupancyGrid maps (.pgm + .yaml) from SLAM
+- 🚗 **[ASAM Export](docs/exporter.md)** - Export OpenDRIVE / OpenSCENARIO and esmini-ready zip bundles
 - 🤖 **[AI Scene Generator](extensions/ai-scene-generator/)** - Generate editable scenes from natural language, OpenSCENARIO XML, or DSL
 
 ## 🎯 Main Features
@@ -129,6 +130,9 @@ Generate footprints on a Path with the Generate button. Rectangle or any vehicle
 | **drawtonomy.svg** | ✓      | ✓      | Re-editable           |
 | **OSM (Lanelet2)** |        | ✓      |                       |
 | **PGM+YAML (ROS)** |        | ✓      | OccupancyGrid map     |
+| **OpenDRIVE (.xodr)** | ✓   |        | ASAM 1.8              |
+| **OpenSCENARIO (.xosc)** | ✓ |       | ASAM 1.3              |
+| **esmini bundle (.zip)** | ✓ |       | .xodr + .xosc together |
 
 > **Note on EPS export**: EPS format does not support transparency. When exporting shapes with opacity settings, the exported EPS will show shapes at full opacity, which may differ from the canvas display. For accurate transparency rendering, use PDF export instead.
 
@@ -156,6 +160,18 @@ Compatible with nav2, cartographer, gmapping, and other SLAM tools.
 <p align="center">
   <img src="./docs/images/ros-occupancy-grid-map.png" width="80%" />
 </p>
+
+#### ASAM Export (OpenDRIVE / OpenSCENARIO / esmini)
+
+Export the current scene as an ASAM-format file or a single zip bundle ready
+for [esmini](https://github.com/esmini/esmini) to play back. Use the **Export
+for esmini** menu item to produce a zip containing both `.xodr` and `.xosc`.
+
+The exporter is implemented in `@drawtonomy/sdk` and is the main extension
+point for adding new shapes, animation features, or entirely new target
+formats (CARLA, Unity, SUMO, …).
+
+📖 **[Exporter Developer Guide](docs/exporter.md)** | [日本語](docs/exporter.ja.md)
 
 ### 🤖 [AI Scene Generator](extensions/ai-scene-generator/)
 
@@ -235,3 +251,5 @@ Available npm packages:
 | [`@drawtonomy/dev-server`](https://www.npmjs.com/package/@drawtonomy/dev-server) | Local dev server for extension development |
 
 📖 **[Extension Development Guide](docs/extensions.md)** | [日本語](docs/extensions.ja.md) | [AI Scene Generator](extensions/ai-scene-generator/) | [Template Preview](extensions/template-preview/)
+
+📖 **[Exporter Developer Guide](docs/exporter.md)** | [日本語](docs/exporter.ja.md) — extend OpenDRIVE / OpenSCENARIO output, or add a new target format (CARLA, Unity, SUMO, …)

--- a/docs/exporter.ja.md
+++ b/docs/exporter.ja.md
@@ -1,0 +1,331 @@
+# drawtonomy Exporter
+
+[English](exporter.md)
+
+`@drawtonomy/sdk` の `exporter` サブモジュールは、`DrawtonomySnapshot` を
+ASAM 仕様のファイル (OpenDRIVE 1.8 / OpenSCENARIO 1.3) や esmini 用の zip
+バンドルに変換します。エディタランタイムへの依存はゼロなので、ヘッドレス
+ツール、サーバーサイドパイプライン、ブラウザ拡張、CI チェックなどから
+そのまま呼べます。
+
+新しいシェイプ対応、アニメーション仕様の拡張、別フォーマットアダプタ
+(CARLA / Unity / SUMO 等) を追加する際の主要な拡張ポイントです。
+
+## 目次
+
+- [Quick Start (ユーザー向け)](#quick-start-ユーザー向け)
+- [Quick Start (開発者向け)](#quick-start-開発者向け)
+- [アーキテクチャ](#アーキテクチャ)
+- [API リファレンス](#api-リファレンス)
+- [Exporter を拡張する](#exporter-を拡張する)
+- [ロードマップ](#ロードマップ)
+
+---
+
+## Quick Start (ユーザー向け)
+
+1. drawtonomy でシーンを描画する (レーン、車両、信号機等)。
+2. メニュー → **Export** → **Export for esmini** をクリック。
+3. プロンプトでファイル名を入力する。
+4. `<name>.zip` がダウンロードされる (中身は `<name>.xodr` と `<name>.xosc`)。
+5. 解凍して esmini で開く:
+
+   ```bash
+   unzip <name>.zip
+   esmini --osc <name>/<name>.xosc --window 60 60 1024 768
+   ```
+
+---
+
+## Quick Start (開発者向け)
+
+```bash
+pnpm add @drawtonomy/sdk
+```
+
+```typescript
+import { exporter, createSnapshot } from '@drawtonomy/sdk'
+
+// shapes は BaseShape の配列 (後述「Snapshot の形」参照)。
+const snapshot = createSnapshot(shapes)
+
+// フォーマットごとの文字列を取得
+const xodr = exporter.exportToOpenDrive(snapshot)
+const xosc = exporter.exportToOpenScenario(snapshot, {
+  xodrFilename: 'scene.xodr',
+})
+
+// 便利関数: 両方をまとめて esmini 用の zip にする
+const { blob, baseName } = exporter.buildEsminiZip(snapshot, {
+  baseName: 'my-scene',
+})
+```
+
+Exporter は純関数群です (同じ入力なら必ず同じ出力、エディタや DOM へのアクセスなし)。
+
+---
+
+## アーキテクチャ
+
+### Snapshot の形
+
+```typescript
+interface DrawtonomySnapshot {
+  version: string
+  timestamp: string
+  shapes: BaseShape[]   // points, linestrings, lanes, vehicles, …
+  camera?: { x: number; y: number; z: number }
+}
+```
+
+Exporter は `shapes` だけを読みます。各シェイプは `id` / `type` / `x` /
+`y` / `rotation` / `props` を持つ自己完結したオブジェクトで、レーンの
+ジオメトリは id 参照 (lane → 2 本の境界 linestring → points) で構築されます。
+Exporter 内部では id ルックアップ用 Map を作って解決しています。
+
+### モジュール構成
+
+```
+@drawtonomy/sdk/exporter/
+├── opendrive.ts        Lane / TrafficLight / Crosswalk / Polygon → .xodr
+├── openscenario.ts     Vehicle / Pedestrian / Path → .xosc
+├── trajectory.ts       Path → 時系列頂点列
+├── laneCenterline.ts   2 本の境界ポリライン → 中心線 + 幅サンプル
+├── packageEsmini.ts    .xodr + .xosc → 1 つの .zip
+├── zip.ts              純 ZIP ビルダー (store mode、依存ゼロ)
+├── sanitize.ts         OS セーフなファイル名サニタイズ
+└── units.ts            canvas px ↔ ENU m、XML 整形ヘルパ
+```
+
+### 座標系の規約
+
+| 軸 | drawtonomy キャンバス | OpenDRIVE / OpenSCENARIO (ENU) |
+|---|---|---|
+| x | 右 + | 東 + |
+| y | **下 +** | **上 +** (符号反転) |
+| heading | CW 正 (degree) | CCW 正 (radian) |
+| 長さ単位 | ピクセル | メートル (`PIXELS_PER_METER = 16.67`) |
+
+車両テンプレートはキャンバス上で前面が −Y (画面上方向) を向く規約のため、
+`rotation = 0` は ENU では heading `π/2` (北) に対応します。このオフセットは
+`exportToOpenScenario` 内で適用されます。
+
+---
+
+## API リファレンス
+
+### `exportToOpenDrive(snapshot)`
+
+```typescript
+function exportToOpenDrive(snapshot: DrawtonomySnapshot): string
+```
+
+OpenDRIVE 1.8 の XML 文字列を返します。`LaneShape` は `<road>`、
+`TrafficLightShape` は `<signal>`、`CrosswalkShape` と `PolygonShape` は
+`<object>` として出力されます。レーン接続 (`next` / `prev`) は road レベルと
+lane レベルの `<link>` 要素として書かれます。junction はまだ未対応です
+(後述 [ロードマップ](#ロードマップ))。
+
+### `exportToOpenScenario(snapshot, options?)`
+
+```typescript
+interface OpenScenarioExportOptions {
+  xodrFilename?: string          // <LogicFile> から参照される
+  scenarioName?: string
+  templateResolver?: TemplateResolver
+}
+
+function exportToOpenScenario(
+  snapshot: DrawtonomySnapshot,
+  options?: OpenScenarioExportOptions
+): string
+```
+
+`VehicleShape` は `templateId` から解決した category で `<ScenarioObject>`
+になります。歩行者テンプレートは `<Vehicle>` ではなく `<Pedestrian>` を
+出力します。footprint を持つ Path linestring は先頭 footprint の車両を
+アクターとする `<FollowTrajectoryAction>` ストーリーになります。
+
+### `buildEsminiZip(snapshot, options?)`
+
+```typescript
+interface EsminiPackageOptions {
+  baseName?: string
+  templateResolver?: TemplateResolver
+}
+
+interface EsminiPackageResult {
+  blob: Blob
+  baseName: string
+}
+
+function buildEsminiZip(
+  snapshot: DrawtonomySnapshot,
+  options?: EsminiPackageOptions
+): EsminiPackageResult
+```
+
+両 exporter を呼び、結果を `<baseName>.zip` (中身は
+`<baseName>/<baseName>.xodr` と `<baseName>/<baseName>.xosc`) として
+パッケージします。ファイル名を統一しているので xosc 内の `<LogicFile>`
+参照がリネームなしに解決されます。
+
+### `buildPathTrajectory(input)`
+
+```typescript
+interface PathTrajectoryInput {
+  points: { x: number; y: number }[]
+  tValues?: number[]                  // 事前計算済みの正規化位置
+  interval?: number                   // サンプル間 px
+  offset?: number                     // 開始からのオフセット px
+  speedMps?: number                   // デフォルト 10
+}
+
+interface PathSamplePoint {
+  x: number       // ENU m
+  y: number       // ENU m
+  heading: number // ENU rad
+  time: number    // s
+}
+
+function buildPathTrajectory(input: PathTrajectoryInput): PathSamplePoint[]
+```
+
+Polyline path を `<FollowTrajectoryAction>` 用の時系列頂点列に変換します。
+3 つのモード: `tValues` (事前計算)、`interval` (等弧長)、フォールバック
+(等速で制御点を辿る)。
+
+### `computeCenterlineWithWidth(left, right, numSamples?)`
+
+両境界ポリラインを同じ正規化弧長パラメータでサンプルし、サンプルごとの
+中点 + 幅を返します。OpenDRIVE exporter のリファレンスライン生成と
+`<width>` エントリ生成に使われます。
+
+### `buildZip(entries)`
+
+```typescript
+interface ZipEntry { path: string; data: string | Uint8Array }
+function buildZip(entries: ZipEntry[]): Blob
+```
+
+PKZIP 互換の純 ZIP ビルダー (store mode、無圧縮)。依存ゼロでブラウザ・
+Node どちらでも動作します。
+
+### `sanitizeFileBaseName(input)`
+
+OS セーフなベース名 (path separator / 制御文字 → アンダースコア、
+最大 100 文字) を返します。空になる入力に対しては `null` を返します。
+
+---
+
+## Exporter を拡張する
+
+Exporter は「公開済み snapshot 形式」のみに依存しているため、新しい
+シェイプ・アニメーション機能・新フォーマットの追加は
+`packages/drawtonomy-sdk/src/exporter/` 配下の変更だけで完結します。
+
+### 新しいシェイプ対応を追加する
+
+例: `TrafficSignShape` を OpenDRIVE `<signal>` として出力する。
+
+1. シェイプの props が公開 SDK 型定義
+   (`packages/drawtonomy-sdk/src/types.ts`) に含まれていることを確認。
+   不足があれば拡張する。
+2. `opendrive.ts` のメイン走査ループに分岐を追加する:
+
+   ```typescript
+   for (const s of shapes) {
+     // …既存の分岐…
+     else if (s.type === 'traffic_sign') trafficSigns.push(s as TrafficSignShape)
+   }
+   ```
+3. `projectToRoad` (既存ヘルパ) で最近傍 road に投影し、`<signal>` を出力。
+4. `packages/drawtonomy-sdk/__tests__/exporter/` にユニットテストを追加。
+
+OpenSCENARIO 側も同じ要領で `openscenario.ts` の `collectEntities` /
+`emitVehicleEntity` に分岐を追加します。
+
+### 新しいターゲットフォーマットを追加する
+
+例: CARLA 拡張 OpenDRIVE を出力する `carla.ts` アダプタ。
+
+1. `packages/drawtonomy-sdk/src/exporter/carla.ts` を作成。
+2. `DrawtonomySnapshot` を入力に取り、必要に応じて `laneCenterline.ts` /
+   `units.ts` を再利用。
+3. `packages/drawtonomy-sdk/src/exporter/index.ts` から再エクスポート。
+4. フォーマット固有の差分をカバーするテストを追加。
+
+既存 exporter は意図的に共通インターフェースを持っていません。フォーマット
+ごとの癖が大きく、早期抽象化より重複を許容する方針です。3 つ以上の
+アダプタが揃った段階で統一インターフェースを再検討します。
+
+### TemplateResolver フック
+
+`exportToOpenScenario` は `templateResolver` オプションを受け取ります。
+SDK にバンドルされていないテンプレートをホスト側が知っている場合に使えます:
+
+```typescript
+const resolver = {
+  resolveTemplateId: (id) => myLegacyMap[id] ?? id,
+  isPedestrianTemplate: (id) => /pedestrian|walk/.test(id),
+}
+exporter.exportToOpenScenario(snapshot, { templateResolver: resolver })
+```
+
+省略時は drawtonomy にバンドルされているテンプレートを前提とした
+デフォルト挙動になります。
+
+### 座標 / heading ユーティリティ
+
+`units.ts` のヘルパを再利用してください。
+
+```typescript
+import { pxToMeter, pxToEnuX, pxToEnuY, fmt, escapeXml } from './units'
+```
+
+px ↔ m 変換係数と y 軸反転を全 exporter で一貫させるための共通モジュールです。
+
+---
+
+## ロードマップ
+
+以下は将来コントリビュートが期待される項目です。いずれも
+`packages/drawtonomy-sdk/src/exporter/` 配下の変更のみで完結します。
+
+### シェイプ対応
+
+- `TrafficSign` → OpenDRIVE `<signal>` (stop / yield / 速度制限等)
+- `Others` (例: 建物) → OpenDRIVE `<object type="building">`
+- 自転車テンプレート → `<Vehicle vehicleCategory="bicycle">`
+
+### レーン接続
+
+- junction (`<junction>`) 出力。3 本以上のレーンが端点を共有する場合の
+  分岐情報。`LaneShape` は既に `next` / `prev` を持っているので、
+  そのデータから判定できる。
+
+### アニメーション機能
+
+- 加速度プロファイル → `<SpeedActionDynamics>`
+- 停止 / dwell イベント → `<StandStillCondition>`
+- 信号連動の path → `<TrafficSignalCondition>`
+- 車線変更 → `<LaneChangeAction>`
+- 複数アクターの協調 → より複雑な `<Storyboard>` 構造
+
+### 別フォーマット
+
+- `carla.ts` — CARLA 拡張 OpenDRIVE、CARLA YAML シナリオ
+- `unity-prefab.ts` — Unity prefab エクスポート
+- `sumo.ts` — SUMO ロードネットワーク + trip 定義
+
+### esmini 運用ノウハウ
+
+esmini v3.0.x 向けの実装ノウハウ (crosswalk heading の規約、
+`scaleMode=ModelToBB`、polygon の色指定制限等) は現状 exporter ソース内の
+インラインコメントに散らばっています。本ドキュメント内の専用セクションに
+集約する PR は歓迎です。
+
+---
+
+非自明なコントリビューションを計画している場合は、実装前に issue を立てて
+設計を相談するのを推奨します。

--- a/docs/exporter.ja.md
+++ b/docs/exporter.ja.md
@@ -15,6 +15,7 @@ ASAM 仕様のファイル (OpenDRIVE 1.8 / OpenSCENARIO 1.3) や esmini 用の 
 
 - [Quick Start (ユーザー向け)](#quick-start-ユーザー向け)
 - [Quick Start (開発者向け)](#quick-start-開発者向け)
+- [ローカル開発](#ローカル開発)
 - [アーキテクチャ](#アーキテクチャ)
 - [API リファレンス](#api-リファレンス)
 - [Exporter を拡張する](#exporter-を拡張する)
@@ -62,6 +63,167 @@ const { blob, baseName } = exporter.buildEsminiZip(snapshot, {
 ```
 
 Exporter は純関数群です (同じ入力なら必ず同じ出力、エディタや DOM へのアクセスなし)。
+
+---
+
+## ローカル開発
+
+このセクションは **exporter 自体に手を入れる** コントリビューター向けです。
+
+開発スタイルは大きく 2 通りあります。組み合わせて使います。
+
+1. **スナップショット駆動** — snapshot のフィクスチャをコードで作って vitest を回し、
+   出力 XML をアサートする。ブラウザを起動しないので速い。新しいロジックの実装に最適。
+2. **esmini での目視確認** — 生成した `.xodr` / `.xosc` を esmini に食わせ、
+   3D 再生が期待通りかを確認する。遅いが、純粋な XML アサートでは捕まえられない
+   問題 (描画の崩れ、再生タイミング等) を捕まえられる。
+
+通常は (1) で実装を固め、PR を出す前にフィクスチャを (2) で通します。
+
+### セットアップ
+
+```bash
+git clone https://github.com/kosuke55/drawtonomy.git
+cd drawtonomy
+pnpm install   # workspace 全体をインストール
+```
+
+Exporter のソース: `packages/drawtonomy-sdk/src/exporter/`
+テスト: `packages/drawtonomy-sdk/__tests__/exporter/`
+
+### スナップショット駆動の開発 (高速ループ)
+
+Exporter は `DrawtonomySnapshot` を入力に取る純関数なので、vitest 単体で
+完結して挙動を確認できます (エディタもブラウザも esmini も不要)。
+「コードで snapshot を組み立て、exporter を呼び、出力 XML をアサート」だけで開発できます。
+
+```bash
+cd packages/drawtonomy-sdk
+
+pnpm test                       # 1 回だけ実行
+pnpm exec vitest                # watch モード (保存ごとに再実行)
+pnpm exec vitest exporter       # exporter テストファイルだけ
+pnpm build                      # tsc で型チェック (commit 前推奨)
+```
+
+最小のテスト雛形:
+
+```typescript
+// packages/drawtonomy-sdk/__tests__/exporter/my-feature.test.ts
+import { describe, it, expect } from 'vitest'
+import { exportToOpenDrive } from '../../src/exporter/opendrive'
+import type { DrawtonomySnapshot } from '../../src/types'
+
+function snapshot(shapes: any[]): DrawtonomySnapshot {
+  return { version: '1.1', timestamp: new Date().toISOString(), shapes }
+}
+
+describe('my new feature', () => {
+  it('emits something specific', () => {
+    const xml = exportToOpenDrive(snapshot([
+      // 自分のコードパスをトリガする最小のシーンを組む:
+      // 数個の point、linestring、lane など
+    ]))
+    expect(xml).toContain('<expected-element>')
+  })
+})
+```
+
+ヒント:
+
+- `__tests__/exporter/opendrive.test.ts` には `point` / `linestring` /
+  `lane` を作るための小さなヘルパが揃っているので、コピーして使うのが楽。
+- 開発中は `console.log(xml)` で全文を確認しながら回し、出力が安定したら
+  特定の行だけアサートする形に絞り込む。
+- 大きな XML 差分を扱うなら `expect(xml).toMatchInlineSnapshot()` も便利。
+
+### esmini で出力を検証する
+
+vitest は挙動の回帰を捉えますが、esmini が実際にどう描画するかまでは
+教えてくれません。snapshot テストが通ったら、生成 XML を esmini に
+直接食わせて目視確認します。
+
+ブラウザは不要です。snapshot フィクスチャから `.xodr` / `.xosc` を吐く
+小さなスクリプトを書き、それを esmini に渡すだけです。
+
+#### 1. esmini をインストール
+
+```bash
+# macOS
+brew install esmini
+
+# Linux / Windows: https://github.com/esmini/esmini を参照
+```
+
+#### 2. フィクスチャから bundle を生成
+
+```typescript
+// scripts/preview.mjs
+import { writeFileSync, mkdirSync } from 'node:fs'
+import { exporter } from '@drawtonomy/sdk'
+
+const snapshot = {
+  version: '1.1',
+  timestamp: new Date().toISOString(),
+  shapes: [
+    // 自分の変更をトリガする最小のシーンを組む。
+    // __tests__/exporter/ のフィクスチャを起点にコピペするのが楽。
+  ],
+}
+
+mkdirSync('out', { recursive: true })
+writeFileSync('out/scene.xodr', exporter.exportToOpenDrive(snapshot))
+writeFileSync('out/scene.xosc', exporter.exportToOpenScenario(snapshot, {
+  xodrFilename: 'scene.xodr',
+}))
+console.log('wrote out/scene.{xodr,xosc}')
+```
+
+SDK を `pnpm build` した後にスクリプトを実行:
+
+```bash
+cd packages/drawtonomy-sdk && pnpm build
+node scripts/preview.mjs
+```
+
+#### 3. esmini で開く
+
+```bash
+esmini --osc out/scene.xosc --window 60 60 1024 768
+```
+
+確認ポイント:
+
+- レーン形状がフィクスチャの意図通りか
+- 車両が想定の位置・向きで spawn しているか
+- trajectory がある場合、車両が想定のタイミングで path に沿って動くか
+- XML をテキストエディタで開いてもよい。exporter が出すコメントが手がかりになる
+
+esmini がパースエラーを出した場合、行番号と列を控えて生成 XML の該当箇所を
+grep するのが最短です。多くは属性の過不足程度で、vitest 側で再現して直せます。
+
+#### キャンバスからの完全な通し確認
+
+「キャンバス → snapshot → exporter → esmini」の流れを丸ごと検証したい
+場合は、公開済みの drawtonomy (`https://drawtonomy.com`) を使ってください。
+シーンを描いて **Export for esmini** を実行し、上記の手順で esmini に
+食わせます。drawtonomy.com に組み込まれている `@drawtonomy/sdk` は
+公開済みの最新リリースなので、この通し確認は **PR がマージされて SDK が
+再公開された後** に行うのが一番素直です。
+
+### テストの書き方
+
+挙動を変える PR にはテストを必ず付けてください。慣例:
+
+- ソースとテストは 1 対 1: `opendrive.ts` ↔ `opendrive.test.ts`
+- フィクスチャはコード上で plain object として組む。実エディタの snapshot を
+  そのまま貼ると、UI 側の変更で壊れやすいので避ける。
+- 全文比較ではなく狭いアサーション (`expect(xml).toContain(...)`) を優先。
+  emit のフォーマット微調整で壊れにくくなる。
+- 数値出力は `toBeCloseTo` で浮動小数の誤差を許容する。
+
+`@drawtonomy/sdk` の CI は `pnpm build` と `pnpm test` を実行します。
+PR では両方が通っている必要があります。
 
 ---
 

--- a/docs/exporter.ja.md
+++ b/docs/exporter.ja.md
@@ -106,10 +106,16 @@ pnpm exec vitest exporter       # exporter テストファイルだけ
 pnpm build                      # tsc で型チェック (commit 前推奨)
 ```
 
-最小のテスト雛形:
+#### snapshot を用意する 3 つの方法
+
+リアル度が低い順に 3 通りあります。
+
+**(1) 手書きの最小フィクスチャ**。特定のコードパスを狙うユニットテストに最適。
+`__tests__/exporter/` 配下の既存テストには `point` / `linestring` / `lane`
+を作る小さなヘルパが用意されているので、コピペで始められます。
 
 ```typescript
-// packages/drawtonomy-sdk/__tests__/exporter/my-feature.test.ts
+// __tests__/exporter/my-feature.test.ts
 import { describe, it, expect } from 'vitest'
 import { exportToOpenDrive } from '../../src/exporter/opendrive'
 import type { DrawtonomySnapshot } from '../../src/types'
@@ -121,21 +127,59 @@ function snapshot(shapes: any[]): DrawtonomySnapshot {
 describe('my new feature', () => {
   it('emits something specific', () => {
     const xml = exportToOpenDrive(snapshot([
-      // 自分のコードパスをトリガする最小のシーンを組む:
-      // 数個の point、linestring、lane など
+      // 自分のコードパスをトリガする最小のシーン
     ]))
     expect(xml).toContain('<expected-element>')
   })
 })
 ```
 
-ヒント:
+**(2) SDK ヘルパで組み立てる**。プロパティを 1 つずつ書きたくないけれど
+リアルなシェイプが欲しい時。`createPoint` / `createLinestring` /
+`createLane` / `createLaneWithBoundaries` / `createVehicle` /
+`createPathWithFootprints` / `createSnapshot` を組み合わせます。
 
-- `__tests__/exporter/opendrive.test.ts` には `point` / `linestring` /
-  `lane` を作るための小さなヘルパが揃っているので、コピーして使うのが楽。
+```typescript
+import {
+  createLaneWithBoundaries,
+  createVehicle,
+  createSnapshot,
+} from '@drawtonomy/sdk'
+
+const shapes = [
+  ...createLaneWithBoundaries(
+    [{ x: 0, y: -5 }, { x: 100, y: -5 }],
+    [{ x: 0, y: 5 }, { x: 100, y: 5 }]
+  ),
+  createVehicle(50, 0, { templateId: 'sedan' }),
+]
+const snapshot = createSnapshot(shapes)
+```
+
+**(3) drawtonomy で描いた実シーンを再利用する**。
+[drawtonomy.com](https://drawtonomy.com) でシーンを描き、
+**メニュー → Export → drawtonomy.svg** でダウンロード。
+このファイルは snapshot を埋め込んだ通常の SVG なので、`parseDrawtonomySvg`
+で `DrawtonomySnapshot` に戻せます。
+
+```typescript
+import { readFileSync } from 'node:fs'
+import { parseDrawtonomySvg } from '@drawtonomy/sdk'
+
+const svg = readFileSync('./fixtures/my-scene.drawtonomy.svg', 'utf-8')
+const snapshot = parseDrawtonomySvg(svg)
+if (!snapshot) throw new Error('not a drawtonomy.svg file')
+```
+
+`.drawtonomy.svg` で保存した fixture は「この実シーンを入れたらこの XML が
+出てほしい」という回帰テストの入力に向いています。
+
+#### 反復のヒント
+
 - 開発中は `console.log(xml)` で全文を確認しながら回し、出力が安定したら
   特定の行だけアサートする形に絞り込む。
 - 大きな XML 差分を扱うなら `expect(xml).toMatchInlineSnapshot()` も便利。
+- フィクスチャは小さく保つ。点 3 個 + lane 1 個でだいたい足りる。
 
 ### esmini で出力を検証する
 
@@ -155,21 +199,28 @@ brew install esmini
 # Linux / Windows: https://github.com/esmini/esmini を参照
 ```
 
-#### 2. フィクスチャから bundle を生成
+#### 2. snapshot から bundle を生成
+
+drawtonomy.com からエクスポートした `.drawtonomy.svg` を起点にするのが一番簡単です
+([snapshot を用意する 3 つの方法](#snapshot-を用意する-3-つの方法) 参照)。
+手書きフィクスチャやヘルパで組み立てた snapshot でも同じスクリプトが使えます。
 
 ```typescript
 // scripts/preview.mjs
-import { writeFileSync, mkdirSync } from 'node:fs'
-import { exporter } from '@drawtonomy/sdk'
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { parseDrawtonomySvg, exporter } from '@drawtonomy/sdk'
 
-const snapshot = {
-  version: '1.1',
-  timestamp: new Date().toISOString(),
-  shapes: [
-    // 自分の変更をトリガする最小のシーンを組む。
-    // __tests__/exporter/ のフィクスチャを起点にコピペするのが楽。
-  ],
-}
+// オプション A: drawtonomy.com からの実シーン
+const svg = readFileSync('./fixtures/my-scene.drawtonomy.svg', 'utf-8')
+const snapshot = parseDrawtonomySvg(svg)
+if (!snapshot) throw new Error('not a drawtonomy.svg file')
+
+// オプション B: コードで組み立てた snapshot (使う場合はコメント解除)
+// import { createLaneWithBoundaries, createVehicle, createSnapshot } from '@drawtonomy/sdk'
+// const snapshot = createSnapshot([
+//   ...createLaneWithBoundaries([{x:0,y:-5},{x:100,y:-5}], [{x:0,y:5},{x:100,y:5}]),
+//   createVehicle(50, 0, { templateId: 'sedan' }),
+// ])
 
 mkdirSync('out', { recursive: true })
 writeFileSync('out/scene.xodr', exporter.exportToOpenDrive(snapshot))
@@ -377,6 +428,24 @@ Node どちらでも動作します。
 
 OS セーフなベース名 (path separator / 制御文字 → アンダースコア、
 最大 100 文字) を返します。空になる入力に対しては `null` を返します。
+
+### `parseDrawtonomySvg(svg)` *(SDK ルート、`exporter` サブモジュールではない)*
+
+```typescript
+function parseDrawtonomySvg(svgContent: string): DrawtonomySnapshot | null
+```
+
+`.drawtonomy.svg` のソース文字列を読み、埋め込まれた `DrawtonomySnapshot`
+を返します。snapshot を含まない通常の SVG、壊れたペイロード、文字列でない
+入力に対しては `null` を返します。`data-drawtonomy-snapshot` (現行) と
+`data-drawauto-snapshot` (旧形式) の両方を受け付けます。`DOMParser` /
+`jsdom` を使わない実装なので、純 Node でも動きます。
+
+```typescript
+import { parseDrawtonomySvg } from '@drawtonomy/sdk'
+
+const snapshot = parseDrawtonomySvg(readFileSync('scene.drawtonomy.svg', 'utf-8'))
+```
 
 ---
 

--- a/docs/exporter.md
+++ b/docs/exporter.md
@@ -94,7 +94,7 @@ Tests live in `packages/drawtonomy-sdk/__tests__/exporter/`.
 
 The exporter is a set of pure functions over `DrawtonomySnapshot`, so you can
 exercise it entirely from vitest. No editor, no browser, no esmini — just
-"build a snapshot in code, call the exporter, assert on the XML string."
+"build a snapshot, call the exporter, assert on the XML string."
 
 ```bash
 cd packages/drawtonomy-sdk
@@ -105,10 +105,17 @@ pnpm exec vitest exporter       # only the exporter test files
 pnpm build                      # tsc — catches type errors before you commit
 ```
 
-Minimal test scaffold:
+#### How to obtain a snapshot
+
+You have three options, in order of increasing realism:
+
+**(1) Hand-build a minimal fixture in code.** Best for unit tests that target
+a specific code path. The existing exporter tests under
+`__tests__/exporter/` ship small `point` / `linestring` / `lane` factory
+helpers you can copy.
 
 ```typescript
-// packages/drawtonomy-sdk/__tests__/exporter/my-feature.test.ts
+// __tests__/exporter/my-feature.test.ts
 import { describe, it, expect } from 'vitest'
 import { exportToOpenDrive } from '../../src/exporter/opendrive'
 import type { DrawtonomySnapshot } from '../../src/types'
@@ -120,22 +127,59 @@ function snapshot(shapes: any[]): DrawtonomySnapshot {
 describe('my new feature', () => {
   it('emits something specific', () => {
     const xml = exportToOpenDrive(snapshot([
-      // build the smallest scene that triggers your code path:
-      // a couple of points, a linestring, a lane, etc.
+      // smallest scene that triggers your code path
     ]))
     expect(xml).toContain('<expected-element>')
   })
 })
 ```
 
-Tips:
+**(2) Compose with SDK helpers.** When you want a realistic shape but don't
+want to write every property by hand, use `createPoint` / `createLinestring`
+/ `createLane` / `createLaneWithBoundaries` / `createVehicle` /
+`createPathWithFootprints` / `createSnapshot`.
 
-- Look at `__tests__/exporter/opendrive.test.ts` for ready-made `point` /
-  `linestring` / `lane` factory helpers you can copy.
-- Inspect the full output with `console.log(xml)` while you iterate. Once
-  the shape stabilizes, narrow the assertion down to the specific lines
-  you care about.
+```typescript
+import {
+  createLaneWithBoundaries,
+  createVehicle,
+  createSnapshot,
+} from '@drawtonomy/sdk'
+
+const shapes = [
+  ...createLaneWithBoundaries(
+    [{ x: 0, y: -5 }, { x: 100, y: -5 }],
+    [{ x: 0, y: 5 }, { x: 100, y: 5 }]
+  ),
+  createVehicle(50, 0, { templateId: 'sedan' }),
+]
+const snapshot = createSnapshot(shapes)
+```
+
+**(3) Reuse a real scene exported from drawtonomy.** Open
+[drawtonomy.com](https://drawtonomy.com), draw the scene, then **Menu →
+Export → drawtonomy.svg**. The downloaded file is a regular SVG with the
+full snapshot embedded; pass it through `parseDrawtonomySvg` to get back a
+`DrawtonomySnapshot`.
+
+```typescript
+import { readFileSync } from 'node:fs'
+import { parseDrawtonomySvg } from '@drawtonomy/sdk'
+
+const svg = readFileSync('./fixtures/my-scene.drawtonomy.svg', 'utf-8')
+const snapshot = parseDrawtonomySvg(svg)
+if (!snapshot) throw new Error('not a drawtonomy.svg file')
+```
+
+Saved `.drawtonomy.svg` fixtures make good regression-test inputs for
+"this real scene should produce this XML".
+
+#### Iteration tips
+
+- Inspect the full output with `console.log(xml)` while you iterate, then
+  narrow the assertion to the lines you care about once the shape stabilizes.
 - For larger XML diffs, switch to `expect(xml).toMatchInlineSnapshot()`.
+- Keep fixtures small — three points and one lane is usually enough.
 
 ### Validating the output with esmini
 
@@ -156,21 +200,28 @@ brew install esmini
 # Linux / Windows: see https://github.com/esmini/esmini
 ```
 
-#### 2. Generate a bundle from a fixture
+#### 2. Generate a bundle from a snapshot
+
+The simplest way is to start from a `.drawtonomy.svg` you exported from
+drawtonomy.com (see [How to obtain a snapshot](#how-to-obtain-a-snapshot)
+above). The same script works with hand-built or helper-composed snapshots.
 
 ```typescript
 // scripts/preview.mjs
-import { writeFileSync, mkdirSync } from 'node:fs'
-import { exporter } from '@drawtonomy/sdk'
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { parseDrawtonomySvg, exporter } from '@drawtonomy/sdk'
 
-const snapshot = {
-  version: '1.1',
-  timestamp: new Date().toISOString(),
-  shapes: [
-    // Build the smallest scene that exercises your change.
-    // Copy a fixture from __tests__/exporter/ as a starting point.
-  ],
-}
+// Option A: real scene from drawtonomy.com
+const svg = readFileSync('./fixtures/my-scene.drawtonomy.svg', 'utf-8')
+const snapshot = parseDrawtonomySvg(svg)
+if (!snapshot) throw new Error('not a drawtonomy.svg file')
+
+// Option B: snapshot composed in code (uncomment to use)
+// import { createLaneWithBoundaries, createVehicle, createSnapshot } from '@drawtonomy/sdk'
+// const snapshot = createSnapshot([
+//   ...createLaneWithBoundaries([{x:0,y:-5},{x:100,y:-5}], [{x:0,y:5},{x:100,y:5}]),
+//   createVehicle(50, 0, { templateId: 'sedan' }),
+// ])
 
 mkdirSync('out', { recursive: true })
 writeFileSync('out/scene.xodr', exporter.exportToOpenDrive(snapshot))
@@ -380,6 +431,24 @@ dependencies; works in browsers and Node.
 Returns an OS-safe base name (path separators / control chars replaced with
 underscores, length-capped at 100 chars), or `null` for inputs that reduce
 to empty.
+
+### `parseDrawtonomySvg(svg)` *(SDK root, not under `exporter`)*
+
+```typescript
+function parseDrawtonomySvg(svgContent: string): DrawtonomySnapshot | null
+```
+
+Reads a `.drawtonomy.svg` source string and returns the embedded
+`DrawtonomySnapshot`. Returns `null` for plain SVGs without an embedded
+snapshot, malformed payloads, or non-string inputs. Accepts both
+`data-drawtonomy-snapshot` (current) and `data-drawauto-snapshot` (legacy)
+attributes. Works in plain Node (no `DOMParser` / `jsdom` required).
+
+```typescript
+import { parseDrawtonomySvg } from '@drawtonomy/sdk'
+
+const snapshot = parseDrawtonomySvg(readFileSync('scene.drawtonomy.svg', 'utf-8'))
+```
 
 ---
 

--- a/docs/exporter.md
+++ b/docs/exporter.md
@@ -14,6 +14,7 @@ animation features, or entirely new target formats (CARLA, Unity, SUMO, …).
 
 - [Quick Start (User)](#quick-start-user)
 - [Quick Start (Developer)](#quick-start-developer)
+- [Local Development](#local-development)
 - [Architecture](#architecture)
 - [API Reference](#api-reference)
 - [Extending the Exporter](#extending-the-exporter)
@@ -61,6 +62,171 @@ const { blob, baseName } = exporter.buildEsminiZip(snapshot, {
 ```
 
 The exporter is pure: same input → same output, no editor or DOM access.
+
+---
+
+## Local Development
+
+This section is for contributors who want to **modify the exporter itself**.
+
+There are two complementary ways to develop:
+
+1. **Snapshot-driven** — write a snapshot fixture, run vitest, inspect the
+   generated XML. Fast iteration, no browser, ideal for new logic.
+2. **esmini visual check** — feed the generated `.xodr` / `.xosc` to esmini
+   and confirm the 3D playback matches expectations. Slower but catches
+   issues that pure XML assertions cannot.
+
+Most PRs start with (1), then run a fixture through (2) before opening the PR.
+
+### Setup
+
+```bash
+git clone https://github.com/kosuke55/drawtonomy.git
+cd drawtonomy
+pnpm install   # installs all workspace packages
+```
+
+The exporter source lives in `packages/drawtonomy-sdk/src/exporter/`.
+Tests live in `packages/drawtonomy-sdk/__tests__/exporter/`.
+
+### Snapshot-driven development (fast loop)
+
+The exporter is a set of pure functions over `DrawtonomySnapshot`, so you can
+exercise it entirely from vitest. No editor, no browser, no esmini — just
+"build a snapshot in code, call the exporter, assert on the XML string."
+
+```bash
+cd packages/drawtonomy-sdk
+
+pnpm test                       # one-shot
+pnpm exec vitest                # watch mode (re-runs on save)
+pnpm exec vitest exporter       # only the exporter test files
+pnpm build                      # tsc — catches type errors before you commit
+```
+
+Minimal test scaffold:
+
+```typescript
+// packages/drawtonomy-sdk/__tests__/exporter/my-feature.test.ts
+import { describe, it, expect } from 'vitest'
+import { exportToOpenDrive } from '../../src/exporter/opendrive'
+import type { DrawtonomySnapshot } from '../../src/types'
+
+function snapshot(shapes: any[]): DrawtonomySnapshot {
+  return { version: '1.1', timestamp: new Date().toISOString(), shapes }
+}
+
+describe('my new feature', () => {
+  it('emits something specific', () => {
+    const xml = exportToOpenDrive(snapshot([
+      // build the smallest scene that triggers your code path:
+      // a couple of points, a linestring, a lane, etc.
+    ]))
+    expect(xml).toContain('<expected-element>')
+  })
+})
+```
+
+Tips:
+
+- Look at `__tests__/exporter/opendrive.test.ts` for ready-made `point` /
+  `linestring` / `lane` factory helpers you can copy.
+- Inspect the full output with `console.log(xml)` while you iterate. Once
+  the shape stabilizes, narrow the assertion down to the specific lines
+  you care about.
+- For larger XML diffs, switch to `expect(xml).toMatchInlineSnapshot()`.
+
+### Validating the output with esmini
+
+vitest assertions catch behavioral regressions, but they cannot tell you
+whether esmini will actually render the output the way you expect. Once
+your snapshot tests pass, run the generated XML through esmini directly.
+
+You do not need to start drawtonomy or any browser for this — write a tiny
+script that produces a `.xodr` / `.xosc` pair from a snapshot fixture, then
+hand it to esmini.
+
+#### 1. Install esmini
+
+```bash
+# macOS
+brew install esmini
+
+# Linux / Windows: see https://github.com/esmini/esmini
+```
+
+#### 2. Generate a bundle from a fixture
+
+```typescript
+// scripts/preview.mjs
+import { writeFileSync, mkdirSync } from 'node:fs'
+import { exporter } from '@drawtonomy/sdk'
+
+const snapshot = {
+  version: '1.1',
+  timestamp: new Date().toISOString(),
+  shapes: [
+    // Build the smallest scene that exercises your change.
+    // Copy a fixture from __tests__/exporter/ as a starting point.
+  ],
+}
+
+mkdirSync('out', { recursive: true })
+writeFileSync('out/scene.xodr', exporter.exportToOpenDrive(snapshot))
+writeFileSync('out/scene.xosc', exporter.exportToOpenScenario(snapshot, {
+  xodrFilename: 'scene.xodr',
+}))
+console.log('wrote out/scene.{xodr,xosc}')
+```
+
+Run it once you have a fresh `pnpm build` from the SDK:
+
+```bash
+cd packages/drawtonomy-sdk && pnpm build
+node scripts/preview.mjs
+```
+
+#### 3. Open the result in esmini
+
+```bash
+esmini --osc out/scene.xosc --window 60 60 1024 768
+```
+
+What to check:
+
+- Lane geometry matches your fixture's intent.
+- Vehicles spawn at the expected positions and headings.
+- For trajectories, vehicles follow the path with the expected timing.
+- Open the XML files in a text editor; the comments emitted by the exporter
+  often help locate the relevant section.
+
+If esmini reports a parsing error, copy the line/column it prints and grep
+the corresponding part of the generated XML — most issues are off-by-one
+attributes or missing required fields, both easy to fix back in vitest.
+
+#### Going further: full canvas verification
+
+To verify the full chain (canvas → snapshot → exporter → esmini), use
+the published drawtonomy app at `https://drawtonomy.com` — draw your scene,
+hit **Export for esmini**, and feed the zip to esmini as above. The version
+of `@drawtonomy/sdk` available there matches the latest published release,
+so this flow is best used after your PR has been merged and the SDK has been
+re-published.
+
+### Writing tests
+
+Every behavioral change should land with a test. Conventions:
+
+- One spec file per source file: `opendrive.ts` ↔ `opendrive.test.ts`.
+- Tests are pure JS objects, not snapshots from the live editor — they stay
+  stable even if unrelated UI code moves around.
+- Prefer narrow assertions (`expect(xml).toContain(...)`) over full-XML
+  comparisons; the latter break on every cosmetic emit change.
+- For numerical outputs, use `toBeCloseTo` to tolerate floating-point noise.
+
+The CI job for `@drawtonomy/sdk` runs `pnpm build` and `pnpm test`; both
+must pass on PR.
 
 ---
 

--- a/docs/exporter.md
+++ b/docs/exporter.md
@@ -1,0 +1,332 @@
+# drawtonomy Exporter
+
+[日本語版はこちら](exporter.ja.md)
+
+The `exporter` sub-module of `@drawtonomy/sdk` converts a `DrawtonomySnapshot`
+into ASAM-format files (OpenDRIVE 1.8 / OpenSCENARIO 1.3) and esmini-ready
+zip bundles. It has no runtime dependency on the editor, so it can be used
+in headless tooling, server-side pipelines, browser extensions, or CI checks.
+
+This is the main extension point for adding support for new shapes,
+animation features, or entirely new target formats (CARLA, Unity, SUMO, …).
+
+## Table of Contents
+
+- [Quick Start (User)](#quick-start-user)
+- [Quick Start (Developer)](#quick-start-developer)
+- [Architecture](#architecture)
+- [API Reference](#api-reference)
+- [Extending the Exporter](#extending-the-exporter)
+- [Roadmap](#roadmap)
+
+---
+
+## Quick Start (User)
+
+1. Open drawtonomy and draw a scene (lanes, vehicles, traffic lights, …).
+2. Click the menu → **Export** → **Export for esmini**.
+3. Enter a file base name when prompted.
+4. A `<name>.zip` file is downloaded containing `<name>.xodr` and `<name>.xosc`.
+5. Unzip and run with esmini:
+
+   ```bash
+   unzip <name>.zip
+   esmini --osc <name>/<name>.xosc --window 60 60 1024 768
+   ```
+
+---
+
+## Quick Start (Developer)
+
+```bash
+pnpm add @drawtonomy/sdk
+```
+
+```typescript
+import { exporter, createSnapshot } from '@drawtonomy/sdk'
+
+// shapes is an array of BaseShape objects (see "Snapshot shape" below).
+const snapshot = createSnapshot(shapes)
+
+// Per-format strings.
+const xodr = exporter.exportToOpenDrive(snapshot)
+const xosc = exporter.exportToOpenScenario(snapshot, {
+  xodrFilename: 'scene.xodr',
+})
+
+// Convenience: bundle both into a single .zip ready for esmini.
+const { blob, baseName } = exporter.buildEsminiZip(snapshot, {
+  baseName: 'my-scene',
+})
+```
+
+The exporter is pure: same input → same output, no editor or DOM access.
+
+---
+
+## Architecture
+
+### Snapshot shape
+
+```typescript
+interface DrawtonomySnapshot {
+  version: string
+  timestamp: string
+  shapes: BaseShape[]   // points, linestrings, lanes, vehicles, …
+  camera?: { x: number; y: number; z: number }
+}
+```
+
+The exporter only reads from `shapes`. Each shape is a self-describing object
+with `id`, `type`, `x`, `y`, `rotation`, `props`. Lane geometry is referenced
+by id (a lane points to two boundary linestrings, which point to points), so
+the exporter resolves these via an internal id map.
+
+### Module layout
+
+```
+@drawtonomy/sdk/exporter/
+├── opendrive.ts        Lane / TrafficLight / Crosswalk / Polygon → .xodr
+├── openscenario.ts     Vehicle / Pedestrian / Path → .xosc
+├── trajectory.ts       Path → time-stamped vertex sequence
+├── laneCenterline.ts   Two boundary polylines → centerline + width samples
+├── packageEsmini.ts    .xodr + .xosc → single .zip
+├── zip.ts              Pure ZIP builder (store mode, no deps)
+├── sanitize.ts         OS-safe file base name normalization
+└── units.ts            Canvas px ↔ ENU meters, XML formatting helpers
+```
+
+### Coordinate conventions
+
+| Axis | drawtonomy canvas | OpenDRIVE / OpenSCENARIO (ENU) |
+|------|-------------------|-------------------------------|
+| x | right + | east + |
+| y | **down +** | **up +** (sign flipped) |
+| heading | CW positive (degrees) | CCW positive (radians) |
+| length unit | pixels | meters (`PIXELS_PER_METER = 16.67`) |
+
+Vehicle templates face canvas −Y by convention, so `rotation = 0` maps to
+ENU heading `π/2` (north). This offset is applied inside `exportToOpenScenario`.
+
+---
+
+## API Reference
+
+### `exportToOpenDrive(snapshot)`
+
+```typescript
+function exportToOpenDrive(snapshot: DrawtonomySnapshot): string
+```
+
+Returns an OpenDRIVE 1.8 XML string. Each `LaneShape` becomes a `<road>`;
+each `TrafficLightShape` becomes a `<signal>`; each `CrosswalkShape` and
+`PolygonShape` becomes an `<object>`. Lane connectivity (`next` / `prev`) is
+written as road-level and lane-level `<link>` elements. Junctions are not
+yet emitted (see [Roadmap](#roadmap)).
+
+### `exportToOpenScenario(snapshot, options?)`
+
+```typescript
+interface OpenScenarioExportOptions {
+  xodrFilename?: string          // referenced by <LogicFile>
+  scenarioName?: string
+  templateResolver?: TemplateResolver
+}
+
+function exportToOpenScenario(
+  snapshot: DrawtonomySnapshot,
+  options?: OpenScenarioExportOptions
+): string
+```
+
+Each `VehicleShape` becomes a `<ScenarioObject>` with category resolved from
+its `templateId`. Pedestrian templates emit `<Pedestrian>` instead of
+`<Vehicle>`. Path linestrings with footprints become a
+`<FollowTrajectoryAction>` story for the leading footprint vehicle.
+
+### `buildEsminiZip(snapshot, options?)`
+
+```typescript
+interface EsminiPackageOptions {
+  baseName?: string
+  templateResolver?: TemplateResolver
+}
+
+interface EsminiPackageResult {
+  blob: Blob
+  baseName: string
+}
+
+function buildEsminiZip(
+  snapshot: DrawtonomySnapshot,
+  options?: EsminiPackageOptions
+): EsminiPackageResult
+```
+
+Convenience that calls both exporters and packages the results as
+`<baseName>.zip` containing `<baseName>/<baseName>.xodr` and
+`<baseName>/<baseName>.xosc`. Filenames are kept consistent so the
+`<LogicFile>` reference inside the xosc resolves without renames.
+
+### `buildPathTrajectory(input)`
+
+```typescript
+interface PathTrajectoryInput {
+  points: { x: number; y: number }[]
+  tValues?: number[]                  // pre-computed normalized positions
+  interval?: number                   // px between samples
+  offset?: number                     // px from start
+  speedMps?: number                   // default 10
+}
+
+interface PathSamplePoint {
+  x: number       // ENU m
+  y: number       // ENU m
+  heading: number // ENU rad
+  time: number    // s
+}
+
+function buildPathTrajectory(input: PathTrajectoryInput): PathSamplePoint[]
+```
+
+Converts a polyline path into a time-stamped vertex sequence suitable for
+`<FollowTrajectoryAction>`. Three modes: `tValues` (pre-computed), `interval`
+(equal arc-length), or fallback (control points at constant speed).
+
+### `computeCenterlineWithWidth(left, right, numSamples?)`
+
+Samples both boundary polylines at the same normalized arc-length parameter
+and returns the per-sample midpoint + width. Used by the OpenDRIVE exporter
+to emit reference lines and `<width>` entries.
+
+### `buildZip(entries)`
+
+```typescript
+interface ZipEntry { path: string; data: string | Uint8Array }
+function buildZip(entries: ZipEntry[]): Blob
+```
+
+Pure PKZIP-compatible ZIP builder, store mode (no compression). No
+dependencies; works in browsers and Node.
+
+### `sanitizeFileBaseName(input)`
+
+Returns an OS-safe base name (path separators / control chars replaced with
+underscores, length-capped at 100 chars), or `null` for inputs that reduce
+to empty.
+
+---
+
+## Extending the Exporter
+
+The exporter is the recommended extension point because all of its logic
+operates on the public snapshot shape. Adding a new shape type, a new
+animation feature, or an entirely new target format usually requires
+changes only inside `packages/drawtonomy-sdk/src/exporter/`.
+
+### Add support for a new shape
+
+Example: emit `TrafficSignShape` as an OpenDRIVE `<signal>`.
+
+1. Make sure the shape's props are part of the public SDK type definitions
+   (`packages/drawtonomy-sdk/src/types.ts`). Extend if needed.
+2. In `opendrive.ts`, collect the new shape type in the main scan loop:
+
+   ```typescript
+   for (const s of shapes) {
+     // …existing branches…
+     else if (s.type === 'traffic_sign') trafficSigns.push(s as TrafficSignShape)
+   }
+   ```
+3. Project each shape onto the nearest road via `projectToRoad` (reuse the
+   existing helper) and emit a `<signal>` entry.
+4. Add a unit test in `packages/drawtonomy-sdk/__tests__/exporter/`.
+
+The same recipe applies to OpenSCENARIO: add a branch in `collectEntities` /
+`emitVehicleEntity` of `openscenario.ts`.
+
+### Add a new target format
+
+Example: a `carla.ts` adapter that emits CARLA-flavored OpenDRIVE.
+
+1. Add a new file `packages/drawtonomy-sdk/src/exporter/carla.ts`.
+2. Take a `DrawtonomySnapshot` as input. Reuse `laneCenterline.ts`,
+   `units.ts`, etc. as needed.
+3. Export from `packages/drawtonomy-sdk/src/exporter/index.ts`.
+4. Add tests covering the format-specific variations.
+
+The existing exporters intentionally do not share an interface — each format
+has its own quirks, so duplication is preferred over premature abstraction.
+A unifying interface will be considered once 3+ adapters exist.
+
+### TemplateResolver hook
+
+`exportToOpenScenario` accepts a `templateResolver` option for cases where
+the host knows about templates not bundled with the SDK:
+
+```typescript
+const resolver = {
+  resolveTemplateId: (id) => myLegacyMap[id] ?? id,
+  isPedestrianTemplate: (id) => /pedestrian|walk/.test(id),
+}
+exporter.exportToOpenScenario(snapshot, { templateResolver: resolver })
+```
+
+Default behavior covers the templates bundled with drawtonomy.
+
+### Coordinate / heading utilities
+
+Use the helpers in `units.ts` instead of recomputing conversions:
+
+```typescript
+import { pxToMeter, pxToEnuX, pxToEnuY, fmt, escapeXml } from './units'
+```
+
+This keeps the px-to-meter constant and the y-axis flip consistent across
+all exporters.
+
+---
+
+## Roadmap
+
+The following are anticipated as future contributions. None of them require
+changes outside of `packages/drawtonomy-sdk/src/exporter/`.
+
+### Shape coverage
+
+- `TrafficSign` → OpenDRIVE `<signal>` (stop / yield / speed limit)
+- `Others` (e.g. buildings) → OpenDRIVE `<object type="building">`
+- Bicycle template → `<Vehicle vehicleCategory="bicycle">`
+
+### Lane connectivity
+
+- Junction emission (`<junction>`) for lanes that share endpoints with 3+
+  other lanes. The required `next` / `prev` data is already present on
+  `LaneShape`.
+
+### Animation features
+
+- Acceleration profiles → `<SpeedActionDynamics>`
+- Dwell / stop events → `<StandStillCondition>`
+- Signal-aware paths → `<TrafficSignalCondition>`
+- Lane changes → `<LaneChangeAction>`
+- Multi-actor coordination → richer `<Storyboard>` structures
+
+### Additional formats
+
+- `carla.ts` — CARLA OpenDRIVE extensions, CARLA YAML scenarios
+- `unity-prefab.ts` — Unity prefab export
+- `sumo.ts` — SUMO road network + trip definitions
+
+### esmini operational notes
+
+The exporter has accumulated some implementation notes for esmini v3.0.x
+(crosswalk heading conventions, `scaleMode=ModelToBB`, polygon color
+limitations, …). These are currently inline comments in the exporter
+sources; consolidating them into a dedicated section of this document is
+welcome.
+
+---
+
+If you are planning a non-trivial contribution, opening an issue first is
+encouraged so the design can be discussed before implementation.


### PR DESCRIPTION
## Summary

Adds a developer guide for the `@drawtonomy/sdk` exporter sub-module so external contributors can extend OpenDRIVE / OpenSCENARIO output or add new target formats (CARLA, Unity, SUMO, …).

- `docs/exporter.md` (English) — full guide: user / developer quick starts, architecture, API reference, extension recipes, roadmap
- `docs/exporter.ja.md` (Japanese) — translated counterpart, same structure as `extensions.{md,ja.md}`
- README — adds a feature bullet, three rows in the Export/Import table, a small ASAM Export section under Export/Import, and a Documentation link next to the Extension Development Guide

The guide treats the exporter as the main extension point: contributors can add new shape support, animation features, or new target formats by editing only `packages/drawtonomy-sdk/src/exporter/`.

## Test plan

- [x] `docs/exporter.md` and `docs/exporter.ja.md` render cleanly on GitHub
- [x] All cross-links resolve
- [x] README links to the new docs from the Features list, the Export/Import section, and the Documentation footer