### PR TITLE
docs: swap hero logo for the demo video on the home

### DIFF
--- a/docs-site/src/content/docs/ar/index.mdx
+++ b/docs-site/src/content/docs/ar/index.mdx
@@ -58,7 +58,8 @@ jsonLd:
 hero:
   tagline: سبورة بيضاء مجانية تعمل في المتصفح لسيناريوهات القيادة. ارسم المسارات والتقاطعات ومشاهد المرور لأوراق البحث والشرائح ومناقشات التصميم وتأليف السيناريوهات.
   image:
-    file: ../../../assets/logo.png
+    html: |
+      <video src="/videos/drawtonomy-demo.mp4" autoplay loop muted playsinline preload="metadata" class="hero-video" onmouseover="this.setAttribute('controls','')" onmouseout="this.removeAttribute('controls')"></video>
   actions:
     - text: البدء السريع
       link: /ar/start/quickstart/

--- a/docs-site/src/content/docs/de/index.mdx
+++ b/docs-site/src/content/docs/de/index.mdx
@@ -54,7 +54,8 @@ jsonLd:
 hero:
   tagline: Ein kostenloses, browserbasiertes Whiteboard für Fahrszenarien. Skizzieren Sie Fahrspuren, Kreuzungen und Verkehrsszenen für Paper, Folien, Designdiskussionen und Szenario-Authoring.
   image:
-    file: ../../../assets/logo.png
+    html: |
+      <video src="/videos/drawtonomy-demo.mp4" autoplay loop muted playsinline preload="metadata" class="hero-video" onmouseover="this.setAttribute('controls','')" onmouseout="this.removeAttribute('controls')"></video>
   actions:
     - text: Schnellstart
       link: /de/start/quickstart/

--- a/docs-site/src/content/docs/es/index.mdx
+++ b/docs-site/src/content/docs/es/index.mdx
@@ -54,7 +54,8 @@ jsonLd:
 hero:
   tagline: Una pizarra gratuita en el navegador para escenarios de conducción. Dibuja carriles, intersecciones y escenas de tráfico para artículos, presentaciones, debates de diseño y creación de escenarios.
   image:
-    file: ../../../assets/logo.png
+    html: |
+      <video src="/videos/drawtonomy-demo.mp4" autoplay loop muted playsinline preload="metadata" class="hero-video" onmouseover="this.setAttribute('controls','')" onmouseout="this.removeAttribute('controls')"></video>
   actions:
     - text: Inicio rápido
       link: /es/start/quickstart/

--- a/docs-site/src/content/docs/fr/index.mdx
+++ b/docs-site/src/content/docs/fr/index.mdx
@@ -54,7 +54,8 @@ jsonLd:
 hero:
   tagline: Un tableau blanc gratuit en ligne dans le navigateur pour les scénarios de conduite. Esquissez voies, intersections et scènes de trafic pour vos articles, présentations, revues de conception et rédaction de scénarios.
   image:
-    file: ../../../assets/logo.png
+    html: |
+      <video src="/videos/drawtonomy-demo.mp4" autoplay loop muted playsinline preload="metadata" class="hero-video" onmouseover="this.setAttribute('controls','')" onmouseout="this.removeAttribute('controls')"></video>
   actions:
     - text: Démarrage rapide
       link: /fr/start/quickstart/

--- a/docs-site/src/content/docs/he/index.mdx
+++ b/docs-site/src/content/docs/he/index.mdx
@@ -54,7 +54,8 @@ jsonLd:
 hero:
   tagline: לוח לבן חינמי מבוסס דפדפן לתרחישי נהיגה. סרטטו נתיבים, צמתים וסצנות תנועה עבור מאמרים, מצגות, דיוני תכנון וכתיבת תרחישים.
   image:
-    file: ../../../assets/logo.png
+    html: |
+      <video src="/videos/drawtonomy-demo.mp4" autoplay loop muted playsinline preload="metadata" class="hero-video" onmouseover="this.setAttribute('controls','')" onmouseout="this.removeAttribute('controls')"></video>
   actions:
     - text: התחלה מהירה
       link: /he/start/quickstart/

--- a/docs-site/src/content/docs/hi/index.mdx
+++ b/docs-site/src/content/docs/hi/index.mdx
@@ -54,7 +54,8 @@ jsonLd:
 hero:
   tagline: ड्राइविंग सिनारियो के लिए एक मुफ्त, ब्राउज़र-आधारित व्हाइटबोर्ड। पेपर, स्लाइड, डिज़ाइन चर्चा, और सिनारियो ऑथरिंग के लिए लेन, चौराहे, और ट्रैफिक दृश्यों का स्केच बनाएं।
   image:
