### PR TITLE
feat(sdk): add parseDrawtonomySvg

### DIFF
--- a/packages/drawtonomy-sdk/README.md
+++ b/packages/drawtonomy-sdk/README.md
@@ -120,6 +120,12 @@ http://localhost:3000/?ext=http://localhost:3001/manifest.json
 | `getBoundingBox(points)` | Get bounding box |
 | `distanceToSegment(point, a, b)` | Point-to-segment distance |
 
+### Snapshot
+
+| Function | Description |
+|----------|-------------|
+| `parseDrawtonomySvg(svg)` | Read a `.drawtonomy.svg` source string and return the embedded `DrawtonomySnapshot`, or `null` if absent / malformed |
+
 ### Exporter Module
 
 Convert a `DrawtonomySnapshot` into target-format strings (OpenDRIVE,

--- a/packages/drawtonomy-sdk/__tests__/snapshot.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/snapshot.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import { parseDrawtonomySvg } from '../src/snapshot'
+import type { DrawtonomySnapshot } from '../src/types'
+
+function encodePayload(snapshot: DrawtonomySnapshot): string {
+  const json = JSON.stringify(snapshot)
+  // Mirror the editor's encoder: btoa(unescape(encodeURIComponent(json))).
+  // In Node, Buffer.from(json, 'utf-8').toString('base64') produces the
+  // same result.
+  return Buffer.from(json, 'utf-8').toString('base64')
+}
+
+function makeSvg(attrName: string, payload: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" ${attrName}="${payload}">
+  <rect x="10" y="10" width="80" height="80" fill="red"/>
+</svg>`
+}
+
+const sampleSnapshot: DrawtonomySnapshot = {
+  version: '1.1',
+  timestamp: '2026-04-30T00:00:00Z',
+  shapes: [
+    {
+      id: 'p1',
+      type: 'point',
+      x: 10,
+      y: 20,
+      rotation: 0,
+      zIndex: 0,
+      props: { color: 'black', visible: true, osmId: '' },
+    },
+  ],
+}
+
+describe('parseDrawtonomySvg', () => {
+  it('returns the embedded snapshot from data-drawtonomy-snapshot', () => {
+    const svg = makeSvg('data-drawtonomy-snapshot', encodePayload(sampleSnapshot))
+    const out = parseDrawtonomySvg(svg)
+    expect(out).not.toBeNull()
+    expect(out!.version).toBe('1.1')
+    expect(out!.shapes).toHaveLength(1)
+    expect(out!.shapes[0].id).toBe('p1')
+  })
+
+  it('falls back to the legacy data-drawauto-snapshot attribute', () => {
+    const svg = makeSvg('data-drawauto-snapshot', encodePayload(sampleSnapshot))
+    const out = parseDrawtonomySvg(svg)
+    expect(out).not.toBeNull()
+    expect(out!.shapes[0].id).toBe('p1')
+  })
+
+  it('preserves multibyte content in shape props', () => {
+    const snapshot: DrawtonomySnapshot = {
+      ...sampleSnapshot,
+      shapes: [
+        {
+          id: 't1',
+          type: 'text',
+          x: 0,
+          y: 0,
+          rotation: 0,
+          zIndex: 0,
+          props: { text: '交差点', color: 'black' } as any,
+        },
+      ],
+    }
+    const svg = makeSvg('data-drawtonomy-snapshot', encodePayload(snapshot))
+    const out = parseDrawtonomySvg(svg)
+    expect(out).not.toBeNull()
+    expect((out!.shapes[0].props as any).text).toBe('交差点')
+  })
+
+  it('returns null for SVGs without an embedded snapshot', () => {
+    const svg = `<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>`
+    expect(parseDrawtonomySvg(svg)).toBeNull()
+  })
+
+  it('returns null when the embedded payload is not valid base64 JSON', () => {
+    const svg = makeSvg('data-drawtonomy-snapshot', 'not-base64-!!!')
+    expect(parseDrawtonomySvg(svg)).toBeNull()
+  })
+
+  it('returns null when the decoded payload is missing shapes[]', () => {
+    const bogus = Buffer.from(JSON.stringify({ version: '1.0' }), 'utf-8').toString('base64')
+    const svg = makeSvg('data-drawtonomy-snapshot', bogus)
+    expect(parseDrawtonomySvg(svg)).toBeNull()
+  })
+
+  it('returns null for non-string inputs', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(parseDrawtonomySvg(null as any)).toBeNull()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(parseDrawtonomySvg(undefined as any)).toBeNull()
+  })
+})

--- a/packages/drawtonomy-sdk/src/index.ts
+++ b/packages/drawtonomy-sdk/src/index.ts
@@ -3,5 +3,6 @@ export * from './types'
 export * from './helpers'
 export * from './geometry'
 export { ExtensionClient } from './ExtensionClient'
+export { parseDrawtonomySvg } from './snapshot'
 // Exporter sub-module is also available via "@drawtonomy/sdk/exporter".
 export * as exporter from './exporter'

--- a/packages/drawtonomy-sdk/src/snapshot.ts
+++ b/packages/drawtonomy-sdk/src/snapshot.ts
@@ -1,0 +1,62 @@
+// Parse a `.drawtonomy.svg` file (a regular SVG with a base64-encoded
+// snapshot embedded in `data-drawtonomy-snapshot`) back into a
+// DrawtonomySnapshot. The legacy attribute name `data-drawauto-snapshot`
+// is also accepted for backwards compatibility.
+
+import type { DrawtonomySnapshot } from './types'
+
+/**
+ * Decode a base64-encoded UTF-8 string. Mirrors the encoder used when the
+ * editor produces .drawtonomy.svg files: `btoa(unescape(encodeURIComponent(json)))`.
+ */
+function base64DecodeUtf8(encoded: string): string {
+  if (typeof atob === 'function') {
+    return decodeURIComponent(escape(atob(encoded)))
+  }
+  // Node fallback (Buffer is global in Node 18+).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const buf = (globalThis as any).Buffer
+  if (buf) {
+    return buf.from(encoded, 'base64').toString('utf-8')
+  }
+  throw new Error('No base64 decoder available in this environment')
+}
+
+/**
+ * Extract the value of an attribute from the root `<svg>` element of an SVG
+ * source string. Used instead of DOMParser so the parser works in plain
+ * Node without jsdom.
+ */
+function extractRootSvgAttribute(svg: string, attrName: string): string | null {
+  // Match the opening <svg ...> tag (allow line breaks inside).
+  const openTagMatch = svg.match(/<svg\b[^>]*>/)
+  if (!openTagMatch) return null
+  const openTag = openTagMatch[0]
+  const attrRegex = new RegExp(`\\b${attrName}="([^"]*)"`)
+  const m = openTag.match(attrRegex)
+  return m ? m[1] : null
+}
+
+/**
+ * Parse a `.drawtonomy.svg` source string and return the embedded
+ * DrawtonomySnapshot. Returns `null` if the file is not a drawtonomy SVG
+ * (e.g. plain SVG without an embedded snapshot) or the embedded payload is
+ * malformed.
+ */
+export function parseDrawtonomySvg(svgContent: string): DrawtonomySnapshot | null {
+  if (!svgContent || typeof svgContent !== 'string') return null
+
+  const encoded =
+    extractRootSvgAttribute(svgContent, 'data-drawtonomy-snapshot') ??
+    extractRootSvgAttribute(svgContent, 'data-drawauto-snapshot')
+  if (!encoded) return null
+
+  try {
+    const jsonString = base64DecodeUtf8(encoded)
+    const parsed = JSON.parse(jsonString) as DrawtonomySnapshot
+    if (!parsed || !Array.isArray(parsed.shapes)) return null
+    return parsed
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary

Adds `parseDrawtonomySvg` to `@drawtonomy/sdk`. It reads a `.drawtonomy.svg`
source string (a regular SVG with a base64-encoded snapshot embedded in the
root `<svg>` element) and returns the embedded `DrawtonomySnapshot`.

This unlocks the typical "round-trip from a real drawing" workflow for
external tooling: open drawtonomy.com → draw → Export → drawtonomy.svg →
load in Node / a browser extension / a CI script and run it through the
exporter or any other SDK consumer.

### Behavior

- Accepts both `data-drawtonomy-snapshot` (current) and `data-drawauto-snapshot` (legacy) attributes.
- Returns `null` for plain SVGs without an embedded snapshot, malformed payloads, or non-string inputs.
- Decoder works in plain Node (no `DOMParser` / `jsdom` required) and in browsers.

### Why a separate top-level export

The exporter sub-module is for "snapshot → format". Reading a snapshot back
is the inverse direction and conceptually orthogonal, so it lives at the
SDK root rather than under `exporter/`.

## Test plan

- [x] `pnpm --filter @drawtonomy/sdk test` — 119 tests passing (7 new for parseDrawtonomySvg)
- [x] `pnpm --filter @drawtonomy/sdk build` — clean tsc output
- [x] Round-trip test: encode a fixture snapshot to base64, embed it in an SVG string, parse it back, verify shapes and multibyte content survive