### PR TITLE
feat(sdk): add Lanelet2 exporter and OSM parser

### DIFF
--- a/docs/exporter.ja.md
+++ b/docs/exporter.ja.md
@@ -7,10 +7,12 @@
 [English](exporter.md)
 
 `@drawtonomy/sdk` の `exporter` サブモジュールは、`DrawtonomySnapshot` を
-ASAM 仕様のファイル (OpenDRIVE 1.8 / OpenSCENARIO 1.3) や esmini 用の zip
-バンドルに変換します。エディタランタイムへの依存はゼロなので、ヘッドレス
-ツール、サーバーサイドパイプライン、ブラウザ拡張、CI チェックなどから
-そのまま呼べます。
+ASAM 仕様のファイル (OpenDRIVE 1.8 / OpenSCENARIO 1.3)、esmini 用の zip
+バンドル、Lanelet2 (.osm XML) マップに変換します。エディタランタイムへの
+依存はゼロなので、ヘッドレスツール、サーバーサイドパイプライン、
+ブラウザ拡張、CI チェックなどからそのまま呼べます。Lanelet2 については
+OSM XML をエディタが扱える形式（point / linestring / lane）に戻すパーサも
+提供し、インポート / ラウンドトリップワークフローを実現します。
 
 新しいシェイプ対応、アニメーション仕様の拡張、別フォーマットアダプタ
 (CARLA / Unity / SUMO 等) を追加する際の主要な拡張ポイントです。
@@ -64,6 +66,13 @@ const xosc = exporter.exportToOpenScenario(snapshot, {
 const { blob, baseName } = exporter.buildEsminiZip(snapshot, {
   baseName: 'my-scene',
 })
+
+// Lanelet2 (.osm XML) のエクスポート + 再インポート
+const osm = exporter.exportToLanelet2(snapshot, {
+  mapOrigin: { lat: 35.0, lon: 139.0 },
+})
+const data = exporter.parseOsmXml(osm)
+const imported = exporter.osmToShapes(data)
 ```
 
 Exporter は純関数群です (同じ入力なら必ず同じ出力、エディタや DOM へのアクセスなし)。
@@ -373,6 +382,9 @@ Exporter 内部では id ルックアップ用 Map を作って解決してい�
 ├── trajectory.ts       Path → 時系列頂点列
 ├── laneCenterline.ts   2 本の境界ポリライン → 中心線 + 幅サンプル
 ├── packageEsmini.ts    .xodr + .xosc → 1 つの .zip
+├── lanelet2.ts         Snapshot → Lanelet2 .osm XML (sidecar によるラウンドトリップ対応)
+├── osmParser.ts        Lanelet2 .osm XML → 構造化データ + 緯度経度 ↔ canvas 投影
+├── osmToShapes.ts      OSM データ → エディタが扱う point / linestring / lane レコード
 ├── zip.ts              純 ZIP ビルダー (store mode、依存ゼロ)
 ├── sanitize.ts         OS セーフなファイル名サニタイズ
 └── units.ts            canvas px ↔ ENU m、XML 整形ヘルパ
@@ -496,6 +508,91 @@ Node どちらでも動作します。
 
 OS セーフなベース名 (path separator / 制御文字 → アンダースコア、
 最大 100 文字) を返します。空になる入力に対しては `null` を返します。
+
+### `exportToLanelet2(snapshot, options?)`
+
+```typescript
+interface OsmSidecar {
+  rawXml: string         // インポート時に保存した元の .osm XML
+  originLat: number
+  originLon: number
+}
+
+interface MapOrigin {
+  lat: number | null
+  lon: number | null
+}
+
+interface Lanelet2ExportOptions {
+  sidecar?: OsmSidecar | null
+  mapOrigin?: MapOrigin | null
+}
+
+function exportToLanelet2(
+  snapshot: DrawtonomySnapshot,
+  options?: Lanelet2ExportOptions
+): string
+```
+
+Lanelet2 `.osm` XML 文字列を返します。各 `PointShape` は `<node>`、各
+`LinestringShape` は `<way>`、各 `LaneShape` は `<relation type="lanelet">`
+として `<member role="left">` / `<member role="right">` で境界の way を参照
+する形で出力されます。
+
+`sidecar` (インポート時に保存した元の `.osm` XML) を渡すと、shape 由来でない
+要素 (regulatory_element、ele タグ、未編集 relation 等) が原文のまま保持され、
+shape 由来の要素は同じ OSM ID については上書きされます。ルートの `<osm>`
+要素には `drawtonomy_origin_lat` / `drawtonomy_origin_lon` が埋め込まれる
+ため、再インポート時に同じ canvas 原点が復元されます (標準の OSM
+コンシューマは未知の属性を無視します)。
+
+原点の優先順位: `sidecar` > `mapOrigin` > 組み込みのデフォルト。
+
+### `parseOsmXml(xml)`
+
+```typescript
+interface OsmData {
+  nodes: Map<string, OsmNode>
+  ways: Map<string, OsmWay>
+  relations: OsmRelation[]
+  drawtonomyOrigin?: { lat: number; lon: number }
+}
+
+function parseOsmXml(xmlString: string): OsmData
+```
+
+Lanelet2 `.osm` XML を構造化データへパースします。`DOMParser` がグローバルに
+存在する環境 (ブラウザ・jsdom) ではそれを使い、無い環境では OSM XML の
+サブセットに対応した手書き正規表現パーサにフォールバックするため、`jsdom`
+無しの素の Node でも動きます。lanelet 以外の relation (regulatory_element、
+multipolygon 等) もそのまま保持され、ラウンドトリップで失われません。
+
+### `osmToShapes(data, options?)`
+
+```typescript
+interface OsmToShapesOptions {
+  idAllocator?: ShapeIdAllocator
+  selectedLaneIds?: readonly string[]
+}
+
+function osmToShapes(data: OsmData, options?: OsmToShapesOptions): ImportedShapes
+```
+
+パース済み OSM データをエディタが扱う形式に変換します: 共有された point、
+境界 linestring、lane、それに bounding box と投影に使った地理原点を返します。
+レーンの方向は可能な限り維持され、左右関係 (right-of-left invariant) を満たす
+ためにのみ境界が反転されます。lane の前後接続 (`next` / `prev`) は境界の
+端点一致から検出されます。
+
+`selectedLaneIds` を渡すと指定した lanelet relation のみインポートされます。
+`createShapeIdAllocator` で作った独自の `idAllocator` を渡すことで、ホスト
+エディタ側のカウンタと ID を整合させられます。
+
+### `latLonToCanvas(lat, lon, centerLat, centerLon, scale?)` / `canvasToLatLon(...)`
+
+エクスポーターとインポーターの両方で使う等距円筒投影ヘルパ。デフォルトの
+`scale = 1_855_000` は 16.67 px/m に相当し、drawtonomy の見た目の寸法
+(3 m レーン = 50 px) と一致します。
 
 ### `parseDrawtonomySvg(svg)` *(SDK ルート、`exporter` サブモジュールではない)*
 

--- a/docs/exporter.md
+++ b/docs/exporter.md
@@ -7,9 +7,12 @@
 [日本語版はこちら](exporter.ja.md)
 
 The `exporter` sub-module of `@drawtonomy/sdk` converts a `DrawtonomySnapshot`
-into ASAM-format files (OpenDRIVE 1.8 / OpenSCENARIO 1.3) and esmini-ready
-zip bundles. It has no runtime dependency on the editor, so it can be used
-in headless tooling, server-side pipelines, browser extensions, or CI checks.
+into ASAM-format files (OpenDRIVE 1.8 / OpenSCENARIO 1.3), esmini-ready zip
+bundles, and Lanelet2 (.osm XML) maps. It has no runtime dependency on the
+editor, so it can be used in headless tooling, server-side pipelines, browser
+extensions, or CI checks. The Lanelet2 module additionally exposes a parser
+that turns OSM XML back into editor-ready primitives, enabling import /
+round-trip workflows.
 
 This is the main extension point for adding support for new shapes,
 animation features, or entirely new target formats (CARLA, Unity, SUMO, …).
@@ -63,6 +66,13 @@ const xosc = exporter.exportToOpenScenario(snapshot, {
 const { blob, baseName } = exporter.buildEsminiZip(snapshot, {
   baseName: 'my-scene',
 })
+
+// Lanelet2 (.osm XML) export and round-trip.
+const osm = exporter.exportToLanelet2(snapshot, {
+  mapOrigin: { lat: 35.0, lon: 139.0 },
+})
+const data = exporter.parseOsmXml(osm)
+const imported = exporter.osmToShapes(data)
 ```
 
 The exporter is pure: same input → same output, no editor or DOM access.
@@ -380,6 +390,9 @@ the exporter resolves these via an internal id map.
 ├── trajectory.ts       Path → time-stamped vertex sequence
 ├── laneCenterline.ts   Two boundary polylines → centerline + width samples
 ├── packageEsmini.ts    .xodr + .xosc → single .zip
+├── lanelet2.ts         Snapshot → Lanelet2 .osm XML (with sidecar round-trip)
+├── osmParser.ts        Lanelet2 .osm XML → structured data + lat/lon ↔ canvas projection
+├── osmToShapes.ts      OSM data → editor-ready point / linestring / lane records
 ├── zip.ts              Pure ZIP builder (store mode, no deps)
 ├── sanitize.ts         OS-safe file base name normalization
 └── units.ts            Canvas px ↔ ENU meters, XML formatting helpers
@@ -503,6 +516,91 @@ dependencies; works in browsers and Node.
 Returns an OS-safe base name (path separators / control chars replaced with
 underscores, length-capped at 100 chars), or `null` for inputs that reduce
 to empty.
+
+### `exportToLanelet2(snapshot, options?)`
+
+```typescript
+interface OsmSidecar {
+  rawXml: string         // original .osm XML captured at import time
+  originLat: number
+  originLon: number
+}
+
+interface MapOrigin {
+  lat: number | null
+  lon: number | null
+}
+
+interface Lanelet2ExportOptions {
+  sidecar?: OsmSidecar | null
+  mapOrigin?: MapOrigin | null
+}
+
+function exportToLanelet2(
+  snapshot: DrawtonomySnapshot,
+  options?: Lanelet2ExportOptions
+): string
+```
+
+Returns a Lanelet2 `.osm` XML document. Each `PointShape` becomes a `<node>`,
+each `LinestringShape` becomes a `<way>`, and each `LaneShape` becomes a
+`<relation type="lanelet">` with `<member role="left">` / `<member role="right">`
+referencing the boundary ways.
+
+When a `sidecar` (the original `.osm` XML captured at import time) is supplied,
+unrelated entries (regulatory_element, ele tags, untouched relations) are
+round-tripped verbatim; shape-derived entries override the sidecar copies for
+the same OSM IDs. The root `<osm>` element carries `drawtonomy_origin_lat` /
+`drawtonomy_origin_lon` so re-importing the file restores the same canvas
+origin (standard OSM consumers ignore unknown attributes).
+
+Origin precedence: `sidecar` > `mapOrigin` > built-in default.
+
+### `parseOsmXml(xml)`
+
+```typescript
+interface OsmData {
+  nodes: Map<string, OsmNode>
+  ways: Map<string, OsmWay>
+  relations: OsmRelation[]
+  drawtonomyOrigin?: { lat: number; lon: number }
+}
+
+function parseOsmXml(xmlString: string): OsmData
+```
+
+Parses Lanelet2 `.osm` XML into structured data. Uses the global `DOMParser`
+when available (browser, jsdom) and falls back to a hand-rolled regex parser
+sufficient for the OSM subset, so it works in plain Node without `jsdom`.
+Non-lanelet relations (regulatory_element, multipolygon, …) are kept as-is so
+they survive a round-trip.
+
+### `osmToShapes(data, options?)`
+
+```typescript
+interface OsmToShapesOptions {
+  idAllocator?: ShapeIdAllocator
+  selectedLaneIds?: readonly string[]
+}
+
+function osmToShapes(data: OsmData, options?: OsmToShapesOptions): ImportedShapes
+```
+
+Converts parsed OSM data into editor-ready records: shared points, boundary
+linestrings, lanes, plus a bounding box and the geographic origin used for the
+projection. Lane direction is preserved when possible; boundaries are flipped
+only when needed to keep the right-of-left invariant. Lane connectivity
+(`next` / `prev`) is detected by matching boundary endpoints.
+
+Pass `selectedLaneIds` to import only a subset of lanelet relations. Pass a
+custom `idAllocator` (built via `createShapeIdAllocator`) to coordinate IDs
+with the host editor's counters.
+
+### `latLonToCanvas(lat, lon, centerLat, centerLon, scale?)` / `canvasToLatLon(...)`
+
+Equirectangular projection helpers used by both the exporter and importer.
+The default `scale = 1_855_000` corresponds to 16.67 px/m, matching
+drawtonomy's visual sizing convention (3 m lane = 50 px).
 
 ### `parseDrawtonomySvg(svg)` *(SDK root, not under `exporter`)*
 

--- a/package.json
+++ b/package.json
@@ -2,5 +2,6 @@
   "packageManager": "pnpm@10.33.0",
   "dependencies": {
     "@drawtonomy/sdk": "workspace:*"
-  }
+  },
+  "version": "0.1.0"
 }

