### PR TITLE
docs: add intersections to README feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # <img src="./docs/images/logo.png" width="32" height="32" align="center" /> drawtonomy
 
 <h3 align="center">
-  Whiteboard for Driving Diagrams 🚗
+  Whiteboard for driving scenarios
 </h3>
 
 <p align="center">
-  Intuitively place lanes, vehicles, pedestrians, and traffic lights.<br />
-  Browser-based. For autonomous driving development, traffic planning, and driving education.
+  Place lanes, intersections, vehicles, pedestrians, and traffic lights in the browser.<br />
+  For autonomous driving development, traffic planning, and driving education.<br />
+  Saves are re-editable; scenes can also be exported to OpenSCENARIO, OpenDRIVE, and Lanelet2.
 </p>
 
 <h4 align="center">


### PR DESCRIPTION
Small README cleanup.

- Add \`intersections\` to the feature line so the listed shapes match
  what the app actually places.
- Fold the standalone \`Browser-based.\` sentence into the main line as
  \`... in the browser.\` — same meaning, one less fragment.

The heading and audience line are unchanged.