### PR TITLE
chore(sdk): bump @drawtonomy/sdk to 0.8.0

### DIFF
--- a/packages/drawtonomy-sdk/package.json
+++ b/packages/drawtonomy-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drawtonomy/sdk",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "SDK for building drawtonomy extensions",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Backward-compatible additions since 0.7.0 (PR #70):

- OpenDRIVE exporter now emits `<header><geoReference>` (PROJ.4 string) and populates the real bbox in `north/south/east/west`.
- New optional `origin` field on `DrawtonomySnapshot` (`{ lat, lon, headingRad? }`).
- New helpers exported from `@drawtonomy/sdk/exporter`:
  - `latLonToTmercProj`
  - `latLonToUtmProj`
  - `originToProjString`
  - `FALLBACK_GEO_REFERENCE`

No breaking changes. Existing callers that omit `origin` continue to work and get the WGS84 longlat fallback in `<geoReference>`.

After this PR merges, publish to npm with `pnpm publish` from `packages/drawtonomy-sdk`.