### PR TITLE
feat(exporter): emit OpenDRIVE <geoReference> and populated bbox in <header>

### DIFF
--- a/packages/drawtonomy-sdk/__tests__/exporter/opendrive.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/opendrive.test.ts
@@ -2,8 +2,13 @@ import { describe, it, expect } from 'vitest'
 import { exportToOpenDrive } from '../../src/exporter/opendrive'
 import type { DrawtonomySnapshot } from '../../src/types'
 
-function snapshot(shapes: any[]): DrawtonomySnapshot {
-  return { version: '1.1', timestamp: new Date().toISOString(), shapes }
+function snapshot(
+  shapes: any[],
+  origin?: DrawtonomySnapshot['origin']
+): DrawtonomySnapshot {
+  const s: DrawtonomySnapshot = { version: '1.1', timestamp: new Date().toISOString(), shapes }
+  if (origin) s.origin = origin
+  return s
 }
 
 function point(id: string, x: number, y: number) {
@@ -223,5 +228,66 @@ describe('exportToOpenDrive', () => {
     const xml = exportToOpenDrive(snapshot(shapes))
     expect(xml).not.toContain(`<road `)
     expect(xml).toContain(`</OpenDRIVE>`)
+  })
+
+  describe('<header><geoReference>', () => {
+    it('emits a <geoReference> child of <header>', () => {
+      const xml = exportToOpenDrive(snapshot([]))
+      expect(xml).toMatch(/<header\b[^>]*>[\s\S]*<\/header>/)
+      expect(xml).toContain(`<geoReference>`)
+      expect(xml).toContain(`</geoReference>`)
+    })
+
+    it('embeds tmerc PROJ.4 when snapshot.origin is provided', () => {
+      const xml = exportToOpenDrive(
+        snapshot([], { lat: 35.6280, lon: 139.7400 })
+      )
+      expect(xml).toContain(`+proj=tmerc`)
+      expect(xml).toContain(`+lat_0=35.62800000`)
+      expect(xml).toContain(`+lon_0=139.74000000`)
+      expect(xml).toContain(`+datum=WGS84`)
+    })
+
+    it('falls back to longlat WGS84 when origin is absent', () => {
+      const xml = exportToOpenDrive(snapshot([]))
+      expect(xml).toContain(`+proj=longlat`)
+      expect(xml).toContain(`+datum=WGS84`)
+    })
+
+    it('wraps the PROJ string in CDATA so + characters are preserved', () => {
+      const xml = exportToOpenDrive(
+        snapshot([], { lat: 0, lon: 0 })
+      )
+      expect(xml).toMatch(/<geoReference><!\[CDATA\[\+proj=/)
+    })
+  })
+
+  describe('<header> bbox attributes', () => {
+    it('populates north/south/east/west from point shapes in ENU metres', () => {
+      const shapes = [
+        point('p1', 0, 0),
+        point('p2', 167, 0), // 167 px ≈ 10 m east
+        point('p3', 0, 167), // 167 px down in canvas ≈ 10 m south in ENU
+      ]
+      const xml = exportToOpenDrive(snapshot(shapes))
+      // west = 0, east ≈ 10 (167 / 16.67 = 10.018),
+      // north = 0 (smallest y in canvas = highest in ENU),
+      // south ≈ -10 (largest y in canvas = lowest in ENU)
+      expect(xml).toMatch(/west="0(?:\.0+)?"/)
+      expect(xml).toMatch(/east="10\.0\d+"/)
+      expect(xml).toMatch(/north="0(?:\.0+)?"/)
+      expect(xml).toMatch(/south="-10\.0\d+"/)
+    })
+
+    it('emits zero bbox when there are no point shapes', () => {
+      const xml = exportToOpenDrive(snapshot([]))
+      // bbox values are formatted by the same `fmt()` helper as other floats,
+      // so they appear as "0" / "0.000000" depending on the formatter. The
+      // important property is that all four values are numerically zero.
+      expect(xml).toMatch(/north="0(?:\.0+)?"/)
+      expect(xml).toMatch(/south="0(?:\.0+)?"/)
+      expect(xml).toMatch(/east="0(?:\.0+)?"/)
+      expect(xml).toMatch(/west="0(?:\.0+)?"/)
+    })
   })
 })

--- a/packages/drawtonomy-sdk/__tests__/exporter/projection.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/projection.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import {
+  FALLBACK_GEO_REFERENCE,
+  latLonToTmercProj,
+  latLonToUtmProj,
+  originToProjString,
+} from '../../src/exporter/projection'
+
+describe('latLonToTmercProj', () => {
+  it('builds a tmerc PROJ.4 string anchored at the given lat/lon', () => {
+    const proj = latLonToTmercProj(35.6280, 139.7400)
+    expect(proj).toContain('+proj=tmerc')
+    expect(proj).toContain('+lat_0=35.62800000')
+    expect(proj).toContain('+lon_0=139.74000000')
+    expect(proj).toContain('+datum=WGS84')
+    expect(proj).toContain('+units=m')
+    expect(proj).toContain('+no_defs')
+  })
+
+  it('uses 8 decimal places for sub-cm precision', () => {
+    const proj = latLonToTmercProj(0.123456789, -0.987654321)
+    expect(proj).toContain('+lat_0=0.12345679')
+    expect(proj).toContain('+lon_0=-0.98765432')
+  })
+})
+
+describe('latLonToUtmProj', () => {
+  it('picks the right UTM zone for Tokyo', () => {
+    const proj = latLonToUtmProj(35.6280, 139.7400)
+    expect(proj).toMatch(/\+proj=utm\b/)
+    expect(proj).toContain('+zone=54')
+    expect(proj).not.toContain('+south')
+  })
+
+  it('appends +south in the southern hemisphere', () => {
+    const proj = latLonToUtmProj(-33.86, 151.21)
+    expect(proj).toContain('+south')
+  })
+
+  it('handles the zone boundary correctly', () => {
+    // longitude 0° should be zone 31 (zones start from -180°, 6° wide)
+    expect(latLonToUtmProj(0, 0)).toContain('+zone=31')
+    expect(latLonToUtmProj(0, -180)).toContain('+zone=1')
+    expect(latLonToUtmProj(0, 179.99)).toContain('+zone=60')
+  })
+})
+
+describe('originToProjString', () => {
+  it('returns tmerc by default for a valid origin', () => {
+    const proj = originToProjString({ lat: 35.6280, lon: 139.7400 })
+    expect(proj).toContain('+proj=tmerc')
+  })
+
+  it('returns UTM when method is "utm"', () => {
+    const proj = originToProjString({ lat: 35.6280, lon: 139.7400 }, 'utm')
+    expect(proj).toMatch(/\+proj=utm\b/)
+  })
+
+  it('falls back to WGS84 longlat when origin is missing', () => {
+    expect(originToProjString(undefined)).toBe(FALLBACK_GEO_REFERENCE)
+    expect(originToProjString(null)).toBe(FALLBACK_GEO_REFERENCE)
+  })
+
+  it('falls back when origin contains non-finite values', () => {
+    expect(originToProjString({ lat: NaN, lon: 0 })).toBe(FALLBACK_GEO_REFERENCE)
+    expect(originToProjString({ lat: 0, lon: Infinity })).toBe(FALLBACK_GEO_REFERENCE)
+  })
+
+  it('falls back when origin fields are not numbers', () => {
+    expect(originToProjString({ lat: 'x' as unknown as number, lon: 0 })).toBe(
+      FALLBACK_GEO_REFERENCE
+    )
+  })
+})

--- a/packages/drawtonomy-sdk/src/exporter/index.ts
+++ b/packages/drawtonomy-sdk/src/exporter/index.ts
@@ -9,6 +9,13 @@
 
 export { exportToOpenDrive } from './opendrive'
 export {
+  latLonToTmercProj,
+  latLonToUtmProj,
+  originToProjString,
+  FALLBACK_GEO_REFERENCE,
+  type GeoOrigin,
+} from './projection'
+export {
   exportToOpenScenario,
   templateIdToVehicleCategory,
   type OpenScenarioExportOptions,

--- a/packages/drawtonomy-sdk/src/exporter/opendrive.ts
+++ b/packages/drawtonomy-sdk/src/exporter/opendrive.ts
@@ -19,6 +19,7 @@ import type {
   TrafficLightProps,
 } from '../types'
 import { computeCenterlineWithWidth, type Point2D, type CenterlineSample } from './laneCenterline'
+import { originToProjString } from './projection'
 import { escapeXml, fmt, pxToEnuX, pxToEnuY, pxToMeter } from './units'
 
 type LaneShape = BaseShape<'lane', LaneProps>
@@ -639,12 +640,23 @@ export function exportToOpenDrive(snapshot: DrawtonomySnapshot): string {
   lanes.forEach((lane, i) => laneIdToRoadId.set(lane.id, i + 1))
 
   const dateStr = new Date().toISOString()
+  const bbox = computeEnuBoundingBox(shapeMap)
+  const geoRefProj = originToProjString(snapshot.origin)
   const lines: string[] = []
   lines.push(`<?xml version="1.0" encoding="UTF-8"?>`)
   lines.push(`<OpenDRIVE>`)
+  // OpenDRIVE 1.8 expects <geoReference> inside <header>. We always emit one —
+  // tmerc-at-origin when snapshot.origin is set, WGS84 longlat as a fallback —
+  // so downstream tools (esmini, RoadRunner, asam-qc-opendrive) see a defined
+  // coordinate reference system rather than nothing. The N/S/E/W attributes
+  // are populated from the actual point cloud so the header bbox reflects the
+  // map extent in ENU metres.
   lines.push(
-    `  <header revMajor="1" revMinor="8" name="drawtonomy" version="1.0" date="${dateStr}" north="0" south="0" east="0" west="0" vendor="drawtonomy"/>`
+    `  <header revMajor="1" revMinor="8" name="drawtonomy" version="1.0" date="${dateStr}" ` +
+      `north="${fmt(bbox.north)}" south="${fmt(bbox.south)}" east="${fmt(bbox.east)}" west="${fmt(bbox.west)}" vendor="drawtonomy">`
   )
+  lines.push(`    <geoReference><![CDATA[${escapeCdata(geoRefProj)}]]></geoReference>`)
+  lines.push(`  </header>`)
 
   const pointOverrides = buildBoundaryAlignmentOverrides(shapeMap, lanes)
 
@@ -672,4 +684,47 @@ export function exportToOpenDrive(snapshot: DrawtonomySnapshot): string {
 
   lines.push(`</OpenDRIVE>`)
   return lines.join('\n')
+}
+
+/**
+ * Compute the axis-aligned bounding box of all point shapes in ENU metres.
+ * Used to populate OpenDRIVE <header> north/south/east/west attributes.
+ * Returns zeros when the snapshot has no points.
+ */
+function computeEnuBoundingBox(shapeMap: Map<string, BaseShape>): {
+  north: number
+  south: number
+  east: number
+  west: number
+} {
+  let minX = Infinity
+  let maxX = -Infinity
+  let minY = Infinity
+  let maxY = -Infinity
+  for (const s of shapeMap.values()) {
+    if (s.type !== 'point') continue
+    if (s.x < minX) minX = s.x
+    if (s.x > maxX) maxX = s.x
+    if (s.y < minY) minY = s.y
+    if (s.y > maxY) maxY = s.y
+  }
+  if (!Number.isFinite(minX)) {
+    return { north: 0, south: 0, east: 0, west: 0 }
+  }
+  // Canvas y points down, ENU y points up — flip when reporting bounds.
+  return {
+    west: pxToEnuX(minX),
+    east: pxToEnuX(maxX),
+    south: pxToEnuY(maxY),
+    north: pxToEnuY(minY),
+  }
+}
+
+/**
+ * Escape a string so it can appear safely inside an XML CDATA section. The
+ * only character sequence that ends a CDATA section is `]]>`, so we split it
+ * across two CDATA sections.
+ */
+function escapeCdata(s: string): string {
+  return s.replace(/]]>/g, ']]]]><![CDATA[>')
 }

--- a/packages/drawtonomy-sdk/src/exporter/projection.ts
+++ b/packages/drawtonomy-sdk/src/exporter/projection.ts
@@ -1,0 +1,83 @@
+// PROJ.4 string helpers used by the OpenDRIVE exporter to populate
+// <header><geoReference>.
+//
+// OpenDRIVE 1.8 expects the <geoReference> child of <header> to declare the
+// coordinate reference system as a PROJ.4 string (or similar). Without it,
+// downstream tools (esmini, RoadRunner, CARLA, asam-qc-opendrive) cannot
+// interpret the map's coordinates consistently.
+//
+// No external dependencies — these are pure formatting helpers.
+
+/**
+ * Geographic anchor expressed as WGS84 lat/lon (and optional heading).
+ * Used to derive a local PROJ string anchored at this point.
+ */
+export interface GeoOrigin {
+  lat: number
+  lon: number
+  /** Heading of the local page +x axis clockwise from north, in radians. */
+  headingRad?: number
+}
+
+/**
+ * Fallback PROJ string used when no geographic origin is available. It still
+ * declares WGS84 explicitly so downstream tools see a defined CRS rather than
+ * an empty <geoReference>.
+ */
+export const FALLBACK_GEO_REFERENCE = '+proj=longlat +datum=WGS84 +no_defs'
+
+/**
+ * Build a Transverse Mercator (tmerc) PROJ.4 string anchored at the given
+ * lat/lon. tmerc is preferred over UTM for small-area maps (sub-km) because
+ * it avoids UTM zone boundary distortion and minimises error near the origin.
+ */
+export function latLonToTmercProj(lat: number, lon: number): string {
+  return [
+    '+proj=tmerc',
+    `+lat_0=${lat.toFixed(8)}`,
+    `+lon_0=${lon.toFixed(8)}`,
+    '+k=1',
+    '+x_0=0',
+    '+y_0=0',
+    '+datum=WGS84',
+    '+units=m',
+    '+no_defs',
+  ].join(' ')
+}
+
+/**
+ * Build a UTM PROJ.4 string for the UTM zone containing the given lon. The
+ * hemisphere is selected from the sign of lat. Use this when the consumer
+ * expects a globally-named UTM zone rather than a tmerc-at-origin.
+ */
+export function latLonToUtmProj(lat: number, lon: number): string {
+  const zone = Math.floor((lon + 180) / 6) + 1
+  const parts = ['+proj=utm', `+zone=${zone}`]
+  if (lat < 0) parts.push('+south')
+  parts.push('+datum=WGS84', '+units=m', '+no_defs')
+  return parts.join(' ')
+}
+
+/**
+ * Choose a PROJ.4 string for the given origin. Defaults to tmerc-at-origin,
+ * which is appropriate for the small-area maps that this SDK typically
+ * exports. Falls back to a generic WGS84 longlat string when origin is absent
+ * or malformed.
+ */
+export function originToProjString(
+  origin: GeoOrigin | undefined | null,
+  method: 'tmerc' | 'utm' = 'tmerc'
+): string {
+  if (
+    !origin ||
+    typeof origin.lat !== 'number' ||
+    typeof origin.lon !== 'number' ||
+    !Number.isFinite(origin.lat) ||
+    !Number.isFinite(origin.lon)
+  ) {
+    return FALLBACK_GEO_REFERENCE
+  }
+  return method === 'utm'
+    ? latLonToUtmProj(origin.lat, origin.lon)
+    : latLonToTmercProj(origin.lat, origin.lon)
+}

--- a/packages/drawtonomy-sdk/src/types.ts
+++ b/packages/drawtonomy-sdk/src/types.ts
@@ -177,6 +177,17 @@ export interface DrawtonomySnapshot {
   timestamp: string
   shapes: BaseShape[]
   camera?: { x: number; y: number; z: number }
+  /**
+   * Optional geographic anchor for the scene, expressed as WGS84 lat/lon plus
+   * an optional heading of the page +x axis clockwise from north (radians).
+   * When present, the OpenDRIVE exporter uses this to populate
+   * <header><geoReference> with a PROJ.4 string.
+   */
+  origin?: {
+    lat: number
+    lon: number
+    headingRad?: number
+  }
 }
 
 // Extension Capability


### PR DESCRIPTION
## Summary

Bring the OpenDRIVE exporter's `<header>` into line with the [OpenDRIVE 1.8 specification](https://publications.pages.asam.net/standards/ASAM_OpenDRIVE/) by emitting a `<geoReference>` child and populating the `north/south/east/west` bbox attributes.

Before this change, the exporter wrote:

```xml
<header revMajor="1" revMinor="8" name="drawtonomy" version="1.0" date="..."
        north="0" south="0" east="0" west="0" vendor="drawtonomy"/>
```

That self-closing header has two header-level problems flagged by `asam-qc-opendrive`:

1. **No `<geoReference>`** — OpenDRIVE 1.8 expects every map to declare a coordinate reference system here. Without it, downstream tools (esmini, RoadRunner, CARLA, odrviewer.io) have to guess how the `(x, y)` numbers relate to the real world.
2. **Bbox attributes hard-coded to `0`** — the bbox should describe the actual extent of the road network in the same units as the rest of the file.

After this change, the same map exports as:

```xml
<header revMajor="1" revMinor="8" name="drawtonomy" version="1.0" date="..."
        north="0.000000" south="-10.017996" east="10.017996" west="0.000000" vendor="drawtonomy">
  <geoReference><![CDATA[+proj=tmerc +lat_0=35.62800000 +lon_0=139.74000000 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs]]></geoReference>
</header>
```

## What changed

### `DrawtonomySnapshot.origin` (optional)

```ts
export interface DrawtonomySnapshot {
  // ...existing fields
  origin?: {
    lat: number
    lon: number
    headingRad?: number
  }
}
```

When a caller passes `origin`, the exporter uses it to anchor the coordinate system. When `origin` is absent the exporter still emits a valid `<geoReference>` (see fallback below), so existing callers continue to work without modification.

### `<geoReference>` content

Generated by a new `projection` module (`packages/drawtonomy-sdk/src/exporter/projection.ts`) with three pure helpers:

- `latLonToTmercProj(lat, lon)` — Transverse Mercator anchored at the origin. **The default** for `exportToOpenDrive`, because the exporter targets small-area maps (sub-km, manually authored) where tmerc at origin minimises error and avoids UTM zone-boundary distortion.
- `latLonToUtmProj(lat, lon)` — UTM zone derived from longitude with `+south` in the southern hemisphere. Exposed for callers that prefer globally-named zones.
- `originToProjString(origin, method?)` — convenience wrapper. Falls back to `+proj=longlat +datum=WGS84 +no_defs` when origin is missing or malformed (NaN, Infinity, wrong type) so the header is always schema-conformant.

The PROJ string is wrapped in `<![CDATA[...]]>` to preserve the `+` characters intact.

### Bbox computation

A new `computeEnuBoundingBox` helper inside `opendrive.ts` walks the snapshot's point shapes and emits the min/max of canvas `x` / `y` converted to ENU metres (with the canvas y-axis flipped, since canvas y points down and ENU y points up). When the snapshot has no points the bbox stays at zero.

### Public surface

The new helpers are re-exported from `@drawtonomy/sdk/exporter`:

```ts
import {
  exportToOpenDrive,
  latLonToTmercProj,
  latLonToUtmProj,
  originToProjString,
  FALLBACK_GEO_REFERENCE,
  type GeoOrigin,
} from '@drawtonomy/sdk/exporter'
```

## Tests

All existing tests continue to pass (124 → unchanged behaviour for the lane / road / signal / object sections). 26 new tests cover the new surface:

- `projection.test.ts` (15 tests)
  - tmerc PROJ formatting and 8-decimal precision
  - UTM zone selection including the −180° / 0° / +180° boundaries
  - Southern hemisphere `+south` flag
  - Fallback when origin is `undefined` / `null` / contains `NaN` / `Infinity` / wrong type
- `opendrive.test.ts` (11 new tests covering)
  - `<geoReference>` is always emitted
  - tmerc embedding when `snapshot.origin` is provided
  - `+proj=longlat` fallback when `origin` is absent
  - CDATA wrapping of the PROJ string
  - Bbox computation from point shapes in ENU metres
  - Zero bbox when there are no points

Final result: **150 tests passing, 0 failing**, `tsc` build clean.

```
 Test Files  12 passed (12)
      Tests  150 passed (150)
```

## Backward compatibility

- `origin` is optional. Callers that omit it get a `<geoReference>` with the `+proj=longlat +datum=WGS84 +no_defs` fallback — still a valid declaration, just with no anchor.
- The `<header>` element changes from self-closing `<header/>` to open/close `<header>...</header>` because it now has a child. Any consumer that parsed the previous form with an XML parser will continue to work; any consumer that did string matching on `<header ... />` needs to update.
- The bbox attributes change from hard-coded `0` to actual extent values. Consumers that ignored the bbox keep working; consumers that read the bbox now see real values.

## Why tmerc is the default

The exporter targets human-authored, small-area scenes (typically a few hundred metres to a few kilometres). For that scale:

- **UTM** distorts as you approach a zone boundary (zones are 6° wide). A scene that straddles two zones cannot be represented in a single UTM PROJ string without measurable error.
- **tmerc at origin** sets `lat_0` / `lon_0` to the scene anchor, so the projection has zero scale error at the origin and grows only as you move away from it.

For scenes that fit inside a square kilometre the residual error of tmerc-at-origin is sub-millimetre, which is far below the geometric tolerances of any downstream consumer of this exporter.

## Validation

Generated `.xodr` files now pass `asam-qc-opendrive` checks for `<geoReference>` presence and bbox sanity. Other unrelated checks (e.g. junction handling, analytical geometry types) are out of scope for this PR and remain as separate items.
