### PR TITLE
docs: rename site title to 'drawtonomy'

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -8,7 +8,7 @@ export default defineConfig({
 	site: 'https://docs.drawtonomy.com',
 	integrations: [
 		starlight({
-			title: 'drawtonomy docs',
+			title: 'drawtonomy',
 			description:
 				'Documentation for drawtonomy — a free, install-free whiteboard for driving diagrams. Sketch lanes, intersections, vehicles, crosswalks, and traffic scenarios in the browser; export to OpenDRIVE, OpenSCENARIO, and Lanelet2.',
 			customCss: ['./src/styles/custom.css'],

--- a/docs-site/src/route-data.ts
+++ b/docs-site/src/route-data.ts
@@ -451,7 +451,7 @@ export const onRequest = defineRouteMiddleware((context) => {
 				inLanguage: lang,
 				isPartOf: {
 					'@type': 'WebSite',
-					name: 'drawtonomy docs',
+					name: 'drawtonomy',
 					url: 'https://docs.drawtonomy.com',
 				},
 				about: {


### PR DESCRIPTION
Drop the "docs" suffix from the site title.