### PR TITLE
feat(templates): add 6 XYZ axis templates at the top of Others

### DIFF
--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1604,6 +1604,78 @@
   ],
   "other": [
     {
+      "id": "axis_z_up",
+      "name": "Axis Z toward viewer",
+      "svg": "other/axis_z_up.svg",
+      "w": 60,
+      "h": 60,
+      "viewBox": [
+        200,
+        200
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "axis_z_depth",
+      "name": "Axis Z into screen",
+      "svg": "other/axis_z_depth.svg",
+      "w": 60,
+      "h": 60,
+      "viewBox": [
+        200,
+        200
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "axis_x_up",
+      "name": "Axis X toward viewer",
+      "svg": "other/axis_x_up.svg",
+      "w": 60,
+      "h": 60,
+      "viewBox": [
+        200,
+        200
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "axis_x_depth",
+      "name": "Axis X into screen",
+      "svg": "other/axis_x_depth.svg",
+      "w": 60,
+      "h": 60,
+      "viewBox": [
+        200,
+        200
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "axis_y_up",
+      "name": "Axis Y toward viewer",
+      "svg": "other/axis_y_up.svg",
+      "w": 60,
+      "h": 60,
+      "viewBox": [
+        200,
+        200
+      ],
+      "defaultColor": "transparent"
+    },
+    {
+      "id": "axis_y_depth",
+      "name": "Axis Y into screen",
+      "svg": "other/axis_y_depth.svg",
+      "w": 60,
+      "h": 60,
+      "viewBox": [
+        200,
+        200
+      ],
+      "defaultColor": "transparent"
+    },
+    {
       "id": "building",
       "name": "Building",
       "svg": "other/building.svg",
@@ -2043,7 +2115,10 @@
       "svg": "road_marking/marking_arrow_straight.svg",
       "w": 24,
       "h": 60,
-      "viewBox": [200, 500],
+      "viewBox": [
+        200,
+        500
+      ],
       "replaceColor": "#000000",
       "defaultColor": "white"
     },
@@ -2053,7 +2128,10 @@
       "svg": "road_marking/marking_arrow_left.svg",
       "w": 24,
       "h": 60,
-      "viewBox": [200, 500],
+      "viewBox": [
+        200,
+        500
+      ],
       "replaceColor": "#000000",
       "defaultColor": "white"
     },
@@ -2063,7 +2141,10 @@
       "svg": "road_marking/marking_arrow_right.svg",
       "w": 24,
       "h": 60,
-      "viewBox": [200, 500],
+      "viewBox": [
+        200,
+        500
+      ],
       "replaceColor": "#000000",
       "defaultColor": "white"
     },
@@ -2073,7 +2154,10 @@
       "svg": "road_marking/marking_arrow_straight_left.svg",
       "w": 24,
       "h": 60,
-      "viewBox": [200, 500],
+      "viewBox": [
+        200,
+        500
+      ],
       "replaceColor": "#000000",
       "defaultColor": "white"
     },
@@ -2083,7 +2167,10 @@
       "svg": "road_marking/marking_arrow_straight_right.svg",
       "w": 24,
       "h": 60,
-      "viewBox": [200, 500],
+      "viewBox": [
+        200,
+        500
+      ],
       "replaceColor": "#000000",
       "defaultColor": "white"
     },
@@ -2093,7 +2180,10 @@
       "svg": "road_marking/marking_arrow_left_right.svg",
       "w": 24,
       "h": 60,
-      "viewBox": [200, 500],
+      "viewBox": [
+        200,
+        500
+      ],
       "replaceColor": "#000000",
       "defaultColor": "white"
     },
@@ -2103,7 +2193,10 @@
       "svg": "road_marking/marking_arrow_uturn.svg",
       "w": 24,
       "h": 60,
-      "viewBox": [200, 500],
+      "viewBox": [
+        200,
+        500
+      ],
       "replaceColor": "#000000",
       "defaultColor": "white"
     },
