### PR TITLE
docs: place hero video below headline on mobile

### DIFF
--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -84,6 +84,14 @@
 	display: block;
 }
 
+/* On mobile (single-column hero) place the video below the headline +
+   CTA stack. On desktop Starlight already moves it to the right column. */
+@media (max-width: 50rem) {
+	.hero > .hero-html {
+		order: 2;
+	}
+}
+
 /* Cards / link cards — match AttributePanel chrome:
    white panel, 10px radius, hairline indigo border. */
 .card,


### PR DESCRIPTION
On mobile the hero collapses to a single column. Move the demo video below the headline and CTA buttons so the page leads with the title.