--- a/packages/drawtonomy-sdk/README.ja.md
+++ b/packages/drawtonomy-sdk/README.ja.md
@@ -118,6 +118,42 @@ https://drawtonomy.com?ext=http://localhost:3001/manifest.json
 | `getBoundingBox(points)` | バウンディングボックスを取得 |
 | `distanceToSegment(point, a, b)` | 点からセグメントまでの距離 |
 
+### Exporter モジュール
+
+`DrawtonomySnapshot` を OpenDRIVE / OpenSCENARIO / Lanelet2 OSM 形式の文字列に変換します。エディタランタイムに依存しないため、ヘッドレスツール、サーバーサイドパイプライン、ブラウザ拡張等から利用可能です。Lanelet2 については OSM XML をエディタが扱える形式（point / linestring / lane）に戻すパーサも提供し、ラウンドトリップを実現します。
+
+```typescript
+import { exporter, createSnapshot } from '@drawtonomy/sdk'
+
+const snapshot = createSnapshot(myShapes)
+const xodr = exporter.exportToOpenDrive(snapshot)
+const xosc = exporter.exportToOpenScenario(snapshot, { xodrFilename: 'scene.xodr' })
+
+// .xodr + .xosc を 1 つの zip にまとめて esmini で実行可能に
+const { blob, baseName } = exporter.buildEsminiZip(snapshot, { baseName: 'my-scene' })
+
+// Lanelet2 (.osm XML) のエクスポート + 再インポート
+const osm = exporter.exportToLanelet2(snapshot, { mapOrigin: { lat: 35.0, lon: 139.0 } })
+const data = exporter.parseOsmXml(osm)
+const imported = exporter.osmToShapes(data)
+```
+
+| 関数 | 説明 |
+|------|------|
+| `exporter.exportToOpenDrive(snapshot)` | OpenDRIVE 1.8 (.xodr) XML |
+| `exporter.exportToOpenScenario(snapshot, options?)` | OpenSCENARIO 1.3 (.xosc) XML |
+| `exporter.buildEsminiZip(snapshot, options?)` | .xodr + .xosc を 1 つの zip にまとめる |
+| `exporter.exportToLanelet2(snapshot, options?)` | Lanelet2 (.osm XML) ドキュメント |
+| `exporter.parseOsmXml(xml)` | Lanelet2 OSM XML を構造化データへパース |
+| `exporter.osmToShapes(data, options?)` | OSM → エディタが使う point / linestring / lane レコード |
+| `exporter.alignBoundaries(left, right)` | レーンの左右境界の反転フラグを判定 |
+| `exporter.createShapeIdAllocator()` | `osmToShapes` で使用する ID アロケータ |
+| `exporter.latLonToCanvas(lat, lon, ...)` / `canvasToLatLon(...)` | 等距円筒投影ヘルパ |
+| `exporter.buildPathTrajectory(input)` | Path → 時刻付き頂点列 |
+| `exporter.computeCenterlineWithWidth(left, right)` | レーン中心線 + 幅サンプル |
+| `exporter.buildZip(entries)` | 純粋な ZIP ビルダー (store mode、依存なし) |
+| `exporter.sanitizeFileBaseName(input)` | OS-safe なベース名サニタイザ |
+
 ## デプロイ
 
 エクステンションは任意のHTTPSホスティングサービスにデプロイできます。

--- a/packages/drawtonomy-sdk/README.md
+++ b/packages/drawtonomy-sdk/README.md
@@ -129,8 +129,11 @@ http://localhost:3000/?ext=http://localhost:3001/manifest.json
 ### Exporter Module
 
 Convert a `DrawtonomySnapshot` into target-format strings (OpenDRIVE,
-OpenSCENARIO) without depending on the editor runtime — useful for headless
-tooling, server-side pipelines, or browser extensions.
+OpenSCENARIO, Lanelet2 OSM) without depending on the editor runtime — useful
+for headless tooling, server-side pipelines, or browser extensions. The
+Lanelet2 module additionally exposes a parser that turns OSM XML back into
+editor-ready primitives (points / linestrings / lanes), enabling round-trip
+workflows.
 
 ```typescript
 import { exporter, createSnapshot } from '@drawtonomy/sdk'
@@ -141,6 +144,11 @@ const xosc = exporter.exportToOpenScenario(snapshot, { xodrFilename: 'scene.xodr
 
 // Bundle both into a single .zip ready for esmini.
 const { blob, baseName } = exporter.buildEsminiZip(snapshot, { baseName: 'my-scene' })
+
+// Lanelet2 (.osm XML) export and round-trip.
+const osm = exporter.exportToLanelet2(snapshot, { mapOrigin: { lat: 35.0, lon: 139.0 } })
+const data = exporter.parseOsmXml(osm)
+const imported = exporter.osmToShapes(data)
 ```
 
 | Function | Description |