-    file: ../../../assets/logo.png
+    html: |
+      <video src="/videos/drawtonomy-demo.mp4" autoplay loop muted playsinline preload="metadata" class="hero-video" onmouseover="this.setAttribute('controls','')" onmouseout="this.removeAttribute('controls')"></video>
   actions:
     - text: क्विकस्टार्ट
       link: /hi/start/quickstart/

--- a/docs-site/src/content/docs/id/index.mdx
+++ b/docs-site/src/content/docs/id/index.mdx
@@ -54,7 +54,8 @@ jsonLd:
 hero:
   tagline: Papan tulis berbasis browser yang gratis untuk skenario mengemudi. Sketsa jalur, persimpangan, dan adegan lalu lintas untuk paper, slide, diskusi desain, dan penulisan skenario.
   image:
-    file: ../../../assets/logo.png
+    html: |
+      <video src="/videos/drawtonomy-demo.mp4" autoplay loop muted playsinline preload="metadata" class="hero-video" onmouseover="this.setAttribute('controls','')" onmouseout="this.removeAttribute('controls')"></video>
   actions:
     - text: Mulai Cepat
       link: /id/start/quickstart/

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -55,7 +55,8 @@ jsonLd:
 hero:
   tagline: A free, browser-based whiteboard for driving scenarios. Sketch lanes, intersections, and traffic scenes for papers, slides, design discussions, and scenario authoring.
   image:
-    file: ../../assets/logo.png
+    html: |
+      <video src="/videos/drawtonomy-demo.mp4" autoplay loop muted playsinline preload="metadata" class="hero-video" onmouseover="this.setAttribute('controls','')" onmouseout="this.removeAttribute('controls')"></video>
   actions:
     - text: Quickstart
       link: /start/quickstart/

--- a/docs-site/src/content/docs/it/index.mdx
+++ b/docs-site/src/content/docs/it/index.mdx
@@ -55,7 +55,8 @@ jsonLd:
 hero:
   tagline: Una lavagna gratuita basata su browser per scenari di guida. Disegna corsie, incroci e scene di traffico per articoli, slide, discussioni di progettazione e authoring di scenari.
   image:
-    file: ../../../assets/logo.png
+    html: |
+      <video src="/videos/drawtonomy-demo.mp4" autoplay loop muted playsinline preload="metadata" class="hero-video" onmouseover="this.setAttribute('controls','')" onmouseout="this.removeAttribute('controls')"></video>
   actions:
     - text: Avvio rapido
       link: /it/start/quickstart/

--- a/docs-site/src/content/docs/ja/index.mdx
+++ b/docs-site/src/content/docs/ja/index.mdx
@@ -56,7 +56,8 @@ jsonLd:
 hero:
   tagline: 自動運転シナリオのための、無料・ブラウザベースのホワイトボード。論文、スライド、設計レビュー、シナリオ作成のためにレーンや交差点、交通シーンをスケッチできます。
   image:
-    file: ../../../assets/logo.png
+    html: |
+      <video src="/videos/drawtonomy-demo.mp4" autoplay loop muted playsinline preload="metadata" class="hero-video" onmouseover="this.setAttribute('controls','')" onmouseout="this.removeAttribute('controls')"></video>
   actions:
     - text: クイックスタート
       link: /ja/start/quickstart/

--- a/docs-site/src/content/docs/ko/index.mdx
+++ b/docs-site/src/content/docs/ko/index.mdx
@@ -52,7 +52,8 @@ jsonLd:
 hero:
   tagline: 자율주행 시나리오를 위한 무료 브라우저 기반 화이트보드. 논문·슬라이드·설계 토론·시나리오 작성을 위한 차선과 교차로, 교통 장면을 스케치하세요.
   image:
-    file: ../../../assets/logo.png
+    html: |
+      <video src="/videos/drawtonomy-demo.mp4" autoplay loop muted playsinline preload="metadata" class="hero-video" onmouseover="this.setAttribute('controls','')" onmouseout="this.removeAttribute('controls')"></video>
   actions:
     - text: 빠른 시작
       link: /ko/start/quickstart/

--- a/docs-site/src/content/docs/nl/index.mdx
+++ b/docs-site/src/content/docs/nl/index.mdx
@@ -53,7 +53,8 @@ jsonLd:
 hero:
   tagline: Een gratis, browsergebaseerd whiteboard voor rijscenario's. Schets rijstroken, kruispunten en verkeerssituaties voor papers, dia's, ontwerpdiscussies en scenariocreatie.
   image:
