### PR TITLE
chore(templates): move police to 5th position

### DIFF
--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -45,6 +45,17 @@
       ]
     },
     {
+      "id": "police",
+      "name": "Police",
+      "svg": "vehicle/police.svg",
+      "w": 30,
+      "h": 56,
+      "viewBox": [
+        566,
+        1130
+      ]
+    },
+    {
       "id": "sportscar",
       "name": "Sports Car",
       "svg": "vehicle/sportscar.svg",
@@ -119,17 +130,6 @@
       "viewBox": [
         506,
         1146
-      ]
-    },
-    {
-      "id": "police",
-      "name": "Police",
-      "svg": "vehicle/police.svg",
-      "w": 30,
-      "h": 56,
-      "viewBox": [
-        566,
-        1130
       ]
     },
     {


### PR DESCRIPTION
## Summary

Move the `police` vehicle template up to the 5th position in the manifest so it appears earlier in the picker, right after the common passenger cars (sedan, vw_beetle, coupe, taxi).

### New order (first 8 entries)

1. sedan
2. vw_beetle
3. coupe
4. taxi
5. **police** ← moved here
6. sportscar
7. jeep
8. pickup

No SVGs are added or removed; this PR only changes ordering in `templates/manifest.json`.