@@ -148,6 +156,12 @@ const { blob, baseName } = exporter.buildEsminiZip(snapshot, { baseName: 'my-sce
 | `exporter.exportToOpenDrive(snapshot)` | OpenDRIVE 1.8 (.xodr) XML |
 | `exporter.exportToOpenScenario(snapshot, options?)` | OpenSCENARIO 1.3 (.xosc) XML |
 | `exporter.buildEsminiZip(snapshot, options?)` | One-shot zip bundling .xodr + .xosc |
+| `exporter.exportToLanelet2(snapshot, options?)` | Lanelet2 (.osm XML) document |
+| `exporter.parseOsmXml(xml)` | Parse Lanelet2 OSM XML into structured data |
+| `exporter.osmToShapes(data, options?)` | OSM → editor-ready point / linestring / lane records |
+| `exporter.alignBoundaries(left, right)` | Decide invert flags for a lane's left / right boundary |
+| `exporter.createShapeIdAllocator()` | Pluggable id allocator used by `osmToShapes` |
+| `exporter.latLonToCanvas(lat, lon, ...)` / `canvasToLatLon(...)` | Equirectangular projection helpers |
 | `exporter.buildPathTrajectory(input)` | Path → time-stamped vertex sequence |
 | `exporter.computeCenterlineWithWidth(left, right)` | Lane centerline + width samples |
 | `exporter.buildZip(entries)` | Pure ZIP builder (store mode, no deps) |

--- a/packages/drawtonomy-sdk/__tests__/exporter/lanelet2.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/lanelet2.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect } from 'vitest'
+import { exportToLanelet2, DEFAULT_ORIGIN_LAT, DEFAULT_ORIGIN_LON } from '../../src/exporter/lanelet2'
+import { parseOsmXml, latLonToCanvas, canvasToLatLon } from '../../src/exporter/osmParser'
+import { osmToShapes, alignBoundaries, createShapeIdAllocator } from '../../src/exporter/osmToShapes'
+import type { DrawtonomySnapshot } from '../../src/types'
+
+function snapshot(shapes: any[]): DrawtonomySnapshot {
+  return { version: '1.1', timestamp: new Date().toISOString(), shapes }
+}
+
+function point(id: string, x: number, y: number, osmId = '') {
+  return { id, type: 'point', x, y, rotation: 0, zIndex: 0, props: { color: 'black', visible: true, osmId } }
+}
+
+function linestring(id: string, pointIds: string[], osmId = '', attrs: Record<string, string> = {}) {
+  return {
+    id,
+    type: 'linestring',
+    x: 0,
+    y: 0,
+    rotation: 0,
+    zIndex: 0,
+    props: { pointIds, color: 'black', strokeWidth: 2, attributes: { type: 'line_thin', subtype: 'solid', ...attrs }, osmId },
+  }
+}
+
+function lane(id: string, leftId: string, rightId: string, osmId = '', extra: Record<string, string> = {}) {
+  return {
+    id,
+    type: 'lane',
+    x: 0,
+    y: 0,
+    rotation: 0,
+    zIndex: 0,
+    props: {
+      leftBoundaryId: leftId,
+      rightBoundaryId: rightId,
+      invertLeft: false,
+      invertRight: false,
+      color: 'default',
+      size: 'm',
+      attributes: { type: 'lanelet', subtype: 'road', speed_limit: '30', ...extra },
+      next: [],
+      prev: [],
+      osmId,
+    },
+  }
+}
+
+describe('parseOsmXml', () => {
+  const sample = `<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='drawtonomy' drawtonomy_origin_lat='35.0' drawtonomy_origin_lon='139.0'>
+  <node id='1' lat='35.000001' lon='139.000001' />
+  <node id='2' lat='35.000002' lon='139.000002'>
+    <tag k='ele' v='1.234' />
+  </node>
+  <way id='10'>
+    <nd ref='1' />
+    <nd ref='2' />
+    <tag k='type' v='line_thin' />
+    <tag k='subtype' v='solid' />
+  </way>
+  <relation id='100'>
+    <member type='way' ref='10' role='left' />
+    <member type='way' ref='10' role='right' />
+    <tag k='type' v='lanelet' />
+    <tag k='subtype' v='road' />
+  </relation>
+</osm>`
+
+  it('extracts nodes / ways / relations and the drawtonomy origin', () => {
+    const data = parseOsmXml(sample)
+    expect(data.nodes.size).toBe(2)
+    expect(data.nodes.get('2')?.ele).toBeCloseTo(1.234)
+    expect(data.ways.size).toBe(1)
+    expect(data.ways.get('10')?.nodeRefs).toEqual(['1', '2'])
+    expect(data.relations).toHaveLength(1)
+    expect(data.relations[0].tags.type).toBe('lanelet')
+    expect(data.drawtonomyOrigin).toEqual({ lat: 35.0, lon: 139.0 })
+  })
+
+  it('keeps non-lanelet relations (e.g. regulatory_element)', () => {
+    const xml = `<osm version='0.6'>
+      <relation id='200'>
+        <tag k='type' v='regulatory_element' />
+        <tag k='subtype' v='traffic_sign' />
+      </relation>
+    </osm>`
+    const data = parseOsmXml(xml)
+    expect(data.relations).toHaveLength(1)
+    expect(data.relations[0].tags.type).toBe('regulatory_element')
+  })
+
+  it('decodes XML entities in tag values', () => {
+    const xml = `<osm version='0.6'>
+      <node id='1' lat='0' lon='0'><tag k='name' v='A &amp; B' /></node>
+    </osm>`
+    const data = parseOsmXml(xml)
+    expect(data.nodes.get('1')?.tags.name).toBe('A & B')
+  })
+})
+
+describe('latLonToCanvas / canvasToLatLon', () => {
+  it('round-trips through the projection', () => {
+    const lat = 35.5
+    const lon = 139.6
+    const center = { lat: 35.0, lon: 139.0 }
+    const { x, y } = latLonToCanvas(lat, lon, center.lat, center.lon)
+    const back = canvasToLatLon(x, y, center.lat, center.lon)
+    expect(back.lat).toBeCloseTo(lat, 9)
+    expect(back.lon).toBeCloseTo(lon, 9)
+  })
+})
+
+describe('alignBoundaries', () => {
+  it('keeps both boundaries as-is when right is already on the right', () => {
+    const left = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ]
+    const right = [
+      { x: 0, y: 50 },
+      { x: 100, y: 50 },
+    ]
+    expect(alignBoundaries(left, right)).toEqual({ invertLeft: false, invertRight: false })
+  })
+
+  it('flips the right boundary when it points the opposite direction', () => {
+    const left = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ]
+    const right = [
+      { x: 100, y: 50 },
+      { x: 0, y: 50 },
+    ]
+    expect(alignBoundaries(left, right)).toEqual({ invertLeft: false, invertRight: true })
+  })
+})
+
+describe('exportToLanelet2', () => {
+  it('emits a valid OSM document with the embedded origin even with no shapes', () => {
+    const xml = exportToLanelet2(snapshot([]))
+    expect(xml).toMatch(/^<\?xml version='1\.0' encoding='UTF-8'\?>/)
+    expect(xml).toContain(`drawtonomy_origin_lat='${DEFAULT_ORIGIN_LAT.toFixed(11)}'`)
+    expect(xml).toContain(`drawtonomy_origin_lon='${DEFAULT_ORIGIN_LON.toFixed(11)}'`)
+    expect(xml.trim().endsWith('</osm>')).toBe(true)
+  })
+
+  it('honors mapOrigin when no sidecar is supplied', () => {
+    const xml = exportToLanelet2(snapshot([]), { mapOrigin: { lat: 36.0, lon: 140.0 } })
+    expect(xml).toContain(`drawtonomy_origin_lat='${(36.0).toFixed(11)}'`)
+    expect(xml).toContain(`drawtonomy_origin_lon='${(140.0).toFixed(11)}'`)
+  })
+
+  it('emits a node / way / relation triple for a single lane', () => {
+    const shapes = [
+      point('shape:point_0', 0, 0),
+      point('shape:point_1', 100, 0),
+      point('shape:point_2', 0, 50),
+      point('shape:point_3', 100, 50),
+      linestring('shape:linestring_0', ['shape:point_0', 'shape:point_1']),
+      linestring('shape:linestring_1', ['shape:point_2', 'shape:point_3']),
+      lane('shape:lane_0', 'shape:linestring_0', 'shape:linestring_1'),
+    ]
+    const xml = exportToLanelet2(snapshot(shapes))
+    const data = parseOsmXml(xml)
+    expect(data.nodes.size).toBe(4)
+    expect(data.ways.size).toBe(2)
+    expect(data.relations).toHaveLength(1)
+    expect(data.relations[0].tags.type).toBe('lanelet')
+    const wayMembers = data.relations[0].members.filter(m => m.type === 'way')
+    expect(wayMembers.map(m => m.role).sort()).toEqual(['left', 'right'])
+  })
+
+  it('preserves non-lanelet sidecar relations on round-trip', () => {
+    const sidecar = `<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='drawtonomy' drawtonomy_origin_lat='35.0' drawtonomy_origin_lon='139.0'>
+  <relation id='999'>
+    <tag k='type' v='regulatory_element' />
+    <tag k='subtype' v='traffic_sign' />
+  </relation>
+</osm>`
+    const xml = exportToLanelet2(snapshot([]), {
+      sidecar: { rawXml: sidecar, originLat: 35.0, originLon: 139.0 },
+    })
+    const data = parseOsmXml(xml)
+    expect(data.relations.find(r => r.id === '999')?.tags.type).toBe('regulatory_element')
+  })
+
+  it('overrides sidecar way coordinates when shape position changes', () => {
+    // Original sidecar places node 1 at lat/lon (35.0, 139.0).
+    const sidecar = `<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='drawtonomy' drawtonomy_origin_lat='35.0' drawtonomy_origin_lon='139.0'>
+  <node id='1' lat='35.0' lon='139.0' />
+</osm>`
+    // Shape places same osmId='1' at canvas (100, 0). Coordinates should be
+    // overwritten by the shape (with sidecar tags carried over).
+    const shapes = [point('shape:point_0', 100, 0, '1')]
+    const xml = exportToLanelet2(snapshot(shapes), {
+      sidecar: { rawXml: sidecar, originLat: 35.0, originLon: 139.0 },
+    })
+    const data = parseOsmXml(xml)
+    const node = data.nodes.get('1')!
+    expect(node.lon).toBeGreaterThan(139.0)
+  })
+})
+
+describe('osmToShapes', () => {
+  it('imports a single lane with two boundaries and four points', () => {
+    const allocator = createShapeIdAllocator()
+    const exported = exportToLanelet2(snapshot([
+      point('p0', 0, 0),
+      point('p1', 100, 0),
+      point('p2', 0, 50),
+      point('p3', 100, 50),
+      linestring('l0', ['p0', 'p1']),
+      linestring('l1', ['p2', 'p3']),
+      lane('lane0', 'l0', 'l1'),
+    ]))
+    const data = parseOsmXml(exported)
+    const result = osmToShapes(data, { idAllocator: allocator })
+    expect(result.points).toHaveLength(4)
+    expect(result.linestrings).toHaveLength(2)
+    expect(result.lanes).toHaveLength(1)
+    expect(result.lanes[0].leftBoundaryId).toBe(result.linestrings[0].id)
+  })
+
+  it('honors selectedLaneIds to restrict imported lanes', () => {
+    // Two independent lanes.
+    const xml = exportToLanelet2(snapshot([
+      point('p0', 0, 0, 'n0'),
+      point('p1', 100, 0, 'n1'),
+      point('p2', 0, 50, 'n2'),
+      point('p3', 100, 50, 'n3'),
+      linestring('l0', ['p0', 'p1'], 'w0'),
+      linestring('l1', ['p2', 'p3'], 'w1'),
+      lane('lane0', 'l0', 'l1', 'r0'),
+      point('p4', 200, 0, 'n4'),
+      point('p5', 300, 0, 'n5'),
+      point('p6', 200, 50, 'n6'),
+      point('p7', 300, 50, 'n7'),
+      linestring('l2', ['p4', 'p5'], 'w2'),
+      linestring('l3', ['p6', 'p7'], 'w3'),
+      lane('lane1', 'l2', 'l3', 'r1'),
+    ]))
+    const data = parseOsmXml(xml)
+    const result = osmToShapes(data, { selectedLaneIds: ['r0'] })
+    expect(result.lanes).toHaveLength(1)
+    expect(result.lanes[0].osmId).toBe('r0')
+  })
+
+  it('detects next/prev when two lanes share an end node', () => {
+    // Two collinear lanes that meet at x=100.
+    const xml = exportToLanelet2(snapshot([
+      point('p0', 0, 0, 'n0'),
+      point('p1', 100, 0, 'n1'),
+      point('p2', 0, 50, 'n2'),
+      point('p3', 100, 50, 'n3'),
+      linestring('l0', ['p0', 'p1'], 'w0'),
+      linestring('l1', ['p2', 'p3'], 'w1'),
+      lane('lane0', 'l0', 'l1', 'r0'),
+      // Second lane reuses the meeting nodes (n1, n3) as its start.
+      point('p4', 200, 0, 'n4'),
+      point('p5', 200, 50, 'n5'),
+      linestring('l2', ['p1', 'p4'], 'w2'),
+      linestring('l3', ['p3', 'p5'], 'w3'),
+      lane('lane1', 'l2', 'l3', 'r1'),
+    ]))
+    const data = parseOsmXml(xml)
+    const result = osmToShapes(data)
+    const first = result.lanes.find(l => l.osmId === 'r0')!
+    const second = result.lanes.find(l => l.osmId === 'r1')!
+    expect(first.next).toContain(second.id)
+    expect(second.prev).toContain(first.id)
+  })
+})
+
+describe('round-trip', () => {
+  it('preserves canvas coordinates when sidecar origin is honored', () => {
+    const original = snapshot([
+      point('p0', 12.5, -7.25),
+      point('p1', 100.75, 33.5),
+      linestring('l0', ['p0', 'p1']),
+    ])
+    const xml = exportToLanelet2(original, { mapOrigin: { lat: 35.0, lon: 139.0 } })
+
+    // Re-parse with the same origin and check canvas coords come back.
+    const data = parseOsmXml(xml)
+    const allocator = createShapeIdAllocator()
+    const result = osmToShapes(data, { idAllocator: allocator })
+
+    // No lanes (only points + linestring), so points list is empty (osmToShapes only emits points used by lanes).
+    // But round-trip lat/lon precision check:
+    const node0 = Array.from(data.nodes.values())[0]
+    const back = canvasToLatLon(12.5, -7.25, 35.0, 139.0)
+    expect(node0.lat).toBeCloseTo(back.lat, 9)
+    expect(node0.lon).toBeCloseTo(back.lon, 9)
+
+    // Sanity: importer produces a sane originLatLon when shapes exist.
+    expect(result.points.length).toBe(0)  // no lanelet relation -> no points imported
+  })
+})