@@ -2113,7 +2206,10 @@
       "svg": "road_marking/marking_no_uturn.svg",
       "w": 24,
       "h": 60,
-      "viewBox": [200, 500],
+      "viewBox": [
+        200,
+        500
+      ],
       "replaceColor": "#000000",
       "defaultColor": "white"
     },
@@ -2123,7 +2219,10 @@
       "svg": "road_marking/marking_speed_limit.svg",
       "w": 30,
       "h": 22,
-      "viewBox": [200, 140],
+      "viewBox": [
+        200,
+        140
+      ],
       "replaceColor": "#000000",
       "defaultColor": "white"
     },
@@ -2133,7 +2232,10 @@
       "svg": "road_marking/marking_diamond.svg",
       "w": 24,
       "h": 60,
-      "viewBox": [200, 500],
+      "viewBox": [
+        200,
+        500
+      ],
       "replaceColor": "#000000",
       "defaultColor": "white"
     }

--- a/templates/other/axis_x_depth.svg
+++ b/templates/other/axis_x_depth.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 200 200" fill="none">
+  <line x1="150" y1="150" x2="60.0" y2="150.0" stroke="#1971C2" stroke-width="20" stroke-linecap="butt"/>
+  <polygon points="30.0,150.0 60.0,131.0 60.0,169.0" fill="#1971C2"/>
+  <line x1="150" y1="150" x2="150.0" y2="60.0" stroke="#2F9E44" stroke-width="20" stroke-linecap="butt"/>
+  <polygon points="150.0,30.0 169.0,60.0 131.0,60.0" fill="#2F9E44"/>
+  <polygon points="140.0,140.0 160.0,140.0 160.0,160.0" fill="#2F9E44"/>
+  <polygon points="140.0,140.0 160.0,160.0 140.0,160.0" fill="#1971C2"/>
+</svg>

--- a/templates/other/axis_x_up.svg
+++ b/templates/other/axis_x_up.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 200 200" fill="none">
+  <line x1="150" y1="150" x2="60.0" y2="150.0" stroke="#1971C2" stroke-width="20" stroke-linecap="butt"/>
+  <polygon points="30.0,150.0 60.0,131.0 60.0,169.0" fill="#1971C2"/>
+  <line x1="150" y1="150" x2="150.0" y2="60.0" stroke="#2F9E44" stroke-width="20" stroke-linecap="butt"/>
+  <polygon points="150.0,30.0 169.0,60.0 131.0,60.0" fill="#2F9E44"/>
+  <rect x="140.0" y="140.0" width="20" height="20" fill="#2F9E44"/>
+  <circle cx="150" cy="150" r="15" fill="#E03131"/>
+</svg>

--- a/templates/other/axis_y_depth.svg
+++ b/templates/other/axis_y_depth.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 200 200" fill="none">
+  <line x1="150" y1="150" x2="60.0" y2="150.0" stroke="#E03131" stroke-width="20" stroke-linecap="butt"/>
+  <polygon points="30.0,150.0 60.0,131.0 60.0,169.0" fill="#E03131"/>
+  <line x1="150" y1="150" x2="150.0" y2="60.0" stroke="#1971C2" stroke-width="20" stroke-linecap="butt"/>
+  <polygon points="150.0,30.0 169.0,60.0 131.0,60.0" fill="#1971C2"/>
+  <polygon points="140.0,140.0 160.0,140.0 160.0,160.0" fill="#1971C2"/>
+  <polygon points="140.0,140.0 160.0,160.0 140.0,160.0" fill="#E03131"/>
+</svg>

