### PR TITLE
docs: place hero video under the title on mobile

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -99,6 +99,7 @@ export default defineConfig({
 			],
 			components: {
 				Header: './src/components/Header.astro',
+				Hero: './src/components/Hero.astro',
 			},
 			head: [
 				{

--- a/docs-site/src/components/Hero.astro
+++ b/docs-site/src/components/Hero.astro
@@ -1,0 +1,179 @@
+---
+// Override of Starlight's default Hero.astro.
+//
+// The only structural change is for `image.html`: in addition to the
+// usual side slot (which on desktop sits in the right column and on
+// mobile drops above the headline), we ALSO render the same HTML
+// directly under the <h1>. CSS then shows exactly one of the two:
+// the inline copy on mobile, the side copy on desktop. The result is
+// "title → media → tagline → CTA" stacking on mobile without altering
+// the desktop layout.
+import { Image } from 'astro:assets';
+import DraftContentNotice from 'virtual:starlight/components/DraftContentNotice';
+import { LinkButton } from '@astrojs/starlight/components';
+
+// Mirrors `PAGE_TITLE_ID` in @astrojs/starlight/constants — the constants
+// module is not part of Starlight's public exports map, so we hard-code
+// the value (it is `_top` and the docs anchor depends on it).
+const PAGE_TITLE_ID = '_top';
+
+const { data } = Astro.locals.starlightRoute.entry;
+const { title = data.title, tagline, image, actions = [] } = data.hero || {};
+
+const imageAttrs = {
+	loading: 'eager' as const,
+	decoding: 'async' as const,
+	width: 400,
+	height: 400,
+	alt: image?.alt || '',
+};
+
+let darkImage: ImageMetadata | undefined;
+let lightImage: ImageMetadata | undefined;
+let rawHtml: string | undefined;
+if (image) {
+	if ('file' in image) {
+		darkImage = image.file;
+	} else if ('dark' in image) {
+		darkImage = image.dark;
+		lightImage = image.light;
+	} else {
+		rawHtml = image.html;
+	}
+}
+---
+
+<div class="hero">
+	{
+		darkImage && (
+			<Image
+				src={darkImage}
+				{...imageAttrs}
+				class:list={{ 'light:sl-hidden': Boolean(lightImage) }}
+			/>
+		)
+	}
+	{lightImage && <Image src={lightImage} {...imageAttrs} class="dark:sl-hidden" />}
+	{rawHtml && <div class="hero-html" set:html={rawHtml} />}
+	<div class="sl-flex stack">
+		<div class="sl-flex copy">
+			<h1 id={PAGE_TITLE_ID} data-page-title set:html={title} />
+			{rawHtml && <div class="hero-html-inline" set:html={rawHtml} />}
+			{data.draft && <DraftContentNotice />}
+			{tagline && <div class="tagline" set:html={tagline} />}
+		</div>
+		{
+			actions.length > 0 && (
+				<div class="sl-flex actions">
+					{actions.map(
+						({ attrs: { class: className, ...attrs } = {}, icon, link: href, text, variant }) => (
+							<LinkButton {href} {variant} icon={icon?.name} class:list={[className]} {...attrs}>
+								{text}
+								{icon?.html && <Fragment set:html={icon.html} />}
+							</LinkButton>
+						)
+					)}
+				</div>
+			)
+		}
+	</div>
+</div>
+
+<style>
+	@layer starlight.core {
+		.hero {
+			display: grid;
+			grid-template-columns: 100%;
+			align-items: center;
+			gap: 1rem;
+			padding-bottom: 1rem;
+		}
+
+		.hero > img,
+		.hero > .hero-html {
+			object-fit: contain;
+			width: min(70%, 20rem);
+			height: auto;
+			margin-inline: auto;
+		}
+
+		.stack {
+			flex-direction: column;
+			gap: clamp(1.5rem, calc(1.5rem + 1vw), 2rem);
+			text-align: center;
+		}
+
+		.copy {
+			flex-direction: column;
+			gap: 1rem;
+			align-items: center;
+		}
+
+		.copy > * {
+			max-width: 50ch;
+		}
+
+		h1 {
+			font-size: clamp(var(--sl-text-3xl), calc(0.25rem + 5vw), var(--sl-text-6xl));
+			line-height: var(--sl-line-height-headings);
+			font-weight: 600;
+			color: var(--sl-color-white);
+		}
+
+		.tagline {
+			font-size: clamp(var(--sl-text-base), calc(0.0625rem + 2vw), var(--sl-text-xl));
+			color: var(--sl-color-gray-2);
+		}
+
+		.actions {
+			gap: 1rem 2rem;
+			flex-wrap: wrap;
+			justify-content: center;
+		}
+
+		/* Mobile: hide the side hero-html, the inline copy under <h1>
+		   carries the media. */
+		.hero > .hero-html {
+			display: none;
+		}
+		.hero-html-inline {
+			width: 100%;
+			margin-inline: auto;
+		}
+
+		@media (min-width: 50rem) {
+			.hero {
+				grid-template-columns: 7fr 4fr;
+				gap: 3%;
+				padding-block: clamp(2.5rem, calc(1rem + 10vmin), 10rem);
+			}
+
+			.hero > img,
+			.hero > .hero-html {
+				order: 2;
+				width: min(100%, 25rem);
+			}
+
+			/* Desktop: show the side hero-html again, hide the inline
+			   copy that mobile uses. */
+			.hero > .hero-html {
+				display: flex;
+			}
+			.hero-html-inline {
+				display: none;
+			}
+
+			.stack {
+				text-align: start;
+			}
+
+			.copy {
+				align-items: flex-start;
+			}
+
+			.actions {
+				justify-content: flex-start;
+			}
+		}
+	}
+</style>

--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -71,10 +71,12 @@
 	border-radius: 16px;
 }
 
-/* Hero side video — replaces the static logo on the splash home. Sized
-   to match the slot Starlight reserves for hero images and rounded so
-   it sits cleanly inside the hero panel. */
-.hero .hero-html .hero-video {
+/* Hero video — replaces the static logo on the splash home. Sized to
+   match the slot Starlight reserves for hero images, and rounded so it
+   sits cleanly inside the hero panel. The same CSS applies whether the
+   video is rendered in the side slot (desktop) or under the headline
+   (mobile, via the local Hero.astro override). */
+.hero .hero-video {
 	width: 100%;
 	max-width: 36rem;
 	height: auto;
@@ -82,14 +84,6 @@
 	border-radius: 12px;
 	box-shadow: 0 6px 24px rgba(99, 102, 241, 0.18);
 	display: block;
-}
-
-/* On mobile (single-column hero) place the video below the headline +
-   CTA stack. On desktop Starlight already moves it to the right column. */
-@media (max-width: 50rem) {
-	.hero > .hero-html {
-		order: 2;
-	}
 }
 
 /* Cards / link cards — match AttributePanel chrome:


### PR DESCRIPTION
Override Starlight's Hero so the demo video sits between the title and the tagline on mobile, while the desktop side-by-side layout is unchanged.