--- a/packages/drawtonomy-sdk/package.json
+++ b/packages/drawtonomy-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drawtonomy/sdk",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "SDK for building drawtonomy extensions",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/drawtonomy-sdk/package.json
+++ b/packages/drawtonomy-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drawtonomy/sdk",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "SDK for building drawtonomy extensions",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/drawtonomy-sdk/src/exporter/index.ts
+++ b/packages/drawtonomy-sdk/src/exporter/index.ts
@@ -1,9 +1,11 @@
 // drawtonomy SDK — exporter modules.
 //
 // These exporters convert a `DrawtonomySnapshot` into target-format strings
-// (OpenDRIVE / OpenSCENARIO) without depending on the editor runtime, so
-// they can be used in headless tooling, server-side pipelines, or browser
-// extensions.
+// (OpenDRIVE / OpenSCENARIO / Lanelet2 OSM) without depending on the editor
+// runtime, so they can be used in headless tooling, server-side pipelines, or
+// browser extensions. The Lanelet2 module additionally exposes a parser that
+// turns OSM XML back into editor-ready primitives (points / linestrings /
+// lanes), enabling round-trip workflows.
 
 export { exportToOpenDrive } from './opendrive'
 export {
@@ -29,3 +31,32 @@ export { buildEsminiZip, type EsminiPackageOptions, type EsminiPackageResult } f
 export { buildZip, type ZipEntry } from './zip'
 export { sanitizeFileBaseName } from './sanitize'
 export { PIXELS_PER_METER } from './units'
+export {
+  exportToLanelet2,
+  DEFAULT_ORIGIN_LAT,
+  DEFAULT_ORIGIN_LON,
+  type Lanelet2ExportOptions,
+  type OsmSidecar,
+  type MapOrigin,
+} from './lanelet2'
+export {
+  parseOsmXml,
+  latLonToCanvas,
+  canvasToLatLon,
+  type OsmData,
+  type OsmNode,
+  type OsmWay,
+  type OsmRelation,
+} from './osmParser'
+export {
+  osmToShapes,
+  alignBoundaries,
+  createShapeIdAllocator,
+  type ImportedShapes,
+  type ImportedPoint,
+  type ImportedLinestring,
+  type ImportedLane,
+  type ImportBounds,
+  type OsmToShapesOptions,
+  type ShapeIdAllocator,
+} from './osmToShapes'

--- a/packages/drawtonomy-sdk/src/exporter/lanelet2.ts
+++ b/packages/drawtonomy-sdk/src/exporter/lanelet2.ts
@@ -1,0 +1,324 @@
+// Lanelet2 (.osm XML) exporter — emits an OSM document from a snapshot.
+// No external library dependencies.
+//
+// Behavior summary:
+// - Each PointShape becomes a `<node>`
+// - Each LinestringShape becomes a `<way>` referencing its point nodes
+// - Each LaneShape becomes a `<relation type=lanelet>` referencing its
+//   left/right way as members
+// - When a sidecar (the original OSM XML captured at import time) is supplied,
+//   tags / `ele` / unrelated relations (regulatory_element etc.) are
+//   round-tripped: shape-derived entries override the sidecar copies for the
+//   same OSM IDs, and untouched entries are emitted verbatim in the original
+//   order.
+// - The root `<osm>` element carries `drawtonomy_origin_lat` /
+//   `drawtonomy_origin_lon` so re-importing the file restores the same canvas
+//   origin. Standard OSM consumers ignore unknown attributes.
+
+import type {
+  BaseShape,
+  DrawtonomySnapshot,
+  LaneProps,
+  LinestringProps,
+  PointProps,
+} from '../types'
+import { canvasToLatLon, parseOsmXml, type OsmData } from './osmParser'
+
+type LaneShape = BaseShape<'lane', LaneProps>
+type LinestringShape = BaseShape<'linestring', LinestringProps>
+type PointShape = BaseShape<'point', PointProps>
+
+/** Sidecar captured at OSM import time. Used to round-trip tags / `ele`. */
+export interface OsmSidecar {
+  rawXml: string
+  originLat: number
+  originLon: number
+}
+
+/** Origin to use when no sidecar is provided. */
+export interface MapOrigin {
+  lat: number | null
+  lon: number | null
+}
+
+export interface Lanelet2ExportOptions {
+  sidecar?: OsmSidecar | null
+  mapOrigin?: MapOrigin | null
+}
+
+/**
+ * Default origin used when neither a sidecar nor a map origin is supplied.
+ * Tokyo Teleport Station — picked because it is in a flat area visible at
+ * default zoom on most map providers.
+ */
+export const DEFAULT_ORIGIN_LAT = 35.62614
+export const DEFAULT_ORIGIN_LON = 139.77525
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+function formatLatLon(v: number): string {
+  // 11 decimal places ≈ 0.1 mm precision.
+  return v.toFixed(11)
+}
+
+function formatEle(v: number): string {
+  // 3 decimal places = 1 mm precision.
+  return v.toFixed(3)
+}
+
+interface NodeOut {
+  id: string
+  lat: number
+  lon: number
+  ele?: number
+  tags: Record<string, string>
+}
+
+interface WayOut {
+  id: string
+  nodeRefs: string[]
+  tags: Record<string, string>
+}
+
+interface RelationOut {
+  id: string
+  members: { type: string; ref: string; role: string }[]
+  tags: Record<string, string>
+}
+
+function buildShapeMap(shapes: readonly BaseShape[]): Map<string, BaseShape> {
+  const map = new Map<string, BaseShape>()
+  for (const s of shapes) map.set(s.id, s)
+  return map
+}
+
+function buildFromShapes(
+  shapes: readonly BaseShape[],
+  originLat: number,
+  originLon: number,
+  sidecarData: OsmData | null
+): {
+  nodes: Map<string, NodeOut>
+  ways: Map<string, WayOut>
+  relations: RelationOut[]
+  shapeNodeOsmIds: Set<string>
+  shapeWayOsmIds: Set<string>
+  shapeRelationOsmIds: Set<string>
+} {
+  const shapeMap = buildShapeMap(shapes)
+  const points: PointShape[] = []
+  const linestrings: LinestringShape[] = []
+  const lanes: LaneShape[] = []
+  for (const s of shapes) {
+    if (s.type === 'point') points.push(s as unknown as PointShape)
+    else if (s.type === 'linestring') linestrings.push(s as unknown as LinestringShape)
+    else if (s.type === 'lane') lanes.push(s as unknown as LaneShape)
+  }
+
+  const nodesOut = new Map<string, NodeOut>()
+  const waysOut = new Map<string, WayOut>()
+  const relationsOut: RelationOut[] = []
+
+  const shapeNodeOsmIds = new Set<string>()
+  const shapeWayOsmIds = new Set<string>()
+  const shapeRelationOsmIds = new Set<string>()
+
+  // Resolve a shape -> OSM ID. Empty `osmId` (newly drawn shape) gets a fresh
+  // negative ID, matching the OSM convention for unsubmitted edits.
+  let nextNewId = -1
+  const newIdFor = new Map<string, string>()
+  const resolveOsmId = (shapeId: string, propsOsmId: string | undefined): string => {
+    if (propsOsmId && propsOsmId.length > 0) return propsOsmId
+    const cached = newIdFor.get(shapeId)
+    if (cached !== undefined) return cached
+    const id = String(nextNewId--)
+    newIdFor.set(shapeId, id)
+    return id
+  }
+
+  // Points -> nodes.
+  for (const p of points) {
+    const osmId = resolveOsmId(p.id, p.props.osmId)
+    shapeNodeOsmIds.add(osmId)
+    const { lat, lon } = canvasToLatLon(p.x, p.y, originLat, originLon)
+    const original = sidecarData?.nodes.get(osmId)
+    const tags = original ? { ...original.tags } : {}
+    const ele = original?.ele
+    nodesOut.set(osmId, { id: osmId, lat, lon, ele, tags })
+  }
+
+  // Linestrings -> ways.
+  for (const ls of linestrings) {
+    const osmId = resolveOsmId(ls.id, ls.props.osmId)
+    shapeWayOsmIds.add(osmId)
+    const nodeRefs: string[] = []
+    for (const pid of ls.props.pointIds) {
+      const point = shapeMap.get(pid) as unknown as PointShape | undefined
+      if (!point) continue
+      nodeRefs.push(resolveOsmId(point.id, point.props.osmId))
+    }
+    const original = sidecarData?.ways.get(osmId)
+    const tags: Record<string, string> = original ? { ...original.tags } : {}
+    if (ls.props.attributes) {
+      for (const [k, v] of Object.entries(ls.props.attributes)) {
+        if (v !== undefined && v !== null && v !== '') tags[k] = String(v)
+      }
+    }
+    if (!tags.type) tags.type = 'line_thin'
+    waysOut.set(osmId, { id: osmId, nodeRefs, tags })
+  }
+
+  // Lanes -> relations (type=lanelet).
+  for (const lane of lanes) {
+    const osmId = resolveOsmId(lane.id, lane.props.osmId)
+    shapeRelationOsmIds.add(osmId)
+
+    const original = sidecarData?.relations.find(r => r.id === osmId)
+    const members: { type: string; ref: string; role: string }[] = []
+
+    let leftWayId: string | null = null
+    let rightWayId: string | null = null
+    if (lane.props.leftBoundaryId) {
+      const leftLs = shapeMap.get(lane.props.leftBoundaryId) as unknown as LinestringShape | undefined
+      if (leftLs) leftWayId = resolveOsmId(leftLs.id, leftLs.props.osmId)
+    }
+    if (lane.props.rightBoundaryId) {
+      const rightLs = shapeMap.get(lane.props.rightBoundaryId) as unknown as LinestringShape | undefined
+      if (rightLs) rightWayId = resolveOsmId(rightLs.id, rightLs.props.osmId)
+    }
+
+    if (original) {
+      // Preserve the original member order; only refresh left/right refs.
+      for (const m of original.members) {
+        if (m.type === 'way' && m.role === 'left' && leftWayId) {
+          members.push({ type: 'way', ref: leftWayId, role: 'left' })
+        } else if (m.type === 'way' && m.role === 'right' && rightWayId) {
+          members.push({ type: 'way', ref: rightWayId, role: 'right' })
+        } else {
+          members.push({ ...m })
+        }
+      }
+    } else {
+      if (leftWayId) members.push({ type: 'way', ref: leftWayId, role: 'left' })
+      if (rightWayId) members.push({ type: 'way', ref: rightWayId, role: 'right' })
+    }
+
+    const tags: Record<string, string> = original ? { ...original.tags } : {}
+    if (lane.props.attributes) {
+      for (const [k, v] of Object.entries(lane.props.attributes)) {
+        if (v !== undefined && v !== null && v !== '') tags[k] = String(v)
+      }
+    }
+    if (!tags.type) tags.type = 'lanelet'
+    relationsOut.push({ id: osmId, members, tags })
+  }
+
+  return { nodes: nodesOut, ways: waysOut, relations: relationsOut, shapeNodeOsmIds, shapeWayOsmIds, shapeRelationOsmIds }
+}
+
+function nodeToXml(node: NodeOut): string {
+  const tags: string[] = []
+  // `ele` is emitted as a tag (Lanelet2 OSM convention).
+  const tagEntries = Object.entries(node.tags).filter(([k]) => k !== 'ele')
+  if (node.ele !== undefined) {
+    tags.push(`    <tag k='ele' v='${escapeXml(formatEle(node.ele))}' />`)
+  } else if (node.tags.ele !== undefined) {
+    tags.push(`    <tag k='ele' v='${escapeXml(node.tags.ele)}' />`)
+  }
+  for (const [k, v] of tagEntries) {
+    tags.push(`    <tag k='${escapeXml(k)}' v='${escapeXml(v)}' />`)
+  }
+  if (tags.length === 0) {
+    return `  <node id='${escapeXml(node.id)}' visible='true' version='1' lat='${formatLatLon(node.lat)}' lon='${formatLatLon(node.lon)}' />\n`
+  }
+  let xml = `  <node id='${escapeXml(node.id)}' visible='true' version='1' lat='${formatLatLon(node.lat)}' lon='${formatLatLon(node.lon)}'>\n`
+  xml += tags.join('\n') + '\n'
+  xml += `  </node>\n`
+  return xml
+}
+
+function wayToXml(way: WayOut): string {
+  let xml = `  <way id='${escapeXml(way.id)}' visible='true' version='1'>\n`
+  for (const ref of way.nodeRefs) {
+    xml += `    <nd ref='${escapeXml(ref)}' />\n`
+  }
+  for (const [k, v] of Object.entries(way.tags)) {
+    xml += `    <tag k='${escapeXml(k)}' v='${escapeXml(v)}' />\n`
+  }
+  xml += `  </way>\n`
+  return xml
+}
+
+function relationToXml(rel: RelationOut): string {
+  let xml = `  <relation id='${escapeXml(rel.id)}' visible='true' version='1'>\n`
+  for (const m of rel.members) {
+    xml += `    <member type='${escapeXml(m.type)}' ref='${escapeXml(m.ref)}' role='${escapeXml(m.role)}' />\n`
+  }
+  for (const [k, v] of Object.entries(rel.tags)) {
+    xml += `    <tag k='${escapeXml(k)}' v='${escapeXml(v)}' />\n`
+  }
+  xml += `  </relation>\n`
+  return xml
+}
+
+/** Build a Lanelet2 OSM XML document from a snapshot. */
+export function exportToLanelet2(
+  snapshot: DrawtonomySnapshot,
+  options: Lanelet2ExportOptions = {}
+): string {
+  const { sidecar = null, mapOrigin = null } = options
+
+  // Sidecar wins (= round-trip from import). Otherwise fall back to the
+  // current map origin, then DEFAULT.
+  let originLat: number
+  let originLon: number
+  if (sidecar) {
+    originLat = sidecar.originLat
+    originLon = sidecar.originLon
+  } else {
+    originLat = mapOrigin?.lat ?? DEFAULT_ORIGIN_LAT
+    originLon = mapOrigin?.lon ?? DEFAULT_ORIGIN_LON
+  }
+
+  const sidecarData: OsmData | null = sidecar ? parseOsmXml(sidecar.rawXml) : null
+  const fromShapes = buildFromShapes(snapshot.shapes, originLat, originLon, sidecarData)
+
+  // Combine: sidecar entries (skipping IDs that shapes overwrite) + shape-derived entries.
+  // Sidecar order is preserved to keep round-trips stable.
+  const finalNodes: NodeOut[] = []
+  const finalWays: WayOut[] = []
+  const finalRelations: RelationOut[] = []
+  if (sidecarData) {
+    sidecarData.nodes.forEach((n, id) => {
+      if (fromShapes.shapeNodeOsmIds.has(id)) return
+      finalNodes.push({ id, lat: n.lat, lon: n.lon, ele: n.ele, tags: n.tags })
+    })
+    sidecarData.ways.forEach((w, id) => {
+      if (fromShapes.shapeWayOsmIds.has(id)) return
+      finalWays.push({ id, nodeRefs: w.nodeRefs, tags: w.tags })
+    })
+    for (const r of sidecarData.relations) {
+      if (fromShapes.shapeRelationOsmIds.has(r.id)) continue
+      finalRelations.push({ id: r.id, members: r.members.map(m => ({ ...m })), tags: r.tags })
+    }
+  }
+
+  fromShapes.nodes.forEach(n => finalNodes.push(n))
+  fromShapes.ways.forEach(w => finalWays.push(w))
+  for (const r of fromShapes.relations) finalRelations.push(r)
+
+  let xml = `<?xml version='1.0' encoding='UTF-8'?>\n`
+  xml += `<osm version='0.6' generator='drawtonomy' drawtonomy_origin_lat='${formatLatLon(originLat)}' drawtonomy_origin_lon='${formatLatLon(originLon)}'>\n`
+  for (const n of finalNodes) xml += nodeToXml(n)
+  for (const w of finalWays) xml += wayToXml(w)
+  for (const r of finalRelations) xml += relationToXml(r)
+  xml += `</osm>\n`
+  return xml
+}

--- a/packages/drawtonomy-sdk/src/exporter/osmParser.ts
+++ b/packages/drawtonomy-sdk/src/exporter/osmParser.ts
@@ -1,0 +1,317 @@
+// Lanelet2 OSM (.osm XML) parser.
+//
+// The Lanelet2 format reuses OpenStreetMap's `<node>` / `<way>` / `<relation>`
+// tag structure but with traffic-domain semantics:
+//   - <node>      : a 2D point in lat/lon (optionally with `ele` tag for height)
+//   - <way>       : an ordered list of node refs forming a polyline
+//                   (used for lane boundaries, stop lines, etc.)
+//   - <relation>  : a typed grouping of ways/nodes
+//                   (`type=lanelet` joins a left + right way as a lane;
+//                    `type=regulatory_element` etc. are kept untouched)
+//
+// drawtonomy-emitted files additionally embed `drawtonomy_origin_lat` and
+// `drawtonomy_origin_lon` attributes on the root `<osm>` element so that the
+// canvas page coordinates can be reconstructed exactly on round-trip. Standard
+// OSM consumers ignore unknown attributes, keeping the file compatible.
+//
+// The parser is intentionally hand-written so it works in a plain Node runtime
+// without a DOM. When a global `DOMParser` is available (e.g. in a browser or
+// when jsdom is installed), it is used for robustness; otherwise a regex-based
+// fallback parses the same subset of OSM XML used by Lanelet2.
+
+export interface OsmNode {
+  id: string
+  lat: number
+  lon: number
+  ele?: number
+  tags: Record<string, string>
+}
+
+export interface OsmWay {
+  id: string
+  nodeRefs: string[]
+  tags: Record<string, string>
+}
+
+export interface OsmRelation {
+  id: string
+  members: { type: string; ref: string; role: string }[]
+  tags: Record<string, string>
+}
+
+export interface OsmData {
+  nodes: Map<string, OsmNode>
+  ways: Map<string, OsmWay>
+  relations: OsmRelation[]
+  /**
+   * drawtonomy-emitted `<osm drawtonomy_origin_lat=... drawtonomy_origin_lon=...>`.
+   * Honored on import to restore exact page coordinates; absent for files
+   * produced by other tools.
+   */
+  drawtonomyOrigin?: { lat: number; lon: number }
+}
+
+type DomParserCtor = new () => {
+  parseFromString: (input: string, type: string) => Document
+}
+
+function getDomParser(): DomParserCtor | null {
+  const g = globalThis as unknown as { DOMParser?: DomParserCtor }
+  return typeof g.DOMParser === 'function' ? g.DOMParser : null
+}
+
+function parseOsmXmlWithDom(xmlString: string, DOMParserImpl: DomParserCtor): OsmData {
+  const parser = new DOMParserImpl()
+  const doc = parser.parseFromString(xmlString, 'text/xml')
+
+  const nodes = new Map<string, OsmNode>()
+  const ways = new Map<string, OsmWay>()
+  const relations: OsmRelation[] = []
+
+  let drawtonomyOrigin: { lat: number; lon: number } | undefined
+  const osmEl = doc.querySelector('osm')
+  if (osmEl) {
+    const oLat = parseFloat(osmEl.getAttribute('drawtonomy_origin_lat') || '')
+    const oLon = parseFloat(osmEl.getAttribute('drawtonomy_origin_lon') || '')
+    if (Number.isFinite(oLat) && Number.isFinite(oLon)) {
+      drawtonomyOrigin = { lat: oLat, lon: oLon }
+    }
+  }
+
+  const collectTags = (el: Element): Record<string, string> => {
+    const tags: Record<string, string> = {}
+    el.querySelectorAll(':scope > tag').forEach(tagEl => {
+      const k = tagEl.getAttribute('k') || ''
+      const v = tagEl.getAttribute('v') || ''
+      if (k) tags[k] = v
+    })
+    return tags
+  }
+
+  doc.querySelectorAll('node').forEach(nodeEl => {
+    const id = nodeEl.getAttribute('id') || ''
+    const lat = parseFloat(nodeEl.getAttribute('lat') || '0')
+    const lon = parseFloat(nodeEl.getAttribute('lon') || '0')
+    const tags = collectTags(nodeEl)
+    nodes.set(id, {
+      id,
+      lat,
+      lon,
+      ele: tags.ele !== undefined ? parseFloat(tags.ele) : undefined,
+      tags,
+    })
+  })
+
+  doc.querySelectorAll('way').forEach(wayEl => {
+    const id = wayEl.getAttribute('id') || ''
+    const nodeRefs: string[] = []
+    wayEl.querySelectorAll(':scope > nd').forEach(ndEl => {
+      const ref = ndEl.getAttribute('ref') || ''
+      if (ref) nodeRefs.push(ref)
+    })
+    ways.set(id, { id, nodeRefs, tags: collectTags(wayEl) })
+  })
+
+  doc.querySelectorAll('relation').forEach(relEl => {
+    const id = relEl.getAttribute('id') || ''
+    const members: OsmRelation['members'] = []
+    relEl.querySelectorAll(':scope > member').forEach(memEl => {
+      members.push({
+        type: memEl.getAttribute('type') || '',
+        ref: memEl.getAttribute('ref') || '',
+        role: memEl.getAttribute('role') || '',
+      })
+    })
+    // Keep all relations (regulatory_element etc.) so they survive a
+    // round-trip; consumers can filter by tag type.
+    relations.push({ id, members, tags: collectTags(relEl) })
+  })
+
+  return { nodes, ways, relations, drawtonomyOrigin }
+}
+
+// ---------- Hand-rolled fallback parser (no DOM dependency) ----------
+
+const ATTR_RE = /([a-zA-Z_][\w:.-]*)\s*=\s*(?:"([^"]*)"|'([^']*)')/g
+
+function parseAttributes(attrString: string): Record<string, string> {
+  const attrs: Record<string, string> = {}
+  ATTR_RE.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = ATTR_RE.exec(attrString)) !== null) {
+    const value = m[2] !== undefined ? m[2] : m[3]
+    attrs[m[1]] = decodeXmlEntities(value)
+  }
+  return attrs
+}
+
+function decodeXmlEntities(s: string): string {
+  return s
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(parseInt(code, 10)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, code) => String.fromCharCode(parseInt(code, 16)))
+    .replace(/&amp;/g, '&')
+}
+
+interface XmlElement {
+  name: string
+  attrs: Record<string, string>
+  children: XmlElement[]
+}
+
+/**
+ * Minimal XML parser supporting the subset used by Lanelet2 OSM files:
+ * elements, attributes, self-closing tags, and nested elements. XML comments
+ * and CDATA blocks are stripped first. Sufficient for `<node>`/`<way>`/
+ * `<relation>`/`<tag>`/`<nd>`/`<member>`.
+ */
+function parseXmlSubset(xml: string): XmlElement | null {
+  // Strip XML declaration, comments, processing instructions, and CDATA.
+  let src = xml
+    .replace(/<\?[\s\S]*?\?>/g, '')
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/<!\[CDATA\[[\s\S]*?\]\]>/g, '')
+    .replace(/<!DOCTYPE[\s\S]*?>/g, '')
+
+  const tagRe = /<\/?\s*([a-zA-Z_][\w:.-]*)((?:[^<>"']|"[^"]*"|'[^']*')*)\/?\s*>/g
+  const stack: XmlElement[] = []
+  let root: XmlElement | null = null
+  let m: RegExpExecArray | null
+
+  while ((m = tagRe.exec(src)) !== null) {
+    const fullTag = m[0]
+    const name = m[1]
+    const rest = m[2]
+    const isClosing = fullTag.startsWith('</')
+    const isSelfClosing = fullTag.endsWith('/>')
+
+    if (isClosing) {
+      // Pop matching element.
+      const top = stack.pop()
+      if (!top || top.name !== name) {
+        // Tolerate slight mismatches by ignoring stray closers.
+        continue
+      }
+    } else {
+      const el: XmlElement = { name, attrs: parseAttributes(rest), children: [] }
+      const parent = stack[stack.length - 1]
+      if (parent) parent.children.push(el)
+      else root = el
+      if (!isSelfClosing) stack.push(el)
+    }
+  }
+
+  return root
+}
+
+function findChildren(el: XmlElement, name: string): XmlElement[] {
+  return el.children.filter(c => c.name === name)
+}
+
+function collectTagsFromChildren(el: XmlElement): Record<string, string> {
+  const tags: Record<string, string> = {}
+  for (const c of findChildren(el, 'tag')) {
+    const k = c.attrs.k
+    const v = c.attrs.v ?? ''
+    if (k) tags[k] = v
+  }
+  return tags
+}
+
+function parseOsmXmlFallback(xmlString: string): OsmData {
+  const root = parseXmlSubset(xmlString)
+  const nodes = new Map<string, OsmNode>()
+  const ways = new Map<string, OsmWay>()
+  const relations: OsmRelation[] = []
+  let drawtonomyOrigin: { lat: number; lon: number } | undefined
+
+  if (!root) return { nodes, ways, relations }
+
+  const osmRoot = root.name === 'osm' ? root : findChildren(root, 'osm')[0]
+  if (!osmRoot) return { nodes, ways, relations }
+
+  const oLat = parseFloat(osmRoot.attrs.drawtonomy_origin_lat ?? '')
+  const oLon = parseFloat(osmRoot.attrs.drawtonomy_origin_lon ?? '')
+  if (Number.isFinite(oLat) && Number.isFinite(oLon)) {
+    drawtonomyOrigin = { lat: oLat, lon: oLon }
+  }
+
+  for (const child of osmRoot.children) {
+    if (child.name === 'node') {
+      const id = child.attrs.id ?? ''
+      const lat = parseFloat(child.attrs.lat ?? '0')
+      const lon = parseFloat(child.attrs.lon ?? '0')
+      const tags = collectTagsFromChildren(child)
+      nodes.set(id, {
+        id,
+        lat,
+        lon,
+        ele: tags.ele !== undefined ? parseFloat(tags.ele) : undefined,
+        tags,
+      })
+    } else if (child.name === 'way') {
+      const id = child.attrs.id ?? ''
+      const nodeRefs = findChildren(child, 'nd').map(c => c.attrs.ref ?? '').filter(r => r.length > 0)
+      ways.set(id, { id, nodeRefs, tags: collectTagsFromChildren(child) })
+    } else if (child.name === 'relation') {
+      const id = child.attrs.id ?? ''
+      const members = findChildren(child, 'member').map(c => ({
+        type: c.attrs.type ?? '',
+        ref: c.attrs.ref ?? '',
+        role: c.attrs.role ?? '',
+      }))
+      relations.push({ id, members, tags: collectTagsFromChildren(child) })
+    }
+  }
+
+  return { nodes, ways, relations, drawtonomyOrigin }
+}
+
+/** Parse a Lanelet2 OSM XML string into structured data. */
+export function parseOsmXml(xmlString: string): OsmData {
+  const DOMParserImpl = getDomParser()
+  if (DOMParserImpl) {
+    try {
+      return parseOsmXmlWithDom(xmlString, DOMParserImpl)
+    } catch {
+      // Fall through to the hand-rolled parser.
+    }
+  }
+  return parseOsmXmlFallback(xmlString)
+}
+
+/**
+ * Project lat/lon onto canvas (page) coordinates using a simple
+ * equirectangular projection centered at (centerLat, centerLon).
+ *
+ * The default scale matches drawtonomy's visual sizing convention: a 3 m wide
+ * lane renders as 50 px (16.67 px/m), so `scale = 16.67 * 111320 ≈ 1,855,000`.
+ */
+export function latLonToCanvas(
+  lat: number,
+  lon: number,
+  centerLat: number,
+  centerLon: number,
+  scale: number = 1_855_000
+): { x: number; y: number } {
+  const x = (lon - centerLon) * scale * Math.cos((centerLat * Math.PI) / 180)
+  // Page Y axis points down, latitude grows northward (= up), so flip.
+  const y = -(lat - centerLat) * scale
+  return { x, y }
+}
+
+/** Inverse of `latLonToCanvas`: page coordinates back to lat/lon. */
+export function canvasToLatLon(
+  x: number,
+  y: number,
+  centerLat: number,
+  centerLon: number,
+  scale: number = 1_855_000
+): { lat: number; lon: number } {
+  const lat = centerLat - y / scale
+  const lon = centerLon + x / (scale * Math.cos((centerLat * Math.PI) / 180))
+  return { lat, lon }
+}

--- a/packages/drawtonomy-sdk/src/exporter/osmToShapes.ts
+++ b/packages/drawtonomy-sdk/src/exporter/osmToShapes.ts
@@ -1,0 +1,495 @@
+// Convert parsed Lanelet2 OSM data into the shape primitives that the
+// drawtonomy editor consumes (points, linestrings, lanes).
+//
+// The output is the intermediate `ImportedShapes` structure used by the
+// editor's import flow — not a full DrawtonomySnapshot — because the editor
+// needs per-shape positioning + bounds to drive its chunked import (camera
+// alignment, progress reporting, etc.). Callers can wrap the result into
+// shapes themselves.
+
+import type { ShapeId } from '../types'
+import { latLonToCanvas, type OsmData } from './osmParser'
+
+/**
+ * ID allocator interface. The default implementation produces predictable
+ * `shape:<kind>_<n>` ids starting from 0; callers (e.g. the editor) can pass
+ * a custom allocator to coordinate IDs with their own counters.
+ */
+export interface ShapeIdAllocator {
+  next(kind: 'point' | 'linestring' | 'lane'): ShapeId
+}
+
+/** Default allocator: monotonic counter per shape kind. */
+export function createShapeIdAllocator(): ShapeIdAllocator {
+  const counters: Record<string, number> = { point: 0, linestring: 0, lane: 0 }
+  return {
+    next(kind) {
+      const id = `shape:${kind}_${counters[kind]}` as ShapeId
+      counters[kind] += 1
+      return id
+    },
+  }
+}
+
+export interface ImportedPoint {
+  id: ShapeId
+  x: number
+  y: number
+  osmId: string
+}
+
+export interface ImportedLinestring {
+  id: ShapeId
+  x: number
+  y: number
+  pointIds: string[]
+  osmId: string
+  attributes: Record<string, string>
+}
+
+export interface ImportedLane {
+  id: ShapeId
+  x: number
+  y: number
+  leftBoundaryId: string
+  rightBoundaryId: string
+  /**
+   * Whether the boundary's node order should be reversed when interpreted by
+   * the editor. Lanelet2 encodes lane direction via the left boundary's node
+   * order, but a sibling lane in the opposite direction may share the same
+   * boundary read backwards.
+   */
+  invertLeft: boolean
+  invertRight: boolean
+  osmId: string
+  attributes: Record<string, string>
+  next: string[]
+  prev: string[]
+}
+
+export interface ImportBounds {
+  minX: number
+  maxX: number
+  minY: number
+  maxY: number
+  centerX: number
+  centerY: number
+  width: number
+  height: number
+}
+
+export interface ImportedShapes {
+  points: ImportedPoint[]
+  linestrings: ImportedLinestring[]
+  lanes: ImportedLane[]
+  bounds: ImportBounds
+  /**
+   * Geographic center used as the canvas origin during projection. The host
+   * app should call `setMapOrigin(originLatLon)` so that the map background
+   * lines up with the imported lanes at page (0, 0).
+   */
+  originLatLon?: { lat: number; lon: number }
+}
+
+export interface OsmToShapesOptions {
+  /** Custom id allocator. A fresh `createShapeIdAllocator()` is used when omitted. */
+  idAllocator?: ShapeIdAllocator
+  /**
+   * Restrict conversion to the given lanelet relation IDs. When omitted, all
+   * `type=lanelet` relations are converted (regulatory_element etc. are
+   * always skipped here; they are preserved separately via the OSM sidecar).
+   */
+  selectedLaneIds?: readonly string[]
+}
+
+interface Point2d {
+  x: number
+  y: number
+}
+
+function getMiddlePoint(points: Point2d[]): Point2d {
+  if (points.length === 0) return { x: 0, y: 0 }
+  if (points.length === 1) return points[0]
+  if (points.length === 2) {
+    return {
+      x: (points[0].x + points[1].x) / 2,
+      y: (points[0].y + points[1].y) / 2,
+    }
+  }
+  return points[Math.floor(points.length / 2)]
+}
+
+/**
+ * Decide whether to reverse the left and/or right boundary so the lane is
+ * interpreted consistently by the editor.
+ *
+ * In Lanelet2, the way's node order defines the lane direction (the left
+ * boundary's direction is the lane's direction). This routine preserves that
+ * direction whenever possible, only flipping a boundary when needed to keep
+ * the right-of-left invariant.
+ */
+export function alignBoundaries(
+  leftPoints: Point2d[],
+  rightPoints: Point2d[]
+): { invertLeft: boolean; invertRight: boolean } {
+  if (leftPoints.length < 2 || rightPoints.length < 2) {
+    return { invertLeft: false, invertRight: false }
+  }
+
+  const getEffective = (points: Point2d[], invert: boolean) =>
+    invert ? [...points].reverse() : points
+
+  const areParallel = (left: Point2d[], right: Point2d[]) => {
+    const ls = left[0], le = left[left.length - 1]
+    const rs = right[0], re = right[right.length - 1]
+    const parallelDist = Math.hypot(ls.x - rs.x, ls.y - rs.y) + Math.hypot(le.x - re.x, le.y - re.y)
+    const crossDist = Math.hypot(ls.x - re.x, ls.y - re.y) + Math.hypot(le.x - rs.x, le.y - rs.y)
+    return parallelDist <= crossDist
+  }
+
+  const isRightOnRightSide = (left: Point2d[], right: Point2d[]) => {
+    if (left.length < 2 || right.length < 1) return false
+
+    const leftDir = {
+      x: left[left.length - 1].x - left[0].x,
+      y: left[left.length - 1].y - left[0].y,
+    }
+
+    const leftMid = getMiddlePoint(left)
+    const rightMid = getMiddlePoint(right)
+
+    const leftToRight = {
+      x: rightMid.x - leftMid.x,
+      y: rightMid.y - leftMid.y,
+    }
+
+    // Cross product. In screen coordinates (Y points down), the sign is
+    // inverted vs. standard math convention; positive means "right is on the
+    // right of left".
+    const cross = leftDir.x * leftToRight.y - leftDir.y * leftToRight.x
+
+    if (Math.abs(cross) < 1e-6) {
+      // Converging boundaries: fall back to comparing start-to-start.
+      const leftToRightStart = {
+        x: right[0].x - left[0].x,
+        y: right[0].y - left[0].y,
+      }
+      const crossStart = leftDir.x * leftToRightStart.y - leftDir.y * leftToRightStart.x
+      return crossStart > 0
+    }
+
+    return cross > 0
+  }
+
+  if (areParallel(leftPoints, rightPoints) && isRightOnRightSide(leftPoints, rightPoints)) {
+    return { invertLeft: false, invertRight: false }
+  }
+
+  const rightInverted = getEffective(rightPoints, true)
+  if (areParallel(leftPoints, rightInverted) && isRightOnRightSide(leftPoints, rightInverted)) {
+    return { invertLeft: false, invertRight: true }
+  }
+
+  const leftInverted = getEffective(leftPoints, true)
+  if (areParallel(leftInverted, rightPoints) && isRightOnRightSide(leftInverted, rightPoints)) {
+    return { invertLeft: true, invertRight: false }
+  }
+
+  if (areParallel(leftInverted, rightInverted) && isRightOnRightSide(leftInverted, rightInverted)) {
+    return { invertLeft: true, invertRight: true }
+  }
+
+  if (areParallel(leftPoints, rightPoints)) {
+    return { invertLeft: false, invertRight: false }
+  }
+  if (areParallel(leftPoints, rightInverted)) {
+    return { invertLeft: false, invertRight: true }
+  }
+
+  return { invertLeft: false, invertRight: false }
+}
+
+interface LaneInfo {
+  osmId: string
+  laneId: ShapeId
+  leftWayId: string
+  rightWayId: string
+  leftFirstNode: string
+  leftLastNode: string
+  rightFirstNode: string
+  rightLastNode: string
+  invertLeft: boolean
+  invertRight: boolean
+}
+
+/**
+ * Detect lane connectivity (next/prev) by matching the boundary endpoints of
+ * one lane to the start of another. Runs in O(n) using start/end node hash
+ * maps.
+ */
+function detectLaneConnections(
+  laneInfos: LaneInfo[]
+): Map<string, { next: string[]; prev: string[] }> {
+  const connections = new Map<string, { next: string[]; prev: string[] }>()
+  laneInfos.forEach(info => {
+    connections.set(info.laneId, { next: [], prev: [] })
+  })
+
+  const getEffectiveNodes = (lane: LaneInfo) => {
+    const leftStart = lane.invertLeft ? lane.leftLastNode : lane.leftFirstNode
+    const leftEnd = lane.invertLeft ? lane.leftFirstNode : lane.leftLastNode
+    const rightStart = lane.invertRight ? lane.rightLastNode : lane.rightFirstNode
+    const rightEnd = lane.invertRight ? lane.rightFirstNode : lane.rightLastNode
+    return { leftStart, leftEnd, rightStart, rightEnd }
+  }
+
+  const startNodeMap = new Map<string, ShapeId[]>()
+  const endNodeMap = new Map<string, ShapeId[]>()
+
+  for (const lane of laneInfos) {
+    const nodes = getEffectiveNodes(lane)
+    const startKey = `${nodes.leftStart}|${nodes.rightStart}`
+    const endKey = `${nodes.leftEnd}|${nodes.rightEnd}`
+    if (!startNodeMap.has(startKey)) startNodeMap.set(startKey, [])
+    startNodeMap.get(startKey)!.push(lane.laneId)
+    if (!endNodeMap.has(endKey)) endNodeMap.set(endKey, [])
+    endNodeMap.get(endKey)!.push(lane.laneId)
+  }
+
+  for (const lane of laneInfos) {
+    const nodes = getEffectiveNodes(lane)
+    const endKey = `${nodes.leftEnd}|${nodes.rightEnd}`
+    const nextLaneIds = startNodeMap.get(endKey)
+    if (!nextLaneIds) continue
+    const conn = connections.get(lane.laneId)!
+    for (const nextLaneId of nextLaneIds) {
+      if (nextLaneId === lane.laneId) continue
+      if (!conn.next.includes(nextLaneId)) {
+        conn.next.push(nextLaneId)
+        const nextConn = connections.get(nextLaneId)!
+        if (!nextConn.prev.includes(lane.laneId)) {
+          nextConn.prev.push(lane.laneId)
+        }
+      }
+    }
+  }
+
+  return connections
+}
+
+function emptyBounds(): ImportBounds {
+  return {
+    minX: Infinity,
+    maxX: -Infinity,
+    minY: Infinity,
+    maxY: -Infinity,
+    centerX: 0,
+    centerY: 0,
+    width: 0,
+    height: 0,
+  }
+}
+
+/**
+ * Convert parsed OSM data into editor-ready point/linestring/lane records.
+ *
+ * Pass `selectedLaneIds` to restrict to a subset of lanelet relations
+ * (selective import); leave it `undefined` to import every `type=lanelet`
+ * relation.
+ */
+export function osmToShapes(osmData: OsmData, options: OsmToShapesOptions = {}): ImportedShapes {
+  const idAllocator = options.idAllocator ?? createShapeIdAllocator()
+  const result: ImportedShapes = {
+    points: [],
+    linestrings: [],
+    lanes: [],
+    bounds: emptyBounds(),
+  }
+
+  // Compute the projection center.
+  let minLat = Infinity, maxLat = -Infinity
+  let minLon = Infinity, maxLon = -Infinity
+  osmData.nodes.forEach(node => {
+    if (node.lat < minLat) minLat = node.lat
+    if (node.lat > maxLat) maxLat = node.lat
+    if (node.lon < minLon) minLon = node.lon
+    if (node.lon > maxLon) maxLon = node.lon
+  })
+
+  // For files emitted by drawtonomy, honor the embedded origin so page
+  // coordinates round-trip exactly. Otherwise center on the bbox.
+  const centerLat = osmData.drawtonomyOrigin?.lat ?? (minLat + maxLat) / 2
+  const centerLon = osmData.drawtonomyOrigin?.lon ?? (minLon + maxLon) / 2
+  result.originLatLon = { lat: centerLat, lon: centerLon }
+
+  const osmNodeToPointId = new Map<string, ShapeId>()
+  const osmWayToLinestringId = new Map<string, ShapeId>()
+  const pointIdToPoint = new Map<string, ImportedPoint>()
+  const linestringIdToLinestring = new Map<string, ImportedLinestring>()
+
+  // Only `type=lanelet` relations become lanes. Other relation types
+  // (regulatory_element, multipolygon, etc.) are preserved verbatim via the
+  // OSM sidecar.
+  let laneletRelations = osmData.relations.filter(r => r.tags.type === 'lanelet')
+  if (options.selectedLaneIds) {
+    const selected = new Set(options.selectedLaneIds)
+    laneletRelations = laneletRelations.filter(r => selected.has(r.id))
+  }
+
+  // Collect ways and nodes referenced by the chosen lanelets.
+  const usedWayIds = new Set<string>()
+  const usedNodeIds = new Set<string>()
+  for (const relation of laneletRelations) {
+    for (const member of relation.members) {
+      if (member.type === 'way') usedWayIds.add(member.ref)
+    }
+  }
+  for (const wayId of usedWayIds) {
+    const way = osmData.ways.get(wayId)
+    if (!way) continue
+    for (const ref of way.nodeRefs) usedNodeIds.add(ref)
+  }
+
+  // Materialize points (one per OSM node, shared across boundaries).
+  for (const nodeId of usedNodeIds) {
+    const node = osmData.nodes.get(nodeId)
+    if (!node) continue
+    const { x, y } = latLonToCanvas(node.lat, node.lon, centerLat, centerLon)
+    const pointId = idAllocator.next('point')
+    osmNodeToPointId.set(nodeId, pointId)
+    const data: ImportedPoint = { id: pointId, x, y, osmId: nodeId }
+    result.points.push(data)
+    pointIdToPoint.set(pointId, data)
+  }
+
+  // Materialize linestrings (one per used way).
+  for (const wayId of usedWayIds) {
+    const way = osmData.ways.get(wayId)
+    if (!way) continue
+    const pointIds: string[] = []
+    for (const nodeRef of way.nodeRefs) {
+      const pid = osmNodeToPointId.get(nodeRef)
+      if (pid) pointIds.push(pid)
+    }
+    if (pointIds.length < 2) continue
+
+    const firstPoint = pointIdToPoint.get(pointIds[0])
+    if (!firstPoint) continue
+
+    const linestringId = idAllocator.next('linestring')
+    osmWayToLinestringId.set(wayId, linestringId)
+    const data: ImportedLinestring = {
+      id: linestringId,
+      x: firstPoint.x,
+      y: firstPoint.y,
+      pointIds,
+      osmId: wayId,
+      attributes: {
+        type: way.tags.type || 'line_thin',
+        subtype: way.tags.subtype || 'solid',
+        width: way.tags.width || '0.2',
+      },
+    }
+    result.linestrings.push(data)
+    linestringIdToLinestring.set(linestringId, data)
+  }
+
+  // Materialize lanes and collect info for connectivity detection.
+  const laneInfos: LaneInfo[] = []
+  for (const relation of laneletRelations) {
+    let leftWayId: string | null = null
+    let rightWayId: string | null = null
+    let leftBoundaryId: string | null = null
+    let rightBoundaryId: string | null = null
+    for (const member of relation.members) {
+      if (member.type !== 'way') continue
+      const linestringId = osmWayToLinestringId.get(member.ref)
+      if (!linestringId) continue
+      if (member.role === 'left') {
+        leftBoundaryId = linestringId
+        leftWayId = member.ref
+      } else if (member.role === 'right') {
+        rightBoundaryId = linestringId
+        rightWayId = member.ref
+      }
+    }
+    if (!leftBoundaryId || !rightBoundaryId || !leftWayId || !rightWayId) continue
+
+    const leftWay = osmData.ways.get(leftWayId)
+    const rightWay = osmData.ways.get(rightWayId)
+    const leftLinestring = linestringIdToLinestring.get(leftBoundaryId)
+    const rightLinestring = linestringIdToLinestring.get(rightBoundaryId)
+    if (!leftWay || !rightWay || !leftLinestring || !rightLinestring) continue
+
+    const getPointCoords = (pointIds: string[]): Point2d[] =>
+      pointIds
+        .map(pid => pointIdToPoint.get(pid))
+        .filter((p): p is ImportedPoint => p !== undefined)
+        .map(p => ({ x: p.x, y: p.y }))
+
+    const { invertLeft, invertRight } = alignBoundaries(
+      getPointCoords(leftLinestring.pointIds),
+      getPointCoords(rightLinestring.pointIds)
+    )
+
+    const laneId = idAllocator.next('lane')
+    laneInfos.push({
+      osmId: relation.id,
+      laneId,
+      leftWayId,
+      rightWayId,
+      leftFirstNode: leftWay.nodeRefs[0],
+      leftLastNode: leftWay.nodeRefs[leftWay.nodeRefs.length - 1],
+      rightFirstNode: rightWay.nodeRefs[0],
+      rightLastNode: rightWay.nodeRefs[rightWay.nodeRefs.length - 1],
+      invertLeft,
+      invertRight,
+    })
+
+    result.lanes.push({
+      id: laneId,
+      x: leftLinestring.x,
+      y: leftLinestring.y,
+      leftBoundaryId,
+      rightBoundaryId,
+      invertLeft,
+      invertRight,
+      osmId: relation.id,
+      attributes: {
+        type: 'lanelet',
+        subtype: relation.tags.subtype || 'road',
+        location: relation.tags.location || 'urban',
+        one_way: relation.tags.one_way || 'yes',
+        speed_limit: relation.tags.speed_limit || '30',
+        turn_direction: relation.tags.turn_direction || 'straight',
+      },
+      next: [],
+      prev: [],
+    })
+  }
+
+  const connections = detectLaneConnections(laneInfos)
+  for (const lane of result.lanes) {
+    const conn = connections.get(lane.id)
+    if (conn) {
+      lane.next = conn.next
+      lane.prev = conn.prev
+    }
+  }
+
+  // Bounds across all materialized points.
+  for (const point of result.points) {
+    if (point.x < result.bounds.minX) result.bounds.minX = point.x
+    if (point.x > result.bounds.maxX) result.bounds.maxX = point.x
+    if (point.y < result.bounds.minY) result.bounds.minY = point.y
+    if (point.y > result.bounds.maxY) result.bounds.maxY = point.y
+  }
+  if (result.points.length > 0) {
+    result.bounds.width = result.bounds.maxX - result.bounds.minX
+    result.bounds.height = result.bounds.maxY - result.bounds.minY
+    result.bounds.centerX = result.bounds.minX + result.bounds.width / 2
+    result.bounds.centerY = result.bounds.minY + result.bounds.height / 2
+  }
+
+  return result
+}


### PR DESCRIPTION
## Summary


<video src="https://github.com/user-attachments/assets/92cf1c66-b7d4-4142-b637-7dd9eb0a156f" width="80%" controls></video>

<video src="https://github.com/user-attachments/assets/652af370-8bb6-4da4-8a5b-a798b59cf7f5" width="80%" controls></video>

Add Lanelet2 (.osm XML) export, OSM XML parsing, and OSM-to-shapes conversion to the SDK's exporter module so contributors can extend the Lanelet2 round-trip flow.

This mirrors the OpenDRIVE / OpenSCENARIO exporters previously added: inputs are a `DrawtonomySnapshot` plus optional sidecar/origin, with no editor runtime dependency.

### New SDK APIs

- `exporter.exportToLanelet2(snapshot, { sidecar?, mapOrigin? })` — emit a Lanelet2 OSM XML document
- `exporter.parseOsmXml(xml)` — parse OSM XML; uses `DOMParser` when available, falls back to a hand-rolled parser for plain Node
- `exporter.latLonToCanvas` / `exporter.canvasToLatLon` — equirectangular projection helpers (16.67 px/m, matching editor visuals)
- `exporter.osmToShapes(data, { idAllocator?, selectedLaneIds? })` — convert parsed OSM into editor-ready point/linestring/lane records, with lane-boundary alignment + next/prev connectivity detection
- `exporter.alignBoundaries` — exposed helper for boundary direction analysis
- `exporter.createShapeIdAllocator` — pluggable id allocator so a host editor can coordinate IDs

### Behavior

Exporter:

- Sidecar entries (regulatory_element, ele tags, untouched relations) round-trip verbatim
- Shape-derived entries override sidecar IDs they share
- Root `<osm>` carries `drawtonomy_origin_lat` / `drawtonomy_origin_lon` for exact page-coord round-trip
- Negative IDs allocated for newly drawn shapes (OSM convention)

Importer:

- Only `type=lanelet` relations become lanes; other relations are preserved via sidecar
- One point per OSM node (shared across boundaries)
- Lane boundary direction is preserved when possible; only flipped to maintain right-of-left invariant
- O(n) connectivity detection via start/end node hash maps

### Why a hand-rolled OSM parser

The SDK is consumed both in the browser (DOMParser available) and in headless Node tooling / extensions (no DOMParser, no jsdom dependency). The parser tries `globalThis.DOMParser` first and falls back to a regex-based subset parser sufficient for OSM XML's element/attribute/CDATA structure.

### Bump SDK version

`@drawtonomy/sdk@0.6.0` → `0.7.0` to enable publish.

## Test plan

- [x] `pnpm --filter @drawtonomy/sdk build` — clean tsc build
- [x] `pnpm --filter @drawtonomy/sdk test` — 134/134 passing (11 test files), including new `lanelet2.test.ts` covering:
  - parseOsmXml: nodes / ways / relations / drawtonomy origin / non-lanelet preservation / XML entity decoding
  - latLonToCanvas / canvasToLatLon round-trip precision
  - alignBoundaries: parallel and anti-parallel cases
  - exportToLanelet2: empty snapshot, mapOrigin override, single lane, sidecar preservation, coordinate override
  - osmToShapes: single lane import, selectedLaneIds filter, next/prev connectivity detection
  - Round-trip canvas coordinates via embedded origin