-    file: ../../../assets/logo.png
+    html: |
+      <video src="/videos/drawtonomy-demo.mp4" autoplay loop muted playsinline preload="metadata" class="hero-video" onmouseover="this.setAttribute('controls','')" onmouseout="this.removeAttribute('controls')"></video>
   actions:
     - text: Snelstart
       link: /nl/start/quickstart/

--- a/docs-site/src/content/docs/pl/index.mdx
+++ b/docs-site/src/content/docs/pl/index.mdx
@@ -54,7 +54,8 @@ jsonLd:
 hero:
   tagline: Darmowa, działająca w przeglądarce tablica do scenariuszy jazdy. Szkicuj pasy, skrzyżowania i sceny ruchu drogowego do publikacji, prezentacji, dyskusji projektowych i tworzenia scenariuszy.
   image:
-    file: ../../../assets/logo.png
+    html: |
+      <video src="/videos/drawtonomy-demo.mp4" autoplay loop muted playsinline preload="metadata" class="hero-video" onmouseover="this.setAttribute('controls','')" onmouseout="this.removeAttribute('controls')"></video>
   actions:
     - text: Szybki start
       link: /pl/start/quickstart/

--- a/docs-site/src/content/docs/pt/index.mdx
+++ b/docs-site/src/content/docs/pt/index.mdx
@@ -55,7 +55,8 @@ jsonLd:
 hero:
   tagline: Um quadro branco gratuito, baseado em navegador, para cenários de condução. Esboce faixas, cruzamentos e cenas de tráfego para artigos, slides, discussões de design e criação de cenários.
   image:
-    file: ../../../assets/logo.png
+    html: |
+      <video src="/videos/drawtonomy-demo.mp4" autoplay loop muted playsinline preload="metadata" class="hero-video" onmouseover="this.setAttribute('controls','')" onmouseout="this.removeAttribute('controls')"></video>
   actions:
     - text: Início rápido
       link: /pt/start/quickstart/

--- a/docs-site/src/content/docs/ru/index.mdx
+++ b/docs-site/src/content/docs/ru/index.mdx
@@ -54,7 +54,8 @@ jsonLd:
 hero:
   tagline: Бесплатная браузерная доска для сценариев вождения. Рисуйте полосы, перекрёстки и транспортные сцены для статей, слайдов, обсуждений архитектуры и создания сценариев.
   image:
-    file: ../../../assets/logo.png
+    html: |
+      <video src="/videos/drawtonomy-demo.mp4" autoplay loop muted playsinline preload="metadata" class="hero-video" onmouseover="this.setAttribute('controls','')" onmouseout="this.removeAttribute('controls')"></video>
   actions:
     - text: Быстрый старт
       link: /ru/start/quickstart/

--- a/docs-site/src/content/docs/sv/index.mdx
+++ b/docs-site/src/content/docs/sv/index.mdx
@@ -55,7 +55,8 @@ jsonLd:
 hero:
   tagline: En gratis, webbläsarbaserad whiteboard för körscenarier. Skissa körfält, korsningar och trafikscener för artiklar, presentationer, designdiskussioner och scenarioskapande.
   image:
-    file: ../../../assets/logo.png
+    html: |
+      <video src="/videos/drawtonomy-demo.mp4" autoplay loop muted playsinline preload="metadata" class="hero-video" onmouseover="this.setAttribute('controls','')" onmouseout="this.removeAttribute('controls')"></video>
   actions:
     - text: Snabbstart
       link: /sv/start/quickstart/

--- a/docs-site/src/content/docs/th/index.mdx
+++ b/docs-site/src/content/docs/th/index.mdx
@@ -55,7 +55,8 @@ jsonLd:
 hero:
   tagline: ไวท์บอร์ดสำหรับสถานการณ์ขับขี่บนเบราว์เซอร์แบบฟรี วาดภาพเลน ทางแยก และฉากจราจรสำหรับเปเปอร์ สไลด์ การหารือเรื่องดีไซน์ และการสร้างสถานการณ์
   image:
-    file: ../../../assets/logo.png
+    html: |
+      <video src="/videos/drawtonomy-demo.mp4" autoplay loop muted playsinline preload="metadata" class="hero-video" onmouseover="this.setAttribute('controls','')" onmouseout="this.removeAttribute('controls')"></video>
   actions:
     - text: เริ่มต้นใช้งานแบบรวดเร็ว
       link: /th/start/quickstart/

