### PR TITLE
docs: add intersections to README feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 </h3>
 
 <p align="center">
-  Intuitively place lanes, vehicles, pedestrians, and traffic lights.<br />
-  Browser-based. For autonomous driving development, traffic planning, and driving education.
+  Intuitively place lanes, intersections, vehicles, pedestrians, and traffic lights in the browser.<br />
+  For autonomous driving development, traffic planning, and driving education.
 </p>
 
 <h4 align="center">


### PR DESCRIPTION
Small README cleanup.

- Add \`intersections\` to the feature line so the listed shapes match what the app actually places.
- Fold the standalone \`Browser-based.\` sentence into the main line as \`... in the browser.\` — same meaning, one less fragment.

The heading and audience line are unchanged.

(Replaces #65, which was closed because the earlier proposal moved away from the project's core "driving diagrams" identity.)