--- a/templates/other/axis_y_up.svg
+++ b/templates/other/axis_y_up.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 200 200" fill="none">
+  <line x1="150" y1="150" x2="60.0" y2="150.0" stroke="#E03131" stroke-width="20" stroke-linecap="butt"/>
+  <polygon points="30.0,150.0 60.0,131.0 60.0,169.0" fill="#E03131"/>
+  <line x1="150" y1="150" x2="150.0" y2="60.0" stroke="#1971C2" stroke-width="20" stroke-linecap="butt"/>
+  <polygon points="150.0,30.0 169.0,60.0 131.0,60.0" fill="#1971C2"/>
+  <rect x="140.0" y="140.0" width="20" height="20" fill="#1971C2"/>
+  <circle cx="150" cy="150" r="15" fill="#2F9E44"/>
+</svg>

--- a/templates/other/axis_z_depth.svg
+++ b/templates/other/axis_z_depth.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 200 200" fill="none">
+  <line x1="150" y1="150" x2="60.0" y2="150.0" stroke="#2F9E44" stroke-width="20" stroke-linecap="butt"/>
+  <polygon points="30.0,150.0 60.0,131.0 60.0,169.0" fill="#2F9E44"/>
+  <line x1="150" y1="150" x2="150.0" y2="60.0" stroke="#E03131" stroke-width="20" stroke-linecap="butt"/>
+  <polygon points="150.0,30.0 169.0,60.0 131.0,60.0" fill="#E03131"/>
+  <polygon points="140.0,140.0 160.0,140.0 160.0,160.0" fill="#E03131"/>
+  <polygon points="140.0,140.0 160.0,160.0 140.0,160.0" fill="#2F9E44"/>
+</svg>

--- a/templates/other/axis_z_up.svg
+++ b/templates/other/axis_z_up.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" viewBox="0 0 200 200" fill="none">
+  <line x1="150" y1="150" x2="60.0" y2="150.0" stroke="#2F9E44" stroke-width="20" stroke-linecap="butt"/>
+  <polygon points="30.0,150.0 60.0,131.0 60.0,169.0" fill="#2F9E44"/>
+  <line x1="150" y1="150" x2="150.0" y2="60.0" stroke="#E03131" stroke-width="20" stroke-linecap="butt"/>
+  <polygon points="150.0,30.0 169.0,60.0 131.0,60.0" fill="#E03131"/>
+  <rect x="140.0" y="140.0" width="20" height="20" fill="#E03131"/>
+  <circle cx="150" cy="150" r="15" fill="#1971C2"/>
+</svg>


### PR DESCRIPTION
## Overview

Adds 6 XYZ coordinate-axis templates to the top of the Others category. Top-down, orthogonal style (X=red / Y=green / Z=blue).

<img width="900" height="600" alt="xyz_sheet9" src="https://github.com/user-attachments/assets/fef58692-b1f8-400d-a9ee-a8455654db64" />


## Rules

- The axis that points along the viewing direction (toward/into the screen) is rendered differently per template:
  - **Toward viewer** → drawn as a colored dot at the center.
  - **Into screen** → the corner square (same thickness as the axes) is split diagonally into two colors (top half = up-axis color, bottom half = left-axis color).
- The remaining two axes are arrows pointing up (vertical) and left (horizontal). Line, L-joint, and corner all share a uniform thickness.

## Template list (in this order, at the head of the `other` array)

| id | name | up | left | view-direction axis |
|----|------|----|------|------|
| `axis_z_up` (default) | Axis Z toward viewer | red X | green Y | blue Z (dot) |
| `axis_z_depth` | Axis Z into screen | red X | green Y | Z (diagonal corner) |
| `axis_x_up` | Axis X toward viewer | green Y | blue Z | red X (dot) |
| `axis_x_depth` | Axis X into screen | green Y | blue Z | X (diagonal corner) |
| `axis_y_up` | Axis Y toward viewer | blue Z | red X | green Y (dot) |
| `axis_y_depth` | Axis Y into screen | blue Z | red X | Y (diagonal corner) |

## Changed files

- `templates/other/axis_{z,x,y}_{up,depth}.svg` (6 new files)
- `templates/manifest.json` (6 entries prepended to the `other` array)