--- a/docs-site/src/content/docs/tr/index.mdx
+++ b/docs-site/src/content/docs/tr/index.mdx
@@ -55,7 +55,8 @@ jsonLd:
 hero:
   tagline: Sürüş senaryoları için ücretsiz, tarayıcı tabanlı bir beyaz tahta. Makaleler, slaytlar, tasarım tartışmaları ve senaryo oluşturma için şeritleri, kavşakları ve trafik sahnelerini taslaklayın.
   image:
-    file: ../../../assets/logo.png
+    html: |
+      <video src="/videos/drawtonomy-demo.mp4" autoplay loop muted playsinline preload="metadata" class="hero-video" onmouseover="this.setAttribute('controls','')" onmouseout="this.removeAttribute('controls')"></video>
   actions:
     - text: Hızlı Başlangıç
       link: /tr/start/quickstart/

--- a/docs-site/src/content/docs/vi/index.mdx
+++ b/docs-site/src/content/docs/vi/index.mdx
@@ -55,7 +55,8 @@ jsonLd:
 hero:
   tagline: Bảng trắng miễn phí dựa trên trình duyệt cho kịch bản lái xe. Phác thảo làn đường, giao lộ và cảnh giao thông cho bài báo, slide, thảo luận thiết kế và tạo kịch bản.
   image:
-    file: ../../../assets/logo.png
+    html: |
+      <video src="/videos/drawtonomy-demo.mp4" autoplay loop muted playsinline preload="metadata" class="hero-video" onmouseover="this.setAttribute('controls','')" onmouseout="this.removeAttribute('controls')"></video>
   actions:
     - text: Bắt đầu nhanh
       link: /vi/start/quickstart/

--- a/docs-site/src/content/docs/zh-cn/index.mdx
+++ b/docs-site/src/content/docs/zh-cn/index.mdx
@@ -55,7 +55,8 @@ jsonLd:
 hero:
   tagline: 一款免费、基于浏览器的自动驾驶场景白板。绘制车道、路口与交通场景,用于论文、幻灯片、设计评审和场景编写。
   image:
-    file: ../../../assets/logo.png
+    html: |
+      <video src="/videos/drawtonomy-demo.mp4" autoplay loop muted playsinline preload="metadata" class="hero-video" onmouseover="this.setAttribute('controls','')" onmouseout="this.removeAttribute('controls')"></video>
   actions:
     - text: 快速入门
       link: /zh-cn/start/quickstart/

--- a/docs-site/src/content/docs/zh-tw/index.mdx
+++ b/docs-site/src/content/docs/zh-tw/index.mdx
@@ -54,7 +54,8 @@ jsonLd:
 hero:
   tagline: 一款免費、純瀏覽器運作的自動駕駛場景白板。為論文、簡報、設計討論與場景撰寫繪製車道、路口與交通場景。
   image:
-    file: ../../../assets/logo.png
+    html: |
+      <video src="/videos/drawtonomy-demo.mp4" autoplay loop muted playsinline preload="metadata" class="hero-video" onmouseover="this.setAttribute('controls','')" onmouseout="this.removeAttribute('controls')"></video>
   actions:
     - text: 快速入門
       link: /zh-tw/start/quickstart/

--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -52,7 +52,9 @@
 	);
 }
 
-/* Splash hero: soft indigo wash. */
+/* Splash hero: soft indigo wash. The inner padding keeps the headline,
+   tagline, CTA buttons, and the side media tucked inside the gradient
+   panel rather than running edge-to-edge. */
 .hero {
 	background:
 		radial-gradient(
@@ -65,6 +67,21 @@
 			rgba(196, 181, 253, 0.14),
 			transparent 60%
 		);
+	padding-inline: clamp(0.75rem, 2vw, 1.5rem);
+	border-radius: 16px;
+}
+
+/* Hero side video — replaces the static logo on the splash home. Sized
+   to match the slot Starlight reserves for hero images and rounded so
+   it sits cleanly inside the hero panel. */
+.hero .hero-html .hero-video {
+	width: 100%;
+	max-width: 36rem;
+	height: auto;
+	margin-inline: auto;
+	border-radius: 12px;
+	box-shadow: 0 6px 24px rgba(99, 102, 241, 0.18);
+	display: block;
 }
 
 /* Cards / link cards — match AttributePanel chrome:


### PR DESCRIPTION

<img width="1582" height="1012" alt="image" src="https://github.com/user-attachments/assets/3ee6c112-1c10-4543-a2e8-7e3d674b0da5" />

https://docs.drawtonomy.com/

Replace the static logo on the splash home with the demo clip (autoplay/loop/muted, controls fade in on hover). Tightens the hero panel with inner padding and a subtle radius. Applied across all 21 locales.