### PR TITLE
feat(exporter): high-quality OpenDRIVE export — road bundling, standard junctions, analytic geometry, carry-through

### DIFF
--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -29,3 +29,45 @@ jobs:
 
       - name: Unit tests
         run: pnpm test
+
+  opendrive-qc:
+    if: contains(github.event.pull_request.labels.*.name, 'run-tests')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/drawtonomy-sdk
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Install ASAM qc-opendrive checker
+        run: pip install asam-qc-opendrive
+
+      - name: Fetch sample maps
+        run: |
+          mkdir -p /tmp/qc/maps
+          base_esmini="https://raw.githubusercontent.com/esmini/esmini/master/resources/xodr"
+          for m in fabriksgatan two_plus_one curves e6mini; do
+            curl -fsSL -o "/tmp/qc/maps/${m}.xodr" "${base_esmini}/${m}.xodr"
+          done
+          curl -fsSL -o /tmp/qc/maps/Town01.xodr \
+            "https://raw.githubusercontent.com/carla-simulator/opendrive-test-files/master/OpenDrive/Town01.xodr"
+
+      - name: Export round trips and a drawn scene
+        run: npx --yes tsx scripts/qc-roundtrip.mts /tmp/qc/maps /tmp/qc/out
+
+      - name: ASAM QC check (fail on ERROR-level issues)
+        run: python scripts/check-qc.py /tmp/qc/out

--- a/packages/drawtonomy-sdk/__tests__/exporter/crosswalkRightOfWay.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/crosswalkRightOfWay.test.ts
@@ -343,9 +343,9 @@ describe('exportToLanelet2 crosswalk', () => {
 })
 
 describe('exportToOpenDrive regulatory carry-through', () => {
-  it('stashes yieldLaneIds as <userData code="yieldRoads"> and restores them on import', () => {
+  it('stashes yieldLaneIds as <userData code="yieldLanes"> and restores them on import', () => {
     const xml = exportToOpenDrive(snapshot(rowLaneShapes()))
-    expect(xml).toContain('<userData code="yieldRoads"')
+    expect(xml).toContain('<userData code="yieldLanes"')
 
     const result = odrToShapes(parseOpenDriveXml(xml))
     expect(result.lanes).toHaveLength(2)

--- a/packages/drawtonomy-sdk/__tests__/exporter/odrGeometryFit.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/odrGeometryFit.test.ts
@@ -1,0 +1,194 @@
+// Unit tests for the plan-view geometry fitter: primitive classification
+// (line / arc / paramPoly3), round-trip deviation against the input samples,
+// C1 continuity between consecutive primitives, and station bookkeeping.
+
+import { describe, it, expect } from 'vitest'
+import { fitPlanView, type FitPoint } from '../../src/exporter/odrGeometryFit'
+import { evalGeometry } from '../../src/exporter/odrGeometry'
+import type { OdrGeometry } from '../../src/exporter/opendriveParser'
+
+const POS_TOL = 0.05
+
+/** Max distance from p to the polyline pts. */
+function distToPolyline(p: { x: number; y: number }, pts: readonly FitPoint[]): number {
+  let best = Infinity
+  for (let i = 0; i < pts.length - 1; i++) {
+    const a = pts[i]
+    const b = pts[i + 1]
+    const dx = b.x - a.x
+    const dy = b.y - a.y
+    const len2 = dx * dx + dy * dy
+    let t = len2 > 1e-18 ? ((p.x - a.x) * dx + (p.y - a.y) * dy) / len2 : 0
+    t = Math.max(0, Math.min(1, t))
+    best = Math.min(best, Math.hypot(p.x - (a.x + t * dx), p.y - (a.y + t * dy)))
+  }
+  return best
+}
+
+/** Evaluate every fitted geometry densely and return the inertial points. */
+function evalDense(geometries: readonly OdrGeometry[], step: number): { x: number; y: number }[] {
+  const out: { x: number; y: number }[] = []
+  for (const g of geometries) {
+    const n = Math.max(2, Math.ceil(g.length / step))
+    for (let k = 0; k <= n; k++) {
+      const p = evalGeometry(g, (g.length * k) / n)
+      out.push({ x: p.x, y: p.y })
+    }
+  }
+  return out
+}
+
+/** Max deviation of the fitted curve from the input polyline (both ways). */
+function maxDeviation(geometries: readonly OdrGeometry[], pts: readonly FitPoint[]): number {
+  let max = 0
+  for (const p of evalDense(geometries, 0.25)) max = Math.max(max, distToPolyline(p, pts))
+  const curve = evalDense(geometries, 0.25)
+  for (const p of pts) max = Math.max(max, distToPolyline(p, curve))
+  return max
+}
+
+/** Assert exact C1 chaining: each primitive starts at its predecessor's end pose. */
+function expectC1(geometries: readonly OdrGeometry[]): void {
+  for (let i = 0; i < geometries.length - 1; i++) {
+    const end = evalGeometry(geometries[i], geometries[i].length)
+    const next = geometries[i + 1]
+    expect(Math.hypot(end.x - next.x, end.y - next.y)).toBeLessThan(1e-9)
+    expect(Math.abs(end.hdg - next.hdg)).toBeLessThan(1e-9)
+  }
+}
+
+function arcPoints(radius: number, sweepRad: number, stepRad: number): FitPoint[] {
+  // Circle centered at (0, radius), starting at origin heading +x (left turn).
+  const pts: FitPoint[] = []
+  for (let a = 0; a <= sweepRad + 1e-12; a += stepRad) {
+    pts.push({ x: radius * Math.sin(a), y: radius * (1 - Math.cos(a)) })
+  }
+  return pts
+}
+
+/** Euler spiral samples by numeric integration: heading = 0.5*cDot*s^2. */
+function clothoidPoints(cDot: number, length: number, step: number): FitPoint[] {
+  const pts: FitPoint[] = [{ x: 0, y: 0 }]
+  let x = 0
+  let y = 0
+  const micro = 0.01
+  let emittedAt = 0
+  for (let s = micro; s <= length + 1e-9; s += micro) {
+    const theta = 0.5 * cDot * (s - micro / 2) ** 2
+    x += micro * Math.cos(theta)
+    y += micro * Math.sin(theta)
+    if (s - emittedAt >= step - 1e-9) {
+      pts.push({ x, y })
+      emittedAt = s
+    }
+  }
+  return pts
+}
+
+describe('fitPlanView', () => {
+  it('fits a straight polyline as exactly one line', () => {
+    const pts: FitPoint[] = []
+    for (let i = 0; i <= 10; i++) pts.push({ x: i * 10, y: 5 + i * 2 })
+    const fit = fitPlanView(pts)
+    expect(fit.geometries).toHaveLength(1)
+    expect(fit.geometries[0].kind).toBe('line')
+    expect(fit.length).toBeCloseTo(Math.hypot(100, 20), 6)
+    expect(maxDeviation(fit.geometries, pts)).toBeLessThanOrEqual(POS_TOL)
+  })
+
+  it('fits circular samples as a single arc with the true curvature', () => {
+    const pts = arcPoints(40, Math.PI * 0.66, Math.PI / 90) // 2 deg steps
+    const fit = fitPlanView(pts)
+    expect(fit.geometries).toHaveLength(1)
+    const g = fit.geometries[0]
+    expect(g.kind).toBe('arc')
+    if (g.kind === 'arc') expect(Math.abs(g.curvature - 1 / 40)).toBeLessThan(1e-4)
+    expect(maxDeviation(fit.geometries, pts)).toBeLessThanOrEqual(POS_TOL)
+  })
+
+  it('keeps a noisy straight polyline a single line within tolerance', () => {
+    // Deterministic pseudo-noise well inside the position tolerance.
+    const pts: FitPoint[] = []
+    for (let i = 0; i <= 40; i++) {
+      pts.push({ x: i * 2.5, y: 0.02 * Math.sin(i * 1.7) })
+    }
+    const fit = fitPlanView(pts)
+    expect(fit.geometries).toHaveLength(1)
+    expect(fit.geometries[0].kind).toBe('line')
+  })
+
+  it('fits a clothoid within tolerance using few primitives, C1-chained', () => {
+    // 120 m Euler spiral from straight to R = 1/(0.005*120) ~ 1.7e2..R=83m end.
+    const pts = clothoidPoints(0.0001, 120, 2)
+    const fit = fitPlanView(pts)
+    expect(fit.geometries.length).toBeLessThan(12)
+    expect(maxDeviation(fit.geometries, pts)).toBeLessThanOrEqual(POS_TOL + 0.01)
+    expectC1(fit.geometries)
+    // A clothoid is neither straight nor constant-curvature over its whole
+    // span, so the fit must use at least one curved primitive.
+    expect(fit.geometries.some(g => g.kind === 'arc' || g.kind === 'paramPoly3')).toBe(true)
+  })
+
+  it('classifies a line->arc compound correctly and stays C1', () => {
+    const straight: FitPoint[] = []
+    for (let i = 0; i <= 10; i++) straight.push({ x: i * 5, y: 0 })
+    const bend = arcPoints(30, Math.PI / 2, Math.PI / 60).map(p => ({ x: p.x + 50, y: p.y }))
+    const pts = [...straight, ...bend.slice(1)]
+    const fit = fitPlanView(pts)
+    expect(fit.geometries.length).toBeLessThanOrEqual(3)
+    expect(fit.geometries[0].kind).toBe('line')
+    expect(fit.geometries.some(g => g.kind === 'arc')).toBe(true)
+    expect(maxDeviation(fit.geometries, pts)).toBeLessThanOrEqual(POS_TOL)
+    expectC1(fit.geometries)
+  })
+
+  it('survives a sharp corner by degrading to chord lines', () => {
+    const pts: FitPoint[] = []
+    for (let i = 0; i <= 10; i++) pts.push({ x: i * 5, y: 0 })
+    for (let i = 1; i <= 10; i++) pts.push({ x: 50, y: i * 5 })
+    const fit = fitPlanView(pts)
+    expect(maxDeviation(fit.geometries, pts)).toBeLessThanOrEqual(POS_TOL)
+    // Two straight legs; the corner itself may add a short chord.
+    expect(fit.geometries.length).toBeLessThanOrEqual(3)
+    for (const g of fit.geometries) expect(g.kind).toBe('line')
+  })
+
+  it('merges sub-tolerance jogs instead of fitting them', () => {
+    // A 5 mm sideways jog at the start (snap/weld artifact) must not produce
+    // a degenerate primitive or corrupt the start heading.
+    const pts: FitPoint[] = [{ x: 0, y: 0 }, { x: 0.003, y: 0.004 }]
+    for (let i = 1; i <= 10; i++) pts.push({ x: i * 5, y: 0 })
+    const fit = fitPlanView(pts)
+    expect(fit.geometries).toHaveLength(1)
+    expect(fit.geometries[0].kind).toBe('line')
+    expect(Math.abs(fit.geometries[0].hdg)).toBeLessThan(0.01)
+  })
+
+  it('returns monotonic stations covering every input sample', () => {
+    const pts = arcPoints(25, Math.PI / 2, Math.PI / 36)
+    const fit = fitPlanView(pts)
+    expect(fit.samplePoses).toHaveLength(pts.length)
+    expect(fit.samplePoses[0].s).toBe(0)
+    for (let i = 1; i < fit.samplePoses.length; i++) {
+      expect(fit.samplePoses[i].s).toBeGreaterThanOrEqual(fit.samplePoses[i - 1].s)
+    }
+    const last = fit.samplePoses[fit.samplePoses.length - 1]
+    expect(last.s).toBeCloseTo(fit.length, 9)
+    // Poses lie on the fitted curve, near their input samples.
+    for (let i = 0; i < pts.length; i++) {
+      const p = fit.samplePoses[i]
+      expect(Math.hypot(p.x - pts[i].x, p.y - pts[i].y)).toBeLessThanOrEqual(POS_TOL + 0.02)
+    }
+  })
+
+  it('handles degenerate inputs without geometries', () => {
+    expect(fitPlanView([]).geometries).toHaveLength(0)
+    expect(fitPlanView([{ x: 1, y: 2 }]).geometries).toHaveLength(0)
+    const dup = fitPlanView([
+      { x: 1, y: 2 },
+      { x: 1, y: 2 },
+    ])
+    expect(dup.geometries).toHaveLength(0)
+    expect(dup.samplePoses).toHaveLength(2)
+  })
+})

--- a/packages/drawtonomy-sdk/__tests__/exporter/odrToShapes.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/odrToShapes.test.ts
@@ -230,12 +230,14 @@ describe('round-trip smoke (import -> export)', () => {
 
     const xml = exportToOpenDrive(snapshot)
     const reparsed = parseOpenDriveXml(xml)
-    // The current exporter emits one <road> per lane.
-    expect(reparsed.roads).toHaveLength(2)
-    for (const road of reparsed.roads) {
-      expect(road.length).toBeGreaterThan(99)
-      expect(road.length).toBeLessThan(101)
-    }
+    // The two adjacent lanes share a boundary, so the exporter bundles them
+    // back into a single <road> with right lanes -1 and -2 — the same
+    // structure as the source file.
+    expect(reparsed.roads).toHaveLength(1)
+    const road = reparsed.roads[0]
+    expect(road.length).toBeGreaterThan(99)
+    expect(road.length).toBeLessThan(101)
+    expect(road.laneSections[0].right.map(l => l.id)).toEqual([-1, -2])
   })
 })
 

--- a/packages/drawtonomy-sdk/__tests__/exporter/opendrive.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/opendrive.test.ts
@@ -60,7 +60,7 @@ describe('exportToOpenDrive', () => {
     expect(xml).toContain(`</OpenDRIVE>`)
   })
 
-  it('emits one road per lane with planView and lanes sections', () => {
+  it('emits a road with planView and lanes sections for a single lane', () => {
     const shapes = [
       point('p1', 0, -5), point('p2', 100, -5),
       point('p3', 0, 5), point('p4', 100, 5),
@@ -77,16 +77,62 @@ describe('exportToOpenDrive', () => {
     expect(xml).toContain(`<laneSection s="0">`)
     expect(xml).toContain(`<center>`)
     expect(xml).toContain(`<right>`)
-    // One drawtonomy lane = one full-width OpenDRIVE lane: the lane reference
-    // is shifted onto the left boundary via laneOffset, so no left lane exists.
+    // The reference line IS the lane's left boundary, so lane -1 spans the
+    // full lane width with no laneOffset and no left lane.
     expect(xml).not.toContain(`<left>`)
-    expect(xml).toContain(`<laneOffset `)
+    expect(xml).not.toContain(`<laneOffset `)
     const width = xml.match(/<width sOffset="0(?:\.0+)?" a="([\d.]+)"/)
     expect(width).not.toBeNull()
     expect(parseFloat(width![1])).toBeCloseTo(0.5999, 2) // 10 px = 0.6 m, full width
-    const offset = xml.match(/<laneOffset s="0(?:\.0+)?" a="([\d.]+)"/)
-    expect(offset).not.toBeNull()
-    expect(parseFloat(offset![1])).toBeCloseTo(0.29997, 2) // +width/2
+  })
+
+  it('bundles laterally adjacent same-direction lanes into one road', () => {
+    const shapes = [
+      point('p1', 0, 0), point('p2', 100, 0),
+      point('p3', 0, 10), point('p4', 100, 10),
+      point('p5', 0, 20), point('p6', 100, 20),
+      linestring('b0', ['p1', 'p2']),
+      linestring('b1', ['p3', 'p4']),
+      linestring('b2', ['p5', 'p6']),
+      lane('lane1', 'b0', 'b1'), // inner lane
+      lane('lane2', 'b1', 'b2'), // its right neighbour (shares b1)
+    ]
+    const xml = exportToOpenDrive(snapshot(shapes))
+    // One <road> carrying both lanes as -1 / -2, not two single-lane roads.
+    expect(xml.match(/<road /g)).toHaveLength(1)
+    expect(xml).toContain(`<lane id="-1" type="driving"`)
+    expect(xml).toContain(`<lane id="-2" type="driving"`)
+    // Per-lane attributes stay separate in the userData stash.
+    expect(xml).toContain(`<userData code="laneAttributes"`)
+    const ud = xml.match(/<userData code="laneAttributes" value="([^"]+)"/)
+    expect(ud).not.toBeNull()
+    const parsed = JSON.parse(ud![1].replace(/&quot;/g, '"'))
+    expect(Object.keys(parsed).sort()).toEqual(['-1', '-2'])
+  })
+
+  it('keeps opposite-direction neighbours in separate roads', () => {
+    const shapes = [
+      point('p1', 0, 0), point('p2', 100, 0),
+      point('p3', 0, 10), point('p4', 100, 10),
+      point('p5', 0, 20), point('p6', 100, 20),
+      linestring('b0', ['p1', 'p2']),
+      linestring('b1', ['p3', 'p4']),
+      linestring('b2', ['p5', 'p6']),
+      // lane1 travels +x; lane2 shares b1 as its (inverted) left boundary but
+      // travels -x — the same encoding the OpenDRIVE importer uses for left
+      // lanes of a two-way road.
+      lane('lane1', 'b0', 'b1'),
+      {
+        ...lane('lane2', 'b1', 'b2'),
+        props: {
+          ...lane('lane2', 'b1', 'b2').props,
+          invertLeft: true,
+          invertRight: true,
+        },
+      },
+    ]
+    const xml = exportToOpenDrive(snapshot(shapes))
+    expect(xml.match(/<road /g)).toHaveLength(2)
   })
 
   it('preserves lane types from odr_type and lanelet subtypes', () => {

--- a/packages/drawtonomy-sdk/__tests__/exporter/roundtripFidelity.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/roundtripFidelity.test.ts
@@ -31,8 +31,10 @@
 //   Fix D — lanelet-only lane tags ride in <userData code="laneAttributes">,
 //           multi-road signal validity in <signalReference>, stop lines in
 //           <userData code="stopLine">, and are restored on import.
-//   Fix E — boundary-alignment snapping never merges a lane's own start and
-//           end clusters, so sub-epsilon connecting lanes survive export.
+//   Fix E — boundary-alignment snapping never merges a lane's start-side and
+//           end-side endpoint Points into one cluster (tracked per point id,
+//           covering Points shared with neighbouring lanes), so sub-epsilon
+//           connecting lanes survive export.
 //
 // Real-world fixtures: esmini's fabriksgatan.xodr / two_plus_one.xodr ship in
 // __tests__/fixtures. A real Lanelet2 map can additionally be supplied via
@@ -42,12 +44,14 @@
 import { describe, it, expect } from 'vitest'
 import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { parseOpenDriveXml } from '../../src/exporter/opendriveParser'
+import { parseOpenDriveXml, type OdrGeometry } from '../../src/exporter/opendriveParser'
 import { odrToShapes } from '../../src/exporter/odrToShapes'
+import { evalGeometry, sampleReferenceLine } from '../../src/exporter/odrGeometry'
 import { exportToOpenDrive } from '../../src/exporter/opendrive'
 import { exportToLanelet2 } from '../../src/exporter/lanelet2'
 import { parseOsmXml } from '../../src/exporter/osmParser'
 import { osmToShapes, type ImportedShapes } from '../../src/exporter/osmToShapes'
+import { PIXELS_PER_METER } from '../../src/exporter/units'
 import type { DrawtonomySnapshot } from '../../src/types'
 
 // ---------------------------------------------------------------------------
@@ -399,6 +403,7 @@ function snapshotFrom(imported: ImportedShapes): DrawtonomySnapshot {
         next: lane.next,
         prev: lane.prev,
         osmId: lane.osmId,
+        ...(lane.yieldLaneIds ? { yieldLaneIds: lane.yieldLaneIds } : {}),
       },
     })
   }
@@ -419,6 +424,28 @@ function snapshotFrom(imported: ImportedShapes): DrawtonomySnapshot {
         osmId: tl.osmId,
         affectedLaneIds: tl.affectedLaneIds,
         stopLineId: tl.stopLineId,
+      },
+    })
+  }
+  for (const cw of imported.crosswalks ?? []) {
+    shapes.push({
+      id: cw.id,
+      type: 'crosswalk',
+      x: cw.x,
+      y: cw.y,
+      rotation: 0,
+      zIndex: 0,
+      props: {
+        startX: cw.startX,
+        startY: cw.startY,
+        endX: cw.endX,
+        endY: cw.endY,
+        crosswalkWidth: cw.crosswalkWidth,
+        color: 'default',
+        attributes: cw.attributes,
+        osmId: cw.osmId,
+        affectedLaneIds: cw.affectedLaneIds,
+        stopLineId: cw.stopLineId,
       },
     })
   }
@@ -620,8 +647,8 @@ const SYNTHETIC_XODR = `<?xml version="1.0"?>
  * - lane A (r100) -> lane B (r101): consecutive, boundaries share end nodes
  * - lane C (r102): right neighbour of A, sharing way 11 as its left boundary
  * - traffic light regulatory element (r200) on lanes A and C with a stop line
- *   (a multi-lane signal: OpenDRIVE <validity> can only attach to one road
- *   in the 1-lane-per-road export model, so this exercises that loss)
+ *   (a multi-lane signal: A and C bundle into one road, so the OpenDRIVE
+ *   export covers both with a single <validity> lane range)
  * Latitude step of 3.15e-5 deg is roughly 3.5 m.
  */
 const SYNTHETIC_LANELET2 = `<?xml version='1.0' encoding='UTF-8'?>
@@ -696,8 +723,8 @@ const SYNTHETIC_LANELET2 = `<?xml version='1.0' encoding='UTF-8'?>
 
 /**
  * Minimal bidirectional Lanelet2 map: a single lanelet tagged one_way=no.
- * OpenDRIVE roads in the 1-lane-per-road export are always one-directional,
- * so the bidirectional flag is lost through an xodr round trip.
+ * Exported OpenDRIVE roads only carry one-directional right lanes, so the
+ * bidirectional flag is lost through an xodr round trip.
  */
 const BIDIRECTIONAL_LANELET2 = `<?xml version='1.0' encoding='UTF-8'?>
 <osm version='0.6' generator='test'>
@@ -959,20 +986,93 @@ describe('(b) xodr -> shapes -> xodr -> shapes', () => {
       // 1:1 edges ride on road links; branch/merge edges ride on the
       // junctions synthesized by Fix C (see the diamond suite below).
       expect(r.edgesPreserved, `${name}: edges`).toBe(r.edgesBefore)
-      expectAttributesPreserved(r, ['type', 'subtype', 'odr_type', 'one_way'])
+      expectAttributesPreserved(r, [
+        'type',
+        'subtype',
+        'odr_type',
+        'one_way',
+        // Junction turn directions ride per lane in the laneAttributes
+        // userData stash, so they survive even though lane ids shift.
+        'turn_direction',
+      ])
     }
   })
 
-  // Fix B: the exporter emits one <road> per lane with its own reference
-  // line, so re-import would create fresh boundary linestrings per road;
-  // odrToShapes dedupes geometrically identical boundary linestrings so
-  // left/right adjacency (shared boundary linestrings) survives.
-  it('preserves left/right adjacency (Fix B: dedupe shared boundaries)', () => {
+  // Same-direction adjacent lanes are exported as one <road> (lane bundling),
+  // so their shared boundary is structural in the file itself; adjacency
+  // across travel directions (e.g. the two sides of a two-way road) lives in
+  // separate roads and is restored by the importer's boundary dedupe (Fix B).
+  it('preserves left/right adjacency (bundling + Fix B dedupe)', () => {
     for (const { name, imported } of fixtures) {
       const r = measureFidelity(imported, viaOpenDrive(imported))
       expect(r.adjacencyBefore, `${name}: adjacency before`).toBeGreaterThan(0)
       expect(r.adjacencyPreserved, `${name}: adjacency preserved`).toBe(r.adjacencyBefore)
     }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Road bundling: laterally adjacent same-direction lanes become one <road>
+// ---------------------------------------------------------------------------
+
+describe('road bundling (shapes -> xodr structural adjacency)', () => {
+  it('keeps the two adjacent lanes of one road in one exported road (-1/-2)', () => {
+    const before = importXodr(SYNTHETIC_XODR)
+    const snapshot = snapshotFrom(before)
+    if (!snapshot.origin) snapshot.origin = FALLBACK_ORIGIN
+    const xodr = exportToOpenDrive(snapshot)
+    const parsed = parseOpenDriveXml(xodr)
+
+    // Source road 1 carries two adjacent right driving lanes; the export must
+    // keep them inside one road — structurally, in the XML itself, not
+    // recovered by the importer's geometric dedupe.
+    const mainRoads = parsed.roads.filter(r => r.junction === '-1')
+    const twoLaneRoads = mainRoads.filter(r => r.laneSections[0]?.right.length === 2)
+    expect(twoLaneRoads).toHaveLength(1)
+    expect(twoLaneRoads[0].laneSections[0].right.map(l => l.id)).toEqual([-1, -2])
+    // Bundling strictly reduces the mainline road count below
+    // one-road-per-lane (junction-stamped roads are the short synthesized
+    // connecting roads, not lane-carrying mainlines).
+    expect(mainRoads.length).toBeLessThan(before.lanes.length)
+
+    // Re-import: the two lanes carry the same odr_road_id, ids -1/-2, and
+    // share the middle boundary linestring object.
+    const after = importXodr(xodr)
+    const lanes = after.lanes.filter(l => l.attributes.odr_road_id === twoLaneRoads[0].id)
+    expect(lanes).toHaveLength(2)
+    const inner = lanes.find(l => l.attributes.odr_lane_id === '-1')!
+    const outer = lanes.find(l => l.attributes.odr_lane_id === '-2')!
+    expect(inner).toBeDefined()
+    expect(outer).toBeDefined()
+    expect(inner.rightBoundaryId).toBe(outer.leftBoundaryId)
+  })
+
+  it('drops the exported road count well below one-road-per-lane on real maps', () => {
+    for (const { name, imported } of loadXodrFixtures()) {
+      const snapshot = snapshotFrom(imported)
+      if (!snapshot.origin) snapshot.origin = FALLBACK_ORIGIN
+      const parsed = parseOpenDriveXml(exportToOpenDrive(snapshot))
+      const mainRoads = parsed.roads.filter(r => r.junction === '-1')
+      expect(mainRoads.length, `${name}: exported mainline roads`).toBeLessThan(imported.lanes.length)
+      const multiLaneRoads = mainRoads.filter(
+        r => (r.laneSections[0]?.right.length ?? 0) >= 2
+      )
+      expect(multiLaneRoads.length, `${name}: multi-lane roads`).toBeGreaterThan(0)
+    }
+  })
+
+  it('emits multi-lane signal validity as one lane range inside one road', () => {
+    // Lanes A and C of the synthetic Lanelet2 map are laterally adjacent and
+    // both controlled by the signal, so they bundle into one road and the
+    // <validity> covers lanes -2..-1 — no <signalReference> needed.
+    const before = importLanelet2(SYNTHETIC_LANELET2)
+    const snapshot = snapshotFrom(before)
+    if (!snapshot.origin) snapshot.origin = FALLBACK_ORIGIN
+    const xodr = exportToOpenDrive(snapshot)
+    expect(xodr).toContain('<validity fromLane="-2" toLane="-1"/>')
+    expect(xodr).not.toContain('<signalReference')
+    const r = measureFidelity(before, importXodr(xodr))
+    expect(r.trafficLightAffectedPreserved).toBe(r.trafficLightsBefore)
   })
 })
 
@@ -1041,9 +1141,9 @@ describe('(c) lanelet2 -> shapes -> xodr -> shapes', () => {
   })
 
   // Fix D: a regulatory element controlling N lanelets becomes a <signal>
-  // on one road plus <signalReference> records on the other affected roads
-  // (1 lane = 1 road), and the stop line rides in <userData code="stopLine">
-  // on the signal; both are merged back on import.
+  // whose <validity> covers the affected lanes of its road; lanes living in
+  // other road bundles get <signalReference> records. The stop line rides in
+  // <userData code="stopLine"> on the signal; all are merged back on import.
   it('preserves multi-lane signal validity and stop lines (Fix C/D)', () => {
     const before = importLanelet2(SYNTHETIC_LANELET2)
     const r = measureFidelity(before, viaOpenDrive(before))
@@ -1083,6 +1183,99 @@ describe('diamond branch/merge through xodr (shapes -> xodr -> shapes)', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Junction normalization: standard incoming -> connecting -> outgoing roads
+// ---------------------------------------------------------------------------
+
+describe('junction normalization (standard connecting-road structure)', () => {
+  function exportXodr(imported: ImportedShapes): string {
+    const snapshot = snapshotFrom(imported)
+    if (!snapshot.origin) snapshot.origin = FALLBACK_ORIGIN
+    return exportToOpenDrive(snapshot)
+  }
+
+  // Standard OpenDRIVE semantics: roads inside a junction are short
+  // connecting roads carrying a guaranteed predecessor (incoming road) and
+  // successor (outgoing road); the mainlines stay junction="-1". The missing
+  // successor on junction-stamped roads is exactly what esmini warns about
+  // ("connecting road lacks successor").
+  it('emits only short, fully linked connecting roads inside junctions', () => {
+    const sources = [...loadXodrFixtures(), { name: 'diamond', imported: diamondShapes() }]
+    for (const { name, imported } of sources) {
+      const parsed = parseOpenDriveXml(exportXodr(imported))
+      const roadById = new Map(parsed.roads.map(r => [r.id, r]))
+      let connectingCount = 0
+      for (const road of parsed.roads) {
+        if (road.junction === '-1') continue
+        connectingCount++
+        expect(road.length, `${name}: connecting road ${road.id} length`).toBeLessThan(0.5)
+        expect(road.predecessor?.elementType, `${name}: road ${road.id} predecessor`).toBe('road')
+        expect(road.successor?.elementType, `${name}: road ${road.id} successor`).toBe('road')
+      }
+      for (const junction of parsed.junctions) {
+        expect(junction.connections.length, `${name}: junction ${junction.id} connections`).toBeGreaterThan(0)
+        for (const conn of junction.connections) {
+          const connecting = roadById.get(conn.connectingRoad)
+          expect(connecting?.junction, `${name}: connection road ${conn.connectingRoad}`).toBe(junction.id)
+          expect(connecting?.predecessor?.elementId).toBe(conn.incomingRoad)
+          // Incoming and outgoing mainlines are not junction members.
+          expect(roadById.get(conn.incomingRoad)?.junction).toBe('-1')
+          expect(roadById.get(connecting!.successor!.elementId)?.junction).toBe('-1')
+        }
+      }
+      if (parsed.junctions.length > 0) {
+        expect(connectingCount, `${name}: connecting roads exist`).toBeGreaterThan(0)
+      }
+    }
+  })
+
+  // The synthesized connecting roads sit below the importer's micro-section
+  // threshold: a re-import must skip them (no extra sliver lanes) while
+  // bridging the lane links across, keeping the lane set and edge set intact.
+  it('re-imports without materializing the synthesized connecting roads', () => {
+    const before = diamondShapes()
+    const after = importXodr(exportXodr(before))
+    expect(after.lanes).toHaveLength(before.lanes.length)
+    const r = measureFidelity(before, after)
+    expect(r.matchedLanes).toBe(r.laneCountBefore)
+    expect(r.edgesPreserved).toBe(r.edgesBefore)
+  })
+
+  // Right-of-way between two maneuvers of one junction is standard junction
+  // <priority high low> (between connecting roads), replacing the userData
+  // stash for such pairs; the importer maps it back to yieldLaneIds on the
+  // incoming lanes the maneuvers start from.
+  it('expresses junction right-of-way as <priority> and restores yieldLaneIds', () => {
+    const before = diamondShapes()
+    const laneA = before.lanes.find(l => (l.id as string) === 'shape:lane_A')!
+    const laneD = before.lanes.find(l => (l.id as string) === 'shape:lane_D')!
+    laneA.yieldLaneIds = [laneD.id as string] // A has right of way; D yields.
+
+    const xodr = exportXodr(before)
+    const parsed = parseOpenDriveXml(xodr)
+    expect(parsed.junctions).toHaveLength(1)
+    const junction = parsed.junctions[0]
+    // A and D have two maneuvers each -> 2x2 priority records.
+    expect(junction.priorities).toHaveLength(4)
+    const roadById = new Map(parsed.roads.map(r => [r.id, r]))
+    for (const pr of junction.priorities) {
+      expect(roadById.get(pr.high)?.junction).toBe(junction.id)
+      expect(roadById.get(pr.low)?.junction).toBe(junction.id)
+    }
+    // The junction-expressible pair no longer needs the userData fallback.
+    expect(xodr).not.toContain('<userData code="yieldLanes"')
+
+    const after = importXodr(xodr)
+    const rowLanes = after.lanes.filter(l => (l.yieldLaneIds ?? []).length > 0)
+    expect(rowLanes).toHaveLength(1)
+    expect(rowLanes[0].yieldLaneIds).toHaveLength(1)
+    // Lane A was drawn at y=0, lane D at y=200 (canvas px survive the trip).
+    const yielding = after.lanes.find(l => l.id === rowLanes[0].yieldLaneIds![0])!
+    expect(rowLanes[0].y).toBeLessThan(100)
+    expect(yielding.y).toBeGreaterThan(100)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Short connecting lanes vs boundary-alignment snapping (Fix E)
 // ---------------------------------------------------------------------------
 
@@ -1102,6 +1295,341 @@ describe('short connecting lanes through xodr (shapes -> xodr -> shapes)', () =>
     expect(r.laneCountAfter).toBe(r.laneCountBefore)
     expect(r.edgesBefore).toBe(2)
     expect(r.edgesPreserved).toBe(r.edgesBefore)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Plan-view geometry fitting (export quality)
+// ---------------------------------------------------------------------------
+
+/**
+ * Synthetic curvy OpenDRIVE road: line -> spiral -> arc -> spiral -> line
+ * with two right driving lanes. Start poses are chained analytically through
+ * evalGeometry so the plan view is exactly continuous.
+ */
+function buildCurvyXodr(): string {
+  const defs: (Omit<OdrGeometry, 's' | 'x' | 'y' | 'hdg'> & { xml: string })[] = [
+    { kind: 'line', length: 40, xml: '<line/>' },
+    {
+      kind: 'spiral',
+      length: 40,
+      curvStart: 0,
+      curvEnd: 0.02,
+      xml: '<spiral curvStart="0" curvEnd="0.02"/>',
+    },
+    { kind: 'arc', length: 60, curvature: 0.02, xml: '<arc curvature="0.02"/>' },
+    {
+      kind: 'spiral',
+      length: 40,
+      curvStart: 0.02,
+      curvEnd: 0,
+      xml: '<spiral curvStart="0.02" curvEnd="0"/>',
+    },
+    { kind: 'line', length: 30, xml: '<line/>' },
+  ]
+  let pose = { x: 0, y: 0, hdg: 0 }
+  let s = 0
+  const parts: string[] = []
+  for (const d of defs) {
+    const geom = { ...d, s, x: pose.x, y: pose.y, hdg: pose.hdg } as OdrGeometry
+    parts.push(
+      `      <geometry s="${s}" x="${pose.x}" y="${pose.y}" hdg="${pose.hdg}" length="${d.length}">${d.xml}</geometry>`
+    )
+    pose = evalGeometry(geom, d.length)
+    s += d.length
+  }
+  return `<?xml version="1.0"?>
+<OpenDRIVE>
+  <header revMajor="1" revMinor="6">
+    <geoReference><![CDATA[+proj=tmerc +lat_0=35.0 +lon_0=139.0 +datum=WGS84]]></geoReference>
+  </header>
+  <road name="curvy" length="${s}" id="1" junction="-1">
+    <planView>
+${parts.join('\n')}
+    </planView>
+    <lanes>
+      <laneSection s="0">
+        <right>
+          <lane id="-1" type="driving" level="false"><width sOffset="0" a="3.5" b="0" c="0" d="0"/></lane>
+          <lane id="-2" type="driving" level="false"><width sOffset="0" a="3.5" b="0" c="0" d="0"/></lane>
+        </right>
+      </laneSection>
+    </lanes>
+  </road>
+</OpenDRIVE>`
+}
+
+/** Boundary polylines of an imported map in ENU meters. */
+function boundaryPolylinesEnu(shapes: ImportedShapes): { x: number; y: number }[][] {
+  const pointById = new Map(shapes.points.map(p => [p.id, p]))
+  return shapes.linestrings.map(ls =>
+    ls.pointIds
+      .map(id => pointById.get(id))
+      .filter((p): p is NonNullable<typeof p> => !!p)
+      .map(p => ({ x: p.x / PIXELS_PER_METER, y: -p.y / PIXELS_PER_METER }))
+  )
+}
+
+function distToPolyline(p: Pt, poly: readonly Pt[]): number {
+  let best = Infinity
+  for (let i = 0; i < poly.length - 1; i++) {
+    const a = poly[i]
+    const b = poly[i + 1]
+    const dx = b.x - a.x
+    const dy = b.y - a.y
+    const len2 = dx * dx + dy * dy
+    let t = len2 > 1e-18 ? ((p.x - a.x) * dx + (p.y - a.y) * dy) / len2 : 0
+    t = Math.max(0, Math.min(1, t))
+    best = Math.min(best, Math.hypot(p.x - (a.x + t * dx), p.y - (a.y + t * dy)))
+  }
+  return best
+}
+
+/** Max distance (px) from each before-lane boundary point to its matched after boundary. */
+function maxBoundaryDeviationPx(before: ImportedShapes, after: ImportedShapes): number {
+  const topoB = topologySignature(before)
+  const topoA = topologySignature(after)
+  const matching = matchLanesForTest(topoB.geoms, topoA.geoms)
+  const ptB = new Map(before.points.map(p => [p.id, p]))
+  const ptA = new Map(after.points.map(p => [p.id, p]))
+  const lsB = new Map(before.linestrings.map(l => [l.id, l]))
+  const lsA = new Map(after.linestrings.map(l => [l.id, l]))
+  const polyOf = (
+    lane: ImportedShapes['lanes'][number],
+    pts: Map<string, { x: number; y: number }>,
+    ls: Map<string, { pointIds: string[] }>,
+    side: 'left' | 'right'
+  ): Pt[] => {
+    const rec = ls.get(side === 'left' ? lane.leftBoundaryId : lane.rightBoundaryId)
+    if (!rec) return []
+    return rec.pointIds.map(id => pts.get(id)).filter((p): p is Pt => !!p)
+  }
+  let max = 0
+  for (const [b, a] of matching) {
+    for (const side of ['left', 'right'] as const) {
+      const pb = polyOf(before.lanes[b], ptB, lsB, side)
+      const pa = polyOf(after.lanes[a], ptA, lsA, side)
+      if (pb.length < 2 || pa.length < 2) continue
+      for (const p of pb) max = Math.max(max, distToPolyline(p, pa))
+    }
+  }
+  return max
+}
+
+function matchLanesForTest(before: LaneGeom[], after: LaneGeom[]): Map<number, number> {
+  return matchLanes(before, after, DEFAULT_TOL_PX)
+}
+
+describe('plan-view geometry fitting (export quality)', () => {
+  const curvyXml = buildCurvyXodr()
+
+  it('emits compact analytic primitives instead of a line decomposition', () => {
+    const before = importXodr(curvyXml)
+    expect(before.lanes).toHaveLength(2)
+    const xml = exportToOpenDrive(snapshotFrom(before))
+    const geomCount = (xml.match(/<geometry /g) ?? []).length
+    // The previous per-sample line decomposition needed ~40 <line> records
+    // for this road (5 cm chord tolerance on R = 50 m); the fitter must get
+    // far below that and use curved primitives. Tighten only, never relax.
+    expect(geomCount).toBeLessThanOrEqual(16)
+    expect(xml).toContain('<arc ')
+  })
+
+  it('keeps the fitted reference line within tolerance of the source boundaries', () => {
+    const before = importXodr(curvyXml)
+    const exported = parseOpenDriveXml(exportToOpenDrive(snapshotFrom(before)))
+    const boundaries = boundaryPolylinesEnu(before)
+    expect(exported.roads.length).toBeGreaterThan(0)
+    for (const road of exported.roads) {
+      const samples = sampleReferenceLine(road, { maxChordErrorMeters: 0.01, maxStepMeters: 1 })
+      expect(samples.length).toBeGreaterThan(10)
+      for (const sample of samples) {
+        // The road reference line is the bundle's leftmost boundary, so each
+        // re-evaluated point must sit on one of the original boundary
+        // polylines: 5 cm fit tolerance + the polylines' own chordal slack.
+        const d = Math.min(...boundaries.map(b => distToPolyline(sample, b)))
+        expect(d).toBeLessThanOrEqual(0.12)
+      }
+    }
+  })
+
+  it('round-trips curved-lane boundary geometry within 0.15 m', () => {
+    const before = importXodr(curvyXml)
+    const after = viaOpenDrive(before)
+    const r = measureFidelity(before, after)
+    expect(r.laneCountAfter).toBe(r.laneCountBefore)
+    expect(r.matchedLanes).toBe(r.laneCountBefore)
+    expect(r.adjacencyPreserved).toBe(r.adjacencyBefore)
+    const maxDevPx = maxBoundaryDeviationPx(before, after)
+    expect(maxDevPx / PIXELS_PER_METER).toBeLessThanOrEqual(0.15)
+  })
+
+  it('keeps a straight road a single <line> geometry (no regression)', () => {
+    const before = importXodr(SYNTHETIC_XODR)
+    const xml = exportToOpenDrive(snapshotFrom(before))
+    // Synthesized junction connecting stubs are excluded: they blend the
+    // incoming pose onto the outgoing road and legitimately emit an <arc>
+    // when the drawn branch kinks (contact-gap cleanliness, see
+    // emitConnectingRoad).
+    const roadChunks = xml.split('<road ').slice(1).filter(c => !c.startsWith('name="connecting"'))
+    expect(roadChunks.length).toBeGreaterThan(0)
+    for (const chunk of roadChunks) {
+      const planView = chunk.split('<planView>')[1]?.split('</planView>')[0] ?? ''
+      const count = (planView.match(/<geometry /g) ?? []).length
+      expect(count).toBe(1)
+      expect(planView).toContain('<line/>')
+      expect(planView).not.toContain('<arc ')
+      expect(planView).not.toContain('<paramPoly3 ')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Contact-point cleanliness (ASAM QC checker rules)
+// ---------------------------------------------------------------------------
+
+describe('contact-point cleanliness (ASAM QC rules)', () => {
+  const point = (id: string, x: number, y: number) => ({
+    id, type: 'point', x, y, rotation: 0, zIndex: 0,
+    props: { color: 'black', visible: true, osmId: '' },
+  })
+  const linestring = (id: string, pointIds: string[]) => ({
+    id, type: 'linestring', x: 0, y: 0, rotation: 0, zIndex: 0,
+    props: { pointIds, color: 'black', strokeWidth: 2, attributes: {}, osmId: '' },
+  })
+  const lane = (id: string, left: string, right: string, opts: { next?: string[]; prev?: string[] } = {}) => ({
+    id, type: 'lane', x: 0, y: 0, rotation: 0, zIndex: 0,
+    props: {
+      leftBoundaryId: left, rightBoundaryId: right, invertLeft: false, invertRight: false,
+      color: 'default', size: 'm', attributes: { type: 'lanelet', subtype: 'road' },
+      next: opts.next ?? [], prev: opts.prev ?? [], osmId: '',
+    },
+  })
+  const snap = (shapes: unknown[]): DrawtonomySnapshot =>
+    ({ version: '1.1', timestamp: 't', shapes, origin: FALLBACK_ORIGIN } as DrawtonomySnapshot)
+
+  it('omits standard links on zero-width contacts and restores the edge from userData', () => {
+    // Lane t1 tapers to a point (left and right boundaries share the final
+    // Point) where lane t2 grows from the same point — the Town01 sidewalk /
+    // fabriksgatan border pattern. OpenDRIVE forbids linking lanes with zero
+    // width at the linked contact (zero_width_at_start/end, new_lane_appear),
+    // so the edge must leave the standard records and ride in
+    // <userData code="hiddenLaneLinks"> instead — and come back on import.
+    const shapes = [
+      point('p1', 0, -10), point('p2', 100, 0), point('p3', 0, 10),
+      point('p4', 200, -10), point('p5', 200, 10),
+      linestring('t1l', ['p1', 'p2']), linestring('t1r', ['p3', 'p2']),
+      lane('t1', 't1l', 't1r', { next: ['t2'] }),
+      linestring('t2l', ['p2', 'p4']), linestring('t2r', ['p2', 'p5']),
+      lane('t2', 't2l', 't2r', { prev: ['t1'] }),
+    ]
+    const xml = exportToOpenDrive(snap(shapes))
+    expect(xml).not.toContain('<successor id=')
+    expect(xml).not.toContain('<predecessor id=')
+    expect(xml).toContain('userData code="hiddenLaneLinks"')
+    const after = importXodr(xml)
+    expect(after.lanes).toHaveLength(2)
+    const next = after.lanes.flatMap(l => l.next)
+    expect(next).toHaveLength(1)
+  })
+
+  it('keeps narrow connected lanes at full width at the contact (no snap pinch)', () => {
+    // Two connected 10 px (0.6 m) lanes: the endpoint snap must not cluster a
+    // lane's left and right boundary endpoints (which would pinch the lane to
+    // zero width at the weld and bend the geometry).
+    const shapes = [
+      point('p1', 0, -5), point('p2', 100, -5), point('p3', 0, 5), point('p4', 100, 5),
+      linestring('l1l', ['p1', 'p2']), linestring('l1r', ['p3', 'p4']),
+      lane('n1', 'l1l', 'l1r', { next: ['n2'] }),
+      point('p5', 100, -5), point('p6', 200, -5), point('p7', 100, 5), point('p8', 200, 5),
+      linestring('l2l', ['p5', 'p6']), linestring('l2r', ['p7', 'p8']),
+      lane('n2', 'l2l', 'l2r', { prev: ['n1'] }),
+    ]
+    const parsed = parseOpenDriveXml(exportToOpenDrive(snap(shapes)))
+    expect(parsed.roads.length).toBe(2)
+    for (const road of parsed.roads) {
+      const l = road.laneSections[0].right[0]
+      for (const w of l.widths) {
+        // 10 px = 0.6 m everywhere (constant-width rectangles).
+        expect(w.a).toBeGreaterThan(0.55)
+        expect(Math.abs(w.b)).toBeLessThan(1e-6)
+      }
+      // No skew: the reference line stays horizontal.
+      expect(Math.abs(road.planView[0].hdg)).toBeLessThan(1e-6)
+    }
+  })
+
+  it('lands the fitted plan view exactly on the drawn boundary endpoints', () => {
+    // A quarter arc drawn as a polyline: the fitted reference line must end
+    // on the final drawn vertex (the contact point with a neighbouring road),
+    // not merely within the 5 cm fitting band.
+    const n = 24
+    const leftIds: string[] = []
+    const rightIds: string[] = []
+    const shapes: unknown[] = []
+    for (let i = 0; i <= n; i++) {
+      const a = (Math.PI / 2) * (i / n)
+      shapes.push(point(`a${i}`, 560 * Math.cos(a), -560 * Math.sin(a)))
+      shapes.push(point(`b${i}`, 500 * Math.cos(a), -500 * Math.sin(a)))
+      leftIds.push(`a${i}`)
+      rightIds.push(`b${i}`)
+    }
+    shapes.push(linestring('arcL', leftIds), linestring('arcR', rightIds))
+    shapes.push(lane('arc1', 'arcL', 'arcR'))
+    const parsed = parseOpenDriveXml(exportToOpenDrive(snap(shapes)))
+    const road = parsed.roads[0]
+    const last = road.planView[road.planView.length - 1]
+    const end = evalGeometry(last, last.length)
+    // Drawn final left vertex (canvas px -> ENU meters: x/PX, -y/PX).
+    const ex = 0 / PIXELS_PER_METER
+    const ey = 560 / PIXELS_PER_METER
+    expect(Math.hypot(end.x - ex, end.y - ey)).toBeLessThan(0.002)
+    // The start heading honors the drawn tangent (downward in canvas =
+    // +pi/2 in ENU... the arc starts at angle 0 moving toward -y canvas).
+    expect(Math.abs(road.planView[0].hdg - Math.PI / 2)).toBeLessThan(0.01)
+  })
+
+  it('blends synthesized connecting stubs onto kinked outgoing roads (no border step)', () => {
+    // A branch whose exit kinks 0.35 rad at the weld (the hand-drawn case):
+    // the stub must blend heading and width so both of its lane borders meet
+    // the outgoing road within the 1 cm gap tolerance of ASAM QC checkers.
+    const kc = Math.cos(0.35)
+    const ks = Math.sin(0.35)
+    const shapes = [
+      point('m1', 0, -30), point('m2', 300, -30),
+      point('m3', 0, 30), point('m4', 300, 30),
+      linestring('mL', ['m1', 'm2']), linestring('mR', ['m3', 'm4']),
+      lane('main', 'mL', 'mR', { next: ['exitA', 'exitB'] }),
+      point('e1', 300, -30), point('e2', 300 + 200 * kc, -30 + 200 * ks),
+      point('e3', 300, 30), point('e4', 300 + 200 * kc, 30 + 200 * ks),
+      linestring('eL', ['e1', 'e2']), linestring('eR', ['e3', 'e4']),
+      lane('exitA', 'eL', 'eR', { prev: ['main'] }),
+      point('f1', 300, -30), point('f2', 500, -30),
+      point('f3', 300, 30), point('f4', 500, 30),
+      linestring('fL', ['f1', 'f2']), linestring('fR', ['f3', 'f4']),
+      lane('exitB', 'fL', 'fR', { prev: ['main'] }),
+    ]
+    const parsed = parseOpenDriveXml(exportToOpenDrive(snap(shapes)))
+    const roadById = new Map(parsed.roads.map(r => [r.id, r]))
+    const stubs = parsed.roads.filter(r => r.junction !== '-1')
+    expect(stubs.length).toBe(2)
+    for (const stub of stubs) {
+      const out = roadById.get(stub.successor!.elementId)!
+      const stubGeom = stub.planView[0]
+      const stubEnd = evalGeometry(stubGeom, stubGeom.length)
+      const outStart = evalGeometry(out.planView[0], 0)
+      // Inner border: stub end vs outgoing reference start.
+      expect(Math.hypot(stubEnd.x - outStart.x, stubEnd.y - outStart.y)).toBeLessThan(0.01)
+      // Outer border: add each side's width along its own right normal.
+      const wRec = stub.laneSections[0].right[0].widths[0]
+      const stubW = wRec.a + wRec.b * stubGeom.length
+      const wOut = out.laneSections[0].right[0].widths[0].a
+      const ox1 = stubEnd.x + Math.sin(stubEnd.hdg) * stubW
+      const oy1 = stubEnd.y - Math.cos(stubEnd.hdg) * stubW
+      const ox2 = outStart.x + Math.sin(outStart.hdg) * wOut
+      const oy2 = outStart.y - Math.cos(outStart.hdg) * wOut
+      expect(Math.hypot(ox1 - ox2, oy1 - oy2)).toBeLessThan(0.01)
+    }
   })
 })
 
@@ -1155,5 +1683,235 @@ describe.runIf(process.env.ROUNDTRIP_DEBUG === '1')('fidelity matrix (debug)', (
     const { writeFileSync } = await import('node:fs')
     writeFileSync('/tmp/fidelity-matrix.txt', lines.join('\n') + '\n')
     expect(true).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Carry-through export (verbatim re-emission of unedited roads)
+// ---------------------------------------------------------------------------
+
+import { odrToShapes as odrToShapesFull } from '../../src/exporter/odrToShapes'
+import {
+  extractOdrDocument,
+  rewriteRoadLinkTargets,
+} from '../../src/exporter/odrCarryThrough'
+
+describe('carry-through export (sidecar verbatim re-emission)', () => {
+  /** Three single-lane roads chained by plain road links + one signal. */
+  const CHAIN_XODR = `<?xml version="1.0"?>
+<OpenDRIVE>
+  <header revMajor="1" revMinor="6" name="chain">
+    <geoReference><![CDATA[+proj=tmerc +lat_0=35.0 +lon_0=139.0 +datum=WGS84]]></geoReference>
+  </header>
+  <road name="a" length="60" id="1" junction="-1">
+    <link><successor elementType="road" elementId="2" contactPoint="start"/></link>
+    <planView><geometry s="0" x="0" y="0" hdg="0" length="60"><line/></geometry></planView>
+    <lanes>
+      <laneSection s="0">
+        <right>
+          <lane id="-1" type="driving" level="false">
+            <link><successor id="-1"/></link>
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
+    <signals>
+      <signal id="7" s="55" t="-2" zOffset="4.5" name="sig" dynamic="yes" orientation="+" type="1000001" subtype="-1" country="OpenDRIVE" value="0" height="0.8" width="0.5">
+        <validity fromLane="-1" toLane="-1"/>
+      </signal>
+    </signals>
+  </road>
+  <road name="b" length="60" id="2" junction="-1">
+    <link>
+      <predecessor elementType="road" elementId="1" contactPoint="end"/>
+      <successor elementType="road" elementId="3" contactPoint="start"/>
+    </link>
+    <planView><geometry s="0" x="60" y="0" hdg="0" length="60"><line/></geometry></planView>
+    <lanes>
+      <laneSection s="0">
+        <right>
+          <lane id="-1" type="driving" level="false">
+            <link><predecessor id="-1"/><successor id="-1"/></link>
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
+  </road>
+  <road name="c" length="60" id="3" junction="-1">
+    <link><predecessor elementType="road" elementId="2" contactPoint="end"/></link>
+    <planView><geometry s="0" x="120" y="0" hdg="0" length="60"><line/></geometry></planView>
+    <lanes>
+      <laneSection s="0">
+        <right>
+          <lane id="-1" type="driving" level="false">
+            <link><predecessor id="-1"/></link>
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
+  </road>
+</OpenDRIVE>`
+
+  const stripDate = (xml: string): string => xml.replace(/date="[^"]*"/, 'date=""')
+
+  /** Assert a verbatim unedited round trip for the given source document. */
+  const expectVerbatimRoundTrip = (xml: string): void => {
+    const imported = odrToShapesFull(parseOpenDriveXml(xml))
+    expect(imported.sidecar.roadRecords).toBeDefined()
+    const out = exportToOpenDrive(snapshotFrom(imported), { sidecar: imported.sidecar })
+    const doc = extractOdrDocument(xml)!
+    for (const road of doc.roads) {
+      expect(out).toContain(road.text)
+    }
+    for (const junction of doc.junctions) {
+      expect(out).toContain(junction.text)
+    }
+    if (doc.headerText) expect(out).toContain(doc.headerText)
+    // Semantic identity: re-importing the export reproduces the original
+    // lane count, edges, adjacency and signal links exactly.
+    const re = importXodr(out)
+    const rep = measureFidelity(imported, re)
+    expect(rep.laneCountAfter).toBe(rep.laneCountBefore)
+    expect(rep.matchedLanes).toBe(rep.laneCountBefore)
+    expect(rep.edgesAfter).toBe(rep.edgesBefore)
+    expect(rep.edgesPreserved).toBe(rep.edgesBefore)
+    expect(rep.adjacencyAfter).toBe(rep.adjacencyBefore)
+    expect(rep.adjacencyPreserved).toBe(rep.adjacencyBefore)
+    expect(rep.trafficLightsMatched).toBe(rep.trafficLightsBefore)
+    expect(rep.trafficLightAffectedPreserved).toBe(rep.trafficLightsBefore)
+    expect(rep.stopLinesPreserved).toBe(rep.stopLinesBefore)
+  }
+
+  it('re-emits every road verbatim on an unedited chain round trip', () => {
+    expectVerbatimRoundTrip(CHAIN_XODR)
+  })
+
+  it('re-emits the synthetic junction map verbatim (junction + validity)', () => {
+    expectVerbatimRoundTrip(SYNTHETIC_XODR)
+  })
+
+  it('re-emits fabriksgatan verbatim (real-world map, two-way roads, signals)', () => {
+    if (!existsSync(FABRIKSGATAN)) return
+    expectVerbatimRoundTrip(readFileSync(FABRIKSGATAN, 'utf-8'))
+  })
+
+  it('re-emits two_plus_one verbatim', () => {
+    if (!existsSync(TWO_PLUS_ONE)) return
+    expectVerbatimRoundTrip(readFileSync(TWO_PLUS_ONE, 'utf-8'))
+  })
+
+  it('regenerates only the edited road and keeps its original id', () => {
+    const imported = odrToShapesFull(parseOpenDriveXml(CHAIN_XODR))
+    const records = imported.sidecar.roadRecords!
+    // Nudge an interior boundary point of road 2's lane sideways (~1.8 m).
+    const laneId = records['2'].laneShapeIds[0]
+    const lane = imported.lanes.find(l => l.id === laneId)!
+    const ls = imported.linestrings.find(l => l.id === lane.leftBoundaryId)!
+    const midPid = ls.pointIds[Math.floor(ls.pointIds.length / 2)]
+    const pt = imported.points.find(p => p.id === midPid)!
+    pt.y += 30
+
+    const out = exportToOpenDrive(snapshotFrom(imported), { sidecar: imported.sidecar })
+    const doc = extractOdrDocument(CHAIN_XODR)!
+    const road = (id: string) => doc.roads.find(r => r.id === id)!
+    expect(out).toContain(road('1').text)
+    expect(out).toContain(road('3').text)
+    expect(out).not.toContain(road('2').text)
+    // The regenerated bundle covers exactly road 2's lane set -> id reuse,
+    // so the verbatim neighbours' links stay valid without rewriting.
+    expect(out).toMatch(/<road [^>]*id="2"/)
+
+    const re = importXodr(out)
+    expect(re.lanes.length).toBe(3)
+    const rep = measureFidelity(imported, re)
+    expect(rep.matchedLanes).toBe(3)
+    expect(rep.edgesPreserved).toBe(rep.edgesBefore)
+    expect(rep.edgesBefore).toBe(2)
+    // The edit survived: some re-imported boundary point sits near the
+    // nudged position (lane 2's left boundary originally ran along y = 0).
+    const moved = re.points.some(
+      p => Math.abs(p.y - pt.y) < 10 && Math.abs(p.x - pt.x) < 100
+    )
+    expect(moved).toBe(true)
+  })
+
+  it('moving a traffic light regenerates only its carrying road', () => {
+    const imported = odrToShapesFull(parseOpenDriveXml(CHAIN_XODR))
+    const tl = imported.trafficLights[0]
+    expect(tl).toBeDefined()
+    tl.x += 50
+
+    const out = exportToOpenDrive(snapshotFrom(imported), { sidecar: imported.sidecar })
+    const doc = extractOdrDocument(CHAIN_XODR)!
+    const road = (id: string) => doc.roads.find(r => r.id === id)!
+    expect(out).not.toContain(road('1').text)
+    expect(out).toContain(road('2').text)
+    expect(out).toContain(road('3').text)
+    // The regenerated signal id starts above the original signal id space.
+    expect(out).toMatch(/<signal [^>]*id="8"/)
+    const re = importXodr(out)
+    const rep = measureFidelity(imported, re)
+    expect(rep.matchedLanes).toBe(3)
+    expect(rep.edgesPreserved).toBe(rep.edgesBefore)
+    expect(rep.trafficLightsMatched).toBe(1)
+    expect(rep.trafficLightAffectedPreserved).toBe(1)
+  })
+
+  it('regenerates a junction but keeps clean incoming/outgoing roads, re-pointing their junction links', () => {
+    const imported = odrToShapesFull(parseOpenDriveXml(SYNTHETIC_XODR))
+    const records = imported.sidecar.roadRecords!
+    // Nudge an interior boundary point of out_b (road 3).
+    const laneId = records['3'].laneShapeIds[0]
+    const lane = imported.lanes.find(l => l.id === laneId)!
+    const ls = imported.linestrings.find(l => l.id === lane.leftBoundaryId)!
+    const midPid = ls.pointIds[Math.floor(ls.pointIds.length / 2)]
+    imported.points.find(p => p.id === midPid)!.y += 20
+
+    const out = exportToOpenDrive(snapshotFrom(imported), { sidecar: imported.sidecar })
+    const doc = extractOdrDocument(SYNTHETIC_XODR)!
+    const road = (id: string) => doc.roads.find(r => r.id === id)!
+    const stripIds = (s: string): string => s.replace(/elementId="[^"]*"/g, 'elementId=""')
+    // Roads 1 / 2 / 4 stay verbatim except their junction link elementIds,
+    // which are re-pointed at the regenerated junction.
+    for (const rid of ['1', '2', '4']) {
+      expect(stripIds(out)).toContain(stripIds(road(rid).text))
+    }
+    // The dirty road and the junction's connecting roads regenerate.
+    expect(out).not.toContain(road('3').text)
+    expect(stripIds(out)).not.toContain(stripIds(road('5').text))
+    // The original junction element is replaced.
+    const junction = doc.junctions.find(j => j.id === '10')!
+    expect(out).not.toContain(junction.text)
+    expect(out).toMatch(/<junction /)
+    // Semantic identity through re-import: all lanes and junction edges.
+    const re = importXodr(out)
+    const rep = measureFidelity(imported, re)
+    expect(rep.matchedLanes).toBe(rep.laneCountBefore)
+    expect(rep.edgesPreserved).toBe(rep.edgesBefore)
+  })
+
+  it('keeps the no-sidecar behavior unchanged (regression guard)', () => {
+    const imported = odrToShapesFull(parseOpenDriveXml(CHAIN_XODR))
+    const snapshot = snapshotFrom(imported)
+    const base = stripDate(exportToOpenDrive(snapshot))
+    expect(stripDate(exportToOpenDrive(snapshot, {}))).toBe(base)
+    expect(stripDate(exportToOpenDrive(snapshot, { sidecar: null }))).toBe(base)
+    // A legacy sidecar without road records also falls back to full regeneration.
+    const legacy = { ...imported.sidecar }
+    delete legacy.roadRecords
+    expect(stripDate(exportToOpenDrive(snapshot, { sidecar: legacy }))).toBe(base)
+  })
+
+  it('rewrites only road link elementIds in verbatim blocks', () => {
+    const doc = extractOdrDocument(CHAIN_XODR)!
+    const road1 = doc.roads.find(r => r.id === '1')!
+    const rewritten = rewriteRoadLinkTargets(road1.text, new Map([['2', '99']]))
+    expect(rewritten).toContain('elementId="99"')
+    expect(rewritten.replace('elementId="99"', 'elementId="2"')).toBe(road1.text)
+    // No mapping -> byte-identical.
+    expect(rewriteRoadLinkTargets(road1.text, new Map())).toBe(road1.text)
   })
 })

--- a/packages/drawtonomy-sdk/scripts/check-qc.py
+++ b/packages/drawtonomy-sdk/scripts/check-qc.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Run the ASAM qc-opendrive checker bundle on every .xodr in a directory and
+fail when any ERROR-level issue is reported.
+
+Usage: python3 scripts/check-qc.py <xodrDir>
+
+Requires: pip install asam-qc-opendrive
+"""
+import subprocess
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from collections import Counter
+from pathlib import Path
+
+LEVEL_NAMES = {"1": "ERROR", "2": "WARNING", "3": "INFO"}
+
+
+def run_qc(xodr: Path, workdir: Path) -> Counter:
+    config = workdir / f"config_{xodr.stem}.xml"
+    result = workdir / f"result_{xodr.stem}.xqar"
+    config.write_text(
+        f"""<?xml version="1.0" encoding="UTF-8"?>
+<Config>
+    <Param name="InputFile" value="{xodr.resolve()}"/>
+    <CheckerBundle application="xodrBundle">
+        <Param name="resultFile" value="{result.resolve()}"/>
+    </CheckerBundle>
+</Config>
+"""
+    )
+    subprocess.run(
+        [sys.executable, "-m", "qc_opendrive.main", "-c", str(config)],
+        check=True,
+        capture_output=True,
+    )
+    counts: Counter = Counter()
+    for issue in ET.parse(result).getroot().iter("Issue"):
+        counts[(issue.get("level"), issue.get("ruleUID"))] += 1
+    return counts
+
+
+def main() -> int:
+    xodr_dir = Path(sys.argv[1])
+    files = sorted(xodr_dir.glob("*.xodr"))
+    if not files:
+        print(f"no .xodr files in {xodr_dir}", file=sys.stderr)
+        return 2
+    failed = False
+    with tempfile.TemporaryDirectory() as tmp:
+        workdir = Path(tmp)
+        for xodr in files:
+            counts = run_qc(xodr, workdir)
+            errors = sum(n for (level, _), n in counts.items() if level == "1")
+            status = "FAIL" if errors else "ok"
+            if errors:
+                failed = True
+            print(f"{status}  {xodr.name}: " + (
+                ", ".join(
+                    f"{LEVEL_NAMES.get(level, level)} {rule.split(':')[-1]} x{n}"
+                    for (level, rule), n in sorted(counts.items())
+                )
+                or "clean"
+            ))
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/drawtonomy-sdk/scripts/qc-roundtrip.mts
+++ b/packages/drawtonomy-sdk/scripts/qc-roundtrip.mts
@@ -1,0 +1,133 @@
+// Generates OpenDRIVE files for the ASAM quality-checker CI gate:
+//   1. an import -> export round trip of every .xodr sample in <mapsDir>
+//   2. a from-scratch drawn scene (curved two-lane road, kinked branch
+//      junction, zero-width taper, traffic light with stop line)
+// Usage: npx tsx scripts/qc-roundtrip.mts <mapsDir> <outDir>
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join, basename } from 'node:path'
+import { parseOpenDriveXml } from '../src/exporter/opendriveParser'
+import { odrToShapes, type ImportedShapes } from '../src/exporter/odrToShapes'
+import { exportToOpenDrive } from '../src/exporter/opendrive'
+import type { DrawtonomySnapshot } from '../src/types'
+
+const [mapsDir, outDir] = process.argv.slice(2)
+if (!mapsDir || !outDir) {
+  console.error('usage: qc-roundtrip.mts <mapsDir> <outDir>')
+  process.exit(2)
+}
+mkdirSync(outDir, { recursive: true })
+
+function snapshotFrom(im: ImportedShapes): DrawtonomySnapshot {
+  const shapes: unknown[] = []
+  for (const p of im.points) {
+    shapes.push({ id: p.id, type: 'point', x: p.x, y: p.y, rotation: 0, zIndex: 0, props: { color: 'black', visible: true, osmId: p.osmId } })
+  }
+  for (const ls of im.linestrings) {
+    shapes.push({ id: ls.id, type: 'linestring', x: ls.x, y: ls.y, rotation: 0, zIndex: 0, props: { pointIds: ls.pointIds, color: 'black', strokeWidth: 2, attributes: ls.attributes, osmId: ls.osmId } })
+  }
+  for (const l of im.lanes) {
+    shapes.push({ id: l.id, type: 'lane', x: l.x, y: l.y, rotation: 0, zIndex: 0, props: { leftBoundaryId: l.leftBoundaryId, rightBoundaryId: l.rightBoundaryId, invertLeft: l.invertLeft, invertRight: l.invertRight, color: 'default', size: 'm', attributes: l.attributes, next: l.next, prev: l.prev, osmId: l.osmId, ...(l.yieldLaneIds ? { yieldLaneIds: l.yieldLaneIds } : {}) } })
+  }
+  for (const tl of im.trafficLights) {
+    shapes.push({ id: tl.id, type: 'traffic_light', x: tl.x, y: tl.y, rotation: 0, zIndex: 0, props: { w: tl.w, h: tl.h, color: 'default', style: '', attributes: tl.attributes, osmId: tl.osmId, affectedLaneIds: tl.affectedLaneIds, stopLineId: tl.stopLineId } })
+  }
+  return {
+    version: '1.1',
+    timestamp: new Date().toISOString(),
+    shapes: shapes as DrawtonomySnapshot['shapes'],
+    origin: im.originLatLon ?? { lat: 35, lon: 139 },
+  }
+}
+
+for (const file of readdirSync(mapsDir).filter(f => f.endsWith('.xodr')).sort()) {
+  const name = basename(file, '.xodr')
+  const t0 = Date.now()
+  const before = odrToShapes(parseOpenDriveXml(readFileSync(join(mapsDir, file), 'utf-8')))
+  const xml = exportToOpenDrive(snapshotFrom(before))
+  writeFileSync(join(outDir, `${name}_roundtrip.xodr`), xml)
+  console.log(`${name}: lanes=${before.lanes.length} -> ${join(outDir, `${name}_roundtrip.xodr`)} (${Date.now() - t0}ms)`)
+}
+
+// ---- from-scratch drawn scene -------------------------------------------
+const shapes: unknown[] = []
+const point = (id: string, x: number, y: number) => shapes.push({ id, type: 'point', x, y, rotation: 0, zIndex: 0, props: { color: 'black', visible: true, osmId: '' } })
+const linestring = (id: string, pointIds: string[]) => shapes.push({ id, type: 'linestring', x: 0, y: 0, rotation: 0, zIndex: 0, props: { pointIds, color: 'black', strokeWidth: 2, attributes: {}, osmId: '' } })
+const lane = (id: string, left: string, right: string, opts: { next?: string[]; prev?: string[]; attrs?: Record<string, string> } = {}) =>
+  shapes.push({
+    id, type: 'lane', x: 0, y: 0, rotation: 0, zIndex: 0,
+    props: {
+      leftBoundaryId: left, rightBoundaryId: right, invertLeft: false, invertRight: false,
+      color: 'default', size: 'm',
+      attributes: { type: 'lanelet', subtype: 'road', speed_limit: '40', ...(opts.attrs ?? {}) },
+      next: opts.next ?? [], prev: opts.prev ?? [], osmId: '',
+    },
+  })
+
+// Curved two-lane main road (shared middle boundary).
+const R = 600
+const a0 = -Math.PI / 2
+const a1 = a0 + Math.PI / 3
+const arc = (prefix: string, radius: number, n: number): string[] => {
+  const ids: string[] = []
+  for (let i = 0; i <= n; i++) {
+    const a = a0 + ((a1 - a0) * i) / n
+    point(`${prefix}${i}`, radius * Math.cos(a), R + radius * Math.sin(a))
+    ids.push(`${prefix}${i}`)
+  }
+  return ids
+}
+linestring('mL', arc('l', R + 120, 24))
+linestring('mM', arc('m', R + 60, 24))
+linestring('mR', arc('r', R, 24))
+lane('main_outer', 'mL', 'mM', { next: ['exit_a'] })
+lane('main_inner', 'mM', 'mR', { next: ['exit_b'] })
+
+// Two diverging exits (exit_b kinks at the weld).
+const dir: [number, number] = [-Math.sin(a1), Math.cos(a1)]
+const at = (radius: number): [number, number] => [radius * Math.cos(a1), R + radius * Math.sin(a1)]
+const straight = (prefix: string, [sx, sy]: [number, number], [dx, dy]: [number, number], n: number): string[] => {
+  const ids: string[] = []
+  for (let i = 0; i <= n; i++) {
+    point(`${prefix}${i}`, sx + (dx * 300 * i) / n, sy + (dy * 300 * i) / n)
+    ids.push(`${prefix}${i}`)
+  }
+  return ids
+}
+linestring('eaL', straight('ea', at(R + 120), dir, 6))
+linestring('eaM', straight('eb', at(R + 60), dir, 6))
+lane('exit_a', 'eaL', 'eaM', { prev: ['main_outer'] })
+const kink: [number, number] = [
+  dir[0] * Math.cos(0.34) - dir[1] * Math.sin(0.34),
+  dir[0] * Math.sin(0.34) + dir[1] * Math.cos(0.34),
+]
+linestring('ebL', straight('ec', at(R + 60), kink, 6))
+linestring('ebR', straight('ed', at(R), kink, 6))
+lane('exit_b', 'ebL', 'ebR', { prev: ['main_inner'], attrs: { turn_direction: 'right' } })
+
+// Zero-width taper chain off exit_a's far end: continues straight along the
+// travel direction and narrows to a point (border-lane pattern).
+const [tx, ty] = at(R + 120)
+point('tp', tx + dir[0] * 450, ty + dir[1] * 450)
+linestring('tL', ['ea6', 'tp'])
+linestring('tR', ['eb6', 'tp'])
+lane('taper', 'tL', 'tR', { prev: ['exit_a'] })
+;(shapes.find(s => (s as { id: string }).id === 'exit_a') as { props: { next: string[] } }).props.next.push('taper')
+
+// Traffic light over both main lanes with a stop line.
+point('s1', at(R + 120)[0], at(R + 120)[1])
+point('s2', at(R)[0], at(R)[1])
+linestring('stop', ['s1', 's2'])
+shapes.push({
+  id: 'tl1', type: 'traffic_light', x: at(R + 120)[0] - 20, y: at(R + 120)[1] - 40, rotation: 0, zIndex: 0,
+  props: { w: 30, h: 12, color: 'default', style: '', attributes: {}, osmId: '', affectedLaneIds: ['main_outer', 'main_inner'], stopLineId: 'stop' },
+})
+
+const sceneXml = exportToOpenDrive({
+  version: '1.1',
+  timestamp: new Date().toISOString(),
+  shapes: shapes as DrawtonomySnapshot['shapes'],
+  origin: { lat: 35, lon: 139 },
+})
+writeFileSync(join(outDir, 'drawn_scene.xodr'), sceneXml)
+const back = odrToShapes(parseOpenDriveXml(sceneXml))
+console.log(`drawn_scene: lanes=${back.lanes.length} trafficLights=${back.trafficLights.length}`)

--- a/packages/drawtonomy-sdk/src/exporter/index.ts
+++ b/packages/drawtonomy-sdk/src/exporter/index.ts
@@ -7,7 +7,7 @@
 // turns OSM XML back into editor-ready primitives (points / linestrings /
 // lanes), enabling round-trip workflows.
 
-export { exportToOpenDrive } from './opendrive'
+export { exportToOpenDrive, type OpenDriveExportOptions } from './opendrive'
 export {
   latLonToTmercProj,
   latLonToUtmProj,
@@ -102,6 +102,7 @@ export {
   odrToShapes,
   parseGeoReferenceOrigin,
   type OdrImportResult,
+  type OdrRoadRecord,
   type OdrSidecar,
   type OdrToShapesOptions,
 } from './odrToShapes'

--- a/packages/drawtonomy-sdk/src/exporter/odrCarryThrough.ts
+++ b/packages/drawtonomy-sdk/src/exporter/odrCarryThrough.ts
@@ -1,0 +1,286 @@
+// Carry-through support for OpenDRIVE round trips.
+//
+// An imported .xodr keeps its original XML in the sidecar. On export, roads
+// whose shapes were NOT edited since import are re-emitted verbatim (the
+// exact original <road> element text), and only edited roads go through the
+// regular fitting exporter. This makes an unedited import -> export round
+// trip lossless at the XML level, including features the shape model does
+// not represent (elevation profiles, unknown signal types, custom userData).
+//
+// Two halves live here, shared by the importer and the exporter:
+//
+// 1. Road state hashing. At import time `odrToShapes` records, per source
+//    road, the shape ids it materialized plus a hash over their editable
+//    state: boundary point sequences (in travel order), lane attributes,
+//    next/prev connectivity, right-of-way links, and every regulatory shape
+//    (traffic light / crosswalk) touching the road. At export time the same
+//    hash is recomputed from the live shapes; equality means "unedited".
+//
+// 2. Raw document access. <header> / <road> / <junction> / <controller>
+//    elements are extracted from the original XML as verbatim text blocks
+//    together with their ids and cross-references (link targets, junction
+//    membership, signal definitions), so the exporter can decide what stays
+//    verbatim, propagate dirtiness across junctions, keep id spaces
+//    collision-free, and rewrite only the link elementIds that must point at
+//    regenerated roads — leaving every other byte untouched.
+
+import type { Point2D } from './laneCenterline'
+
+/** Per-road record captured at import time (stored in the sidecar). */
+export interface OdrRoadRecord {
+  /** Lane shape ids materialized from this road, in materialization order. */
+  laneShapeIds: string[]
+  /** Hash of the road's editable shape state at import time. */
+  stateHash: string
+}
+
+/** Editable state of one lane shape, as fed into the road state hash. */
+export interface CarryLaneState {
+  /** Left boundary points in travel order (canvas px), or null when unusable. */
+  leftPts: readonly Point2D[] | null
+  rightPts: readonly Point2D[] | null
+  attributes: Record<string, string | undefined>
+  next: readonly string[]
+  prev: readonly string[]
+  yieldLaneIds: readonly string[]
+}
+
+/** Editable state of a regulatory shape (traffic light / crosswalk). */
+export interface CarryRegulatoryState {
+  kind: 'traffic_light' | 'crosswalk'
+  shapeId: string
+  /** Positional numeric fields (position, size, rotation). */
+  numbers: readonly number[]
+  attributes: Record<string, string | undefined>
+  affectedLaneIds: readonly string[]
+  stopLinePts: readonly Point2D[] | null
+  controllerId: string
+}
+
+const fmtPts = (pts: readonly Point2D[] | null): string =>
+  pts ? pts.map(p => `${p.x},${p.y}`).join(';') : 'null'
+
+const fmtAttrs = (attrs: Record<string, string | undefined>): string =>
+  Object.entries(attrs)
+    .filter(([, v]) => v !== undefined && v !== null)
+    .map(([k, v]) => `${k}=${v}`)
+    .sort()
+    .join('&')
+
+const fmtIds = (ids: readonly string[]): string => [...ids].sort().join(',')
+
+/**
+ * Deterministic serialization of a road's editable shape state. Lane order
+ * follows the record's laneShapeIds (identical on both sides by
+ * construction); regulatory shapes are sorted by shape id.
+ */
+export function serializeRoadState(
+  lanes: readonly CarryLaneState[],
+  regulatory: readonly CarryRegulatoryState[]
+): string {
+  const laneStr = lanes
+    .map(
+      l =>
+        `L:${fmtPts(l.leftPts)}|R:${fmtPts(l.rightPts)}|A:${fmtAttrs(l.attributes)}` +
+        `|N:${fmtIds(l.next)}|P:${fmtIds(l.prev)}|Y:${fmtIds(l.yieldLaneIds)}`
+    )
+    .join('\n')
+  const regStr = [...regulatory]
+    .sort((a, b) => (a.shapeId < b.shapeId ? -1 : a.shapeId > b.shapeId ? 1 : 0))
+    .map(
+      r =>
+        `${r.kind}:${r.shapeId}|#:${r.numbers.join(',')}|A:${fmtAttrs(r.attributes)}` +
+        `|F:${fmtIds(r.affectedLaneIds)}|S:${fmtPts(r.stopLinePts)}|C:${r.controllerId}`
+    )
+    .join('\n')
+  return `${laneStr}\u0000${regStr}`
+}
+
+/** Hash of `serializeRoadState` (two independent 32-bit FNV-1a streams). */
+export function hashRoadState(
+  lanes: readonly CarryLaneState[],
+  regulatory: readonly CarryRegulatoryState[]
+): string {
+  const s = serializeRoadState(lanes, regulatory)
+  let a = 0x811c9dc5 | 0
+  let b = (0x811c9dc5 ^ 0x5bd1e995) | 0
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i)
+    a = Math.imul(a ^ c, 0x01000193)
+    b = Math.imul(b ^ c, 0x01000197)
+  }
+  return (
+    (a >>> 0).toString(16).padStart(8, '0') + (b >>> 0).toString(16).padStart(8, '0')
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Raw document access
+// ---------------------------------------------------------------------------
+
+export interface OdrDocRoad {
+  id: string
+  /** Junction this road belongs to ("-1" for normal roads). */
+  junction: string
+  /** Verbatim element text (exact substring of the original XML). */
+  text: string
+  /** elementIds of road-level <predecessor>/<successor> with elementType="road". */
+  linkRoadRefs: string[]
+  /** elementIds of road-level links with elementType="junction". */
+  linkJunctionRefs: string[]
+  /** ids of <signal> definitions inside this road. */
+  signalIds: string[]
+}
+
+export interface OdrDocJunction {
+  id: string
+  text: string
+  /** incomingRoad / connectingRoad ids referenced by <connection> records. */
+  memberRoadIds: string[]
+}
+
+export interface OdrDocController {
+  id: string
+  text: string
+  /** signalIds referenced by <control> records. */
+  signalIds: string[]
+}
+
+export interface OdrDocument {
+  headerText: string | null
+  roads: OdrDocRoad[]
+  junctions: OdrDocJunction[]
+  controllers: OdrDocController[]
+  /** Largest numeric id over roads / junctions (0 when none are numeric). */
+  maxNumericElementId: number
+  /** Largest numeric id over <signal>/<signalReference> records. */
+  maxNumericSignalId: number
+  /** Largest numeric <controller> id. */
+  maxNumericControllerId: number
+}
+
+/** Match all `<tag .../>` or `<tag ...>...</tag>` blocks (tags do not nest). */
+function matchBlocks(xml: string, tag: string): string[] {
+  const re = new RegExp(`<${tag}\\b[^>]*(?:/>|>[\\s\\S]*?</${tag}>)`, 'g')
+  return xml.match(re) ?? []
+}
+
+/** Attribute value from an element's opening tag, or null. */
+function attrOf(block: string, name: string): string | null {
+  const end = block.indexOf('>')
+  const open = end >= 0 ? block.slice(0, end + 1) : block
+  const m = open.match(new RegExp(`\\b${name}="([^"]*)"`))
+  return m ? m[1] : null
+}
+
+/**
+ * Extract the verbatim header / road / junction / controller blocks from an
+ * OpenDRIVE document. Returns null when the input does not look like
+ * OpenDRIVE XML. Regex block matching is safe here because none of these
+ * elements nest within themselves.
+ */
+export function extractOdrDocument(xml: string): OdrDocument | null {
+  if (!/<OpenDRIVE[\s>]/.test(xml)) return null
+
+  const headerMatch = xml.match(/<header\b[^>]*(?:\/>|>[\s\S]*?<\/header>)/)
+
+  const roads: OdrDocRoad[] = []
+  for (const text of matchBlocks(xml, 'road')) {
+    const id = attrOf(text, 'id')
+    if (id === null) continue
+    const linkRoadRefs: string[] = []
+    const linkJunctionRefs: string[] = []
+    for (const tag of text.match(/<(?:predecessor|successor)\b[^>]*\/?>/g) ?? []) {
+      const elementType = tag.match(/\belementType="([^"]*)"/)?.[1]
+      const elementId = tag.match(/\belementId="([^"]*)"/)?.[1]
+      if (elementId === undefined) continue
+      if (elementType === 'road') linkRoadRefs.push(elementId)
+      else if (elementType === 'junction') linkJunctionRefs.push(elementId)
+    }
+    const signalIds: string[] = []
+    for (const tag of text.match(/<signal\b[^>]*/g) ?? []) {
+      const sid = tag.match(/\bid="([^"]*)"/)?.[1]
+      if (sid !== undefined) signalIds.push(sid)
+    }
+    roads.push({
+      id,
+      junction: attrOf(text, 'junction') ?? '-1',
+      text,
+      linkRoadRefs,
+      linkJunctionRefs,
+      signalIds,
+    })
+  }
+
+  const junctions: OdrDocJunction[] = []
+  for (const text of matchBlocks(xml, 'junction')) {
+    const id = attrOf(text, 'id')
+    if (id === null) continue
+    const memberRoadIds: string[] = []
+    for (const tag of text.match(/<connection\b[^>]*/g) ?? []) {
+      for (const name of ['incomingRoad', 'connectingRoad'] as const) {
+        const v = tag.match(new RegExp(`\\b${name}="([^"]*)"`))?.[1]
+        if (v !== undefined && !memberRoadIds.includes(v)) memberRoadIds.push(v)
+      }
+    }
+    junctions.push({ id, text, memberRoadIds })
+  }
+
+  const controllers: OdrDocController[] = []
+  for (const text of matchBlocks(xml, 'controller')) {
+    const id = attrOf(text, 'id') ?? ''
+    const signalIds: string[] = []
+    for (const tag of text.match(/<control\b[^>]*/g) ?? []) {
+      const sid = tag.match(/\bsignalId="([^"]*)"/)?.[1]
+      if (sid !== undefined) signalIds.push(sid)
+    }
+    controllers.push({ id, text, signalIds })
+  }
+
+  const numericMax = (ids: Iterable<string>): number => {
+    let max = 0
+    for (const id of ids) {
+      if (/^\d+$/.test(id)) max = Math.max(max, parseInt(id, 10))
+    }
+    return max
+  }
+  const signalRefIds: string[] = []
+  for (const tag of xml.match(/<signalReference\b[^>]*/g) ?? []) {
+    const sid = tag.match(/\bid="([^"]*)"/)?.[1]
+    if (sid !== undefined) signalRefIds.push(sid)
+  }
+
+  return {
+    headerText: headerMatch ? headerMatch[0] : null,
+    roads,
+    junctions,
+    controllers,
+    maxNumericElementId: numericMax([...roads.map(r => r.id), ...junctions.map(j => j.id)]),
+    maxNumericSignalId: numericMax([...roads.flatMap(r => r.signalIds), ...signalRefIds]),
+    maxNumericControllerId: numericMax(controllers.map(c => c.id)),
+  }
+}
+
+/**
+ * Rewrite the elementId of road-level <predecessor>/<successor> records
+ * according to `roadMapping` (elementType="road") and `junctionMapping`
+ * (elementType="junction"), each original id -> new id. Every byte outside
+ * the rewritten attribute values is preserved.
+ */
+export function rewriteRoadLinkTargets(
+  text: string,
+  roadMapping: Map<string, string>,
+  junctionMapping: Map<string, string> = new Map()
+): string {
+  if (roadMapping.size === 0 && junctionMapping.size === 0) return text
+  return text.replace(/<(?:predecessor|successor)\b[^>]*\/?>/g, tag => {
+    const elementType = tag.match(/\belementType="([^"]*)"/)?.[1]
+    const mapping =
+      elementType === 'road' ? roadMapping : elementType === 'junction' ? junctionMapping : null
+    if (!mapping || mapping.size === 0) return tag
+    return tag.replace(/(\belementId=")([^"]*)(")/, (m, pre: string, idv: string, post: string) => {
+      const repl = mapping.get(idv)
+      return repl !== undefined ? pre + repl + post : m
+    })
+  })
+}

--- a/packages/drawtonomy-sdk/src/exporter/odrGeometryFit.ts
+++ b/packages/drawtonomy-sdk/src/exporter/odrGeometryFit.ts
@@ -1,0 +1,528 @@
+// Plan-view geometry fitting: turns a discrete reference-line polyline into a
+// compact sequence of analytic OpenDRIVE primitives (<line>, <arc>,
+// <paramPoly3 pRange="arcLength">).
+//
+// Approach (first principles, no external references):
+// - Discrete headings are estimated by central differences and de-noised with
+//   a small moving-median filter (robust to single-sample outliers from
+//   hand-drawn input).
+// - Segments are grown greedily (exponential probing + binary search for the
+//   longest fitting span). For each candidate span the simplest primitive
+//   wins: a line when all samples stay within the position tolerance of the
+//   start ray, else an arc through both endpoints (curvature from the
+//   chord/heading geometry of a circle), else a cubic Hermite emitted as
+//   paramPoly3. Every accepted fit is verified against the original samples:
+//   maximum position deviation <= posTol and end-heading deviation <= hdgTol.
+// - C1 continuity is guaranteed by construction: each primitive starts at the
+//   analytic end pose of the previous one, and end headings are constrained
+//   to the sampled tangents. When no primitive fits even a single step (sharp
+//   corner), the span degrades to the plain chord <line> — the same output
+//   the previous line-decomposition exporter produced — which keeps position
+//   continuity and confines the heading break to the corner itself.
+//
+// No external dependencies.
+
+import type { OdrGeometry } from './opendriveParser'
+import { evalGeometry, type GeomPose } from './odrGeometry'
+
+export interface FitPoint {
+  x: number
+  y: number
+}
+
+export interface PlanViewFitOptions {
+  /** Maximum position deviation between samples and the fit (m). Default 0.05. */
+  maxPosErrorMeters?: number
+  /** Maximum end-heading deviation per segment (rad). Default 0.5 degrees. */
+  maxHdgErrorRad?: number
+  /** Moving-median window (odd) for heading de-noising. Default 3; 1 disables. */
+  headingMedianWindow?: number
+}
+
+/** Station + pose on the fitted reference line for one input sample. */
+export interface FittedSamplePose {
+  s: number
+  x: number
+  y: number
+  hdg: number
+}
+
+export interface PlanViewFit {
+  /** Fitted primitives with contiguous stations starting at s = 0. */
+  geometries: OdrGeometry[]
+  /** Fitted station and pose for every input point (duplicates share poses). */
+  samplePoses: FittedSamplePose[]
+  /** Total fitted arc length (m). */
+  length: number
+}
+
+const MIN_SEG_LENGTH = 1e-6
+/**
+ * Input points closer than this (m) are merged. Sub-2cm spacing carries no
+ * road-geometry information at the 5 cm position tolerance — merging shifts
+ * the polyline by less than half the tolerance — but its chord directions are
+ * noise (snap/weld artifacts at lane ends produce millimeter chords pointing
+ * sideways or backwards) that would corrupt the heading estimates.
+ */
+const DEDUPE_EPS = 0.02
+/** Shortest fallback chord worth emitting; closer points snap to the chain. */
+const MIN_EMIT_LENGTH = 1e-3
+/**
+ * Maximum lateral miss allowed for a <line> that ends the whole plan view.
+ * Road endpoints are contact points with neighbouring roads (welded in the
+ * drawing), so the fitted curve must land on the final input point almost
+ * exactly — arcs and Hermites interpolate it by construction, but a line only
+ * projects it onto the start ray. Beyond this tolerance the line candidate is
+ * rejected and an (endpoint-exact) arc or paramPoly3 takes the span instead.
+ */
+const LINE_FINAL_LATERAL_TOL = 1e-3
+/** Largest |chord-to-heading angle| a single arc / Hermite span may subtend. */
+const MAX_TURN_RAD = 1.45
+
+function wrapAngle(a: number): number {
+  while (a > Math.PI) a -= 2 * Math.PI
+  while (a < -Math.PI) a += 2 * Math.PI
+  return a
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = sorted.length >> 1
+  return sorted.length % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2
+}
+
+/** Distance from p to the polyline pts[i0..i1] (projection onto segments). */
+function distToPolyline(p: FitPoint, pts: readonly FitPoint[], i0: number, i1: number): number {
+  let best = Infinity
+  for (let i = i0; i < i1; i++) {
+    const a = pts[i]
+    const b = pts[i + 1]
+    const dx = b.x - a.x
+    const dy = b.y - a.y
+    const len2 = dx * dx + dy * dy
+    let t = len2 > 1e-18 ? ((p.x - a.x) * dx + (p.y - a.y) * dy) / len2 : 0
+    if (t < 0) t = 0
+    if (t > 1) t = 1
+    const d = Math.hypot(p.x - (a.x + t * dx), p.y - (a.y + t * dy))
+    if (d < best) best = d
+  }
+  return best
+}
+
+/**
+ * Fit a plan-view primitive sequence to a polyline of reference-line samples.
+ *
+ * The returned geometries are C1-continuous (each starts at the previous
+ * one's analytic end pose) except across degraded sharp-corner chords, and
+ * deviate from the input samples by at most the position tolerance.
+ */
+export function fitPlanView(
+  points: readonly FitPoint[],
+  options: PlanViewFitOptions = {}
+): PlanViewFit {
+  const posTol = options.maxPosErrorMeters ?? 0.05
+  const hdgTol = options.maxHdgErrorRad ?? (0.5 * Math.PI) / 180
+  const medianWindow = options.headingMedianWindow ?? 3
+
+  // --- Dedupe coincident input points (duplicates share the same station). --
+  const pts: FitPoint[] = []
+  const dedupIndex: number[] = []
+  for (const p of points) {
+    const last = pts[pts.length - 1]
+    if (!last || Math.hypot(p.x - last.x, p.y - last.y) > DEDUPE_EPS) {
+      pts.push({ x: p.x, y: p.y })
+    }
+    dedupIndex.push(pts.length - 1)
+  }
+  // The final input point is a contact point with the neighbouring road and
+  // must survive exactly: when the dedupe pass merged it into the previous
+  // vertex, move that vertex onto it (a sub-DEDUPE_EPS shift, well inside the
+  // position tolerance) instead of dropping the true endpoint.
+  if (pts.length >= 2) {
+    const lastIn = points[points.length - 1]
+    const lastKept = pts[pts.length - 1]
+    if (lastKept.x !== lastIn.x || lastKept.y !== lastIn.y) {
+      lastKept.x = lastIn.x
+      lastKept.y = lastIn.y
+    }
+  }
+  const m = pts.length
+  if (m < 2) {
+    const pose = m === 1 ? { s: 0, x: pts[0].x, y: pts[0].y, hdg: 0 } : { s: 0, x: 0, y: 0, hdg: 0 }
+    return { geometries: [], samplePoses: points.map(() => ({ ...pose })), length: 0 }
+  }
+
+  // --- Cumulative chord length. ---------------------------------------------
+  const u: number[] = [0]
+  for (let i = 1; i < m; i++) {
+    u.push(u[i - 1] + Math.hypot(pts[i].x - pts[i - 1].x, pts[i].y - pts[i - 1].y))
+  }
+
+  // --- Discrete headings: weighted chord blend + unwrap + moving median. ----
+  // On any smooth curve, a chord's direction is the tangent at the chord's
+  // arc-length midpoint (second order, exact on a circular arc). The tangent
+  // at vertex i is therefore the linear (in arc length) interpolation of the
+  // two adjacent chord directions, evaluated at u[i]:
+  //   hdg(i) = a(i-1,i) + Δa · len(i-1) / (len(i-1) + len(i))
+  // which stays circle-exact for arbitrarily uneven spacing — resampled
+  // polylines routinely mix metre chords with centimetre slivers, where the
+  // uniform-spacing forms (symmetric chord / 1.5·a01 − 0.5·a12) pick up
+  // heading errors of κ·Δlen/2 (well past tolerance on curved roads).
+  // Endpoints extrapolate the same linear model to u[0] / u[m-1].
+  // Sub-tolerance jogs that would corrupt these estimates were already merged
+  // away by the dedupe pass above.
+  const chordAngle = (i: number): number =>
+    Math.atan2(pts[i + 1].y - pts[i].y, pts[i + 1].x - pts[i].x)
+  const chordLen = (i: number): number =>
+    Math.hypot(pts[i + 1].x - pts[i].x, pts[i + 1].y - pts[i].y)
+  const rawHdg: number[] = new Array(m)
+  if (m === 2) {
+    rawHdg[0] = chordAngle(0)
+    rawHdg[1] = rawHdg[0]
+  } else {
+    for (let i = 1; i < m - 1; i++) {
+      const a1 = chordAngle(i - 1)
+      const a2 = chordAngle(i)
+      const l1 = chordLen(i - 1)
+      const l2 = chordLen(i)
+      rawHdg[i] = a1 + (wrapAngle(a2 - a1) * l1) / (l1 + l2)
+    }
+    // Endpoint tangents extrapolate the constant-curvature model — but only
+    // when the data is actually curving there. Real roads end with straight
+    // tips (line+arc+line corner roads are everywhere in OpenDRIVE maps), and
+    // for a tip whose first chord lies on the straight piece the chord IS the
+    // tangent; blending in the next chord (already inside the arc) would
+    // rotate the contact cross-section off the neighbouring road's. The tip
+    // counts as straight when its lead turn is at most half the following
+    // turn (plus tolerance): a uniform arc shows equal turns and extrapolates,
+    // a line-into-arc tip shows a doubled second turn and keeps its chord.
+    const tipTangent = (
+      aTip: number,
+      aNext: number,
+      lTip: number,
+      lNext: number,
+      turnBeyond: number | null
+    ): number => {
+      const turnTip = wrapAngle(aNext - aTip)
+      if (turnBeyond !== null && Math.abs(turnTip) <= Math.abs(turnBeyond) / 2 + hdgTol) {
+        return aTip
+      }
+      return aTip - (turnTip * lTip) / (lTip + lNext)
+    }
+    const a01 = chordAngle(0)
+    const a12 = chordAngle(1)
+    rawHdg[0] = tipTangent(
+      a01,
+      a12,
+      chordLen(0),
+      chordLen(1),
+      m >= 4 ? wrapAngle(chordAngle(2) - a12) : null
+    )
+    const aLast = chordAngle(m - 2)
+    const aPrev = chordAngle(m - 3)
+    rawHdg[m - 1] = tipTangent(
+      aLast,
+      aPrev,
+      chordLen(m - 2),
+      chordLen(m - 3),
+      m >= 4 ? wrapAngle(chordAngle(m - 4) - aPrev) : null
+    )
+  }
+  // Unwrap so the sequence is continuous (no 2π jumps) before filtering.
+  for (let i = 1; i < m; i++) {
+    rawHdg[i] = rawHdg[i - 1] + wrapAngle(rawHdg[i] - rawHdg[i - 1])
+  }
+  // Median-filter interior headings only: a truncated window at the ends
+  // degenerates to an average, which would re-bias the carefully built
+  // second-order endpoint estimates.
+  const hdg: number[] = new Array(m)
+  const half = Math.max(0, (medianWindow - 1) >> 1)
+  for (let i = 0; i < m; i++) {
+    if (half === 0 || i < half || i >= m - half) {
+      hdg[i] = rawHdg[i]
+      continue
+    }
+    hdg[i] = median(rawHdg.slice(i - half, i + half + 1))
+  }
+
+  // --- Corner flags -----------------------------------------------------------
+  // A polyline vertex whose adjacent chords turn sharply is a deliberate
+  // corner, not a sampled smooth curve; its "tangent" is meaningless, so
+  // end-heading constraints are waived there (the segmentation naturally
+  // breaks at the corner and the heading discontinuity stays on it).
+  const CORNER_TURN_RAD = 0.3
+  const corner: boolean[] = new Array(m).fill(false)
+  for (let i = 1; i < m - 1; i++) {
+    corner[i] = Math.abs(wrapAngle(chordAngle(i) - chordAngle(i - 1))) > CORNER_TURN_RAD
+  }
+
+  /**
+   * End-heading acceptance for a segment ending at sample j. Corners carry no
+   * reliable tangent; C1 continuity is unaffected (it is enforced by chaining
+   * start poses, not by this check). The very last sample IS constrained: its
+   * heading defines the contact cross-section shared with the successor road,
+   * so a primitive may not land there pointing off the data tangent.
+   */
+  const headingOk = (j: number, endHdg: number): boolean =>
+    corner[j] || Math.abs(wrapAngle(hdg[j] - endHdg)) <= hdgTol
+
+  // --- Primitive candidates (all endpoint-constrained at the chain pose). ---
+
+  type Candidate = OdrGeometry
+
+  /**
+   * Line; passes when all samples hug the ray. Chained segments must follow
+   * the chain heading; the very first segment has no incoming tangent to
+   * honor, so its direction is the (noise-robust) endpoint chord instead of
+   * the local heading estimate at sample 0.
+   */
+  const tryLine = (pose: GeomPose, i: number, j: number, chained: boolean): Candidate | null => {
+    const lineHdg = chained ? pose.hdg : Math.atan2(pts[j].y - pose.y, pts[j].x - pose.x)
+    const dirX = Math.cos(lineHdg)
+    const dirY = Math.sin(lineHdg)
+    const length = (pts[j].x - pose.x) * dirX + (pts[j].y - pose.y) * dirY
+    if (length < MIN_SEG_LENGTH) return null
+    if (!headingOk(j, lineHdg)) return null
+    for (let k = i; k <= j; k++) {
+      const dx = pts[k].x - pose.x
+      const dy = pts[k].y - pose.y
+      const lateral = -dx * dirY + dy * dirX
+      // The final input point is a contact point with the neighbouring road;
+      // it must sit on the line (not merely within the band), or an
+      // endpoint-exact primitive must take the span instead.
+      const tol = k === j && j === m - 1 ? Math.min(posTol, LINE_FINAL_LATERAL_TOL) : posTol
+      if (Math.abs(lateral) > tol) return null
+      const longitudinal = dx * dirX + dy * dirY
+      if (longitudinal < -posTol || longitudinal > length + posTol) return null
+    }
+    return { kind: 'line', s: 0, x: pose.x, y: pose.y, hdg: lineHdg, length }
+  }
+
+  /**
+   * Arc through the chain pose and the end sample. With chord direction φ and
+   * deflection α = φ − hdg, the circle through both endpoints tangent to the
+   * start heading has curvature κ = 2·sin(α)/chord and sweeps 2α (classic
+   * inscribed-angle relation), so length = 2α/κ.
+   */
+  const tryArc = (pose: GeomPose, i: number, j: number): Candidate | null => {
+    const dx = pts[j].x - pose.x
+    const dy = pts[j].y - pose.y
+    const chord = Math.hypot(dx, dy)
+    if (chord < MIN_SEG_LENGTH) return null
+    const alpha = wrapAngle(Math.atan2(dy, dx) - pose.hdg)
+    if (Math.abs(alpha) < 1e-12 || Math.abs(alpha) > MAX_TURN_RAD) return null
+    const curvature = (2 * Math.sin(alpha)) / chord
+    if (Math.abs(curvature) < 1e-12) return null
+    const length = (alpha * chord) / Math.sin(alpha)
+    if (!headingOk(j, pose.hdg + 2 * alpha)) return null
+    // Center / radius checks for the interior samples.
+    const cx = pose.x - Math.sin(pose.hdg) / curvature
+    const cy = pose.y + Math.cos(pose.hdg) / curvature
+    const radius = 1 / Math.abs(curvature)
+    const startAngle = Math.atan2(pose.y - cy, pose.x - cx)
+    const sweep = curvature * length * Math.sign(curvature) // = |2α|
+    const angTol = posTol * Math.abs(curvature) + 1e-9
+    for (let k = i + 1; k < j; k++) {
+      const radial = Math.hypot(pts[k].x - cx, pts[k].y - cy) - radius
+      if (Math.abs(radial) > posTol) return null
+      // The sample must lie inside the swept sector (guards against samples
+      // that are near the circle but on the opposite side).
+      const rel = wrapAngle(Math.atan2(pts[k].y - cy, pts[k].x - cx) - startAngle) * Math.sign(curvature)
+      if (rel < -angTol || rel > sweep + angTol) return null
+    }
+    return { kind: 'arc', s: 0, x: pose.x, y: pose.y, hdg: pose.hdg, length, curvature }
+  }
+
+  /**
+   * Cubic Hermite from the chain pose to the end sample + sampled tangent,
+   * expressed in the start-pose frame and emitted as paramPoly3 with
+   * pRange="arcLength". The parameter domain is iterated to the curve's
+   * actual arc length so evaluating at ds stays close to true arc length;
+   * a unit-speed band check rejects fits where that approximation degrades.
+   */
+  const tryParamPoly3 = (pose: GeomPose, i: number, j: number): Candidate | null => {
+    const cosH = Math.cos(pose.hdg)
+    const sinH = Math.sin(pose.hdg)
+    const ex = pts[j].x - pose.x
+    const ey = pts[j].y - pose.y
+    const u1 = ex * cosH + ey * sinH
+    const v1 = -ex * sinH + ey * cosH
+    const theta1 = wrapAngle(hdg[j] - pose.hdg)
+    if (u1 < MIN_SEG_LENGTH) return null
+    if (Math.abs(theta1) > MAX_TURN_RAD) return null
+    // Spans shorter than a few tolerances never need a cubic: the chord line
+    // already sits within tolerance, and a Hermite squeezed into a tiny span
+    // can only produce huge, meaningless coefficients.
+    if (Math.hypot(ex, ey) < 4 * posTol) return null
+    const cosT = Math.cos(theta1)
+    const sinT = Math.sin(theta1)
+
+    // Hermite boundary conditions with parameter domain [0, L]:
+    //   u(0)=0, u'(0)=1, u(L)=u1, u'(L)=cosθ1   (aU=0, bU=1)
+    //   v(0)=0, v'(0)=0, v(L)=v1, v'(L)=sinθ1   (aV=0, bV=0)
+    let L = Math.max(u[j] - u[i], Math.hypot(ex, ey))
+    if (L < MIN_SEG_LENGTH) return null
+    let cU = 0
+    let dU = 0
+    let cV = 0
+    let dV = 0
+    const solve = (dom: number): void => {
+      const A = u1 - dom
+      const B = cosT - 1
+      cU = (3 * A - B * dom) / (dom * dom)
+      dU = (B * dom - 2 * A) / (dom * dom * dom)
+      cV = (3 * v1 - sinT * dom) / (dom * dom)
+      dV = (sinT * dom - 2 * v1) / (dom * dom * dom)
+    }
+    const arcLength = (dom: number): number => {
+      const n = Math.max(16, Math.min(512, Math.ceil(dom / 0.25)))
+      let acc = 0
+      let px = 0
+      let py = 0
+      for (let k = 1; k <= n; k++) {
+        const p = (dom * k) / n
+        const x = p * (1 + p * (cU + p * dU))
+        const y = p * p * (cV + p * dV)
+        acc += Math.hypot(x - px, y - py)
+        px = x
+        py = y
+      }
+      return acc
+    }
+    for (let iter = 0; iter < 3; iter++) {
+      solve(L)
+      const actual = arcLength(L)
+      if (!(actual > MIN_SEG_LENGTH)) return null
+      if (Math.abs(actual - L) < 1e-6) break
+      L = actual
+    }
+    solve(L)
+
+    // Verification sampling of the candidate in inertial coordinates.
+    const n = Math.max(8, Math.min(512, Math.ceil(L / 0.5)))
+    const curve: FitPoint[] = []
+    for (let k = 0; k <= n; k++) {
+      const p = (L * k) / n
+      const lu = p * (1 + p * (cU + p * dU))
+      const lv = p * p * (cV + p * dV)
+      curve.push({ x: pose.x + lu * cosH - lv * sinH, y: pose.y + lu * sinH + lv * cosH })
+      // Unit-speed band: |r'(p)| must stay near 1 for arcLength pRange.
+      const du = 1 + p * (2 * cU + p * 3 * dU)
+      const dv = p * (2 * cV + p * 3 * dV)
+      const speed = Math.hypot(du, dv)
+      if (speed < 0.5 || speed > 1.6) return null
+    }
+    // Samples -> curve and curve -> samples (the latter catches wiggles
+    // between sample stations).
+    for (let k = i + 1; k < j; k++) {
+      if (distToPolyline(pts[k], curve, 0, curve.length - 1) > posTol) return null
+    }
+    for (const cp of curve) {
+      if (distToPolyline(cp, pts, i, j) > posTol) return null
+    }
+    return {
+      kind: 'paramPoly3',
+      s: 0,
+      x: pose.x,
+      y: pose.y,
+      hdg: pose.hdg,
+      length: L,
+      aU: 0,
+      bU: 1,
+      cU,
+      dU,
+      aV: 0,
+      bV: 0,
+      cV,
+      dV,
+      pRange: 'arcLength',
+    }
+  }
+
+  /** Simplest passing primitive for the span [i..j]. */
+  const bestFit = (pose: GeomPose, i: number, j: number, chained: boolean): Candidate | null =>
+    tryLine(pose, i, j, chained) ?? tryArc(pose, i, j) ?? tryParamPoly3(pose, i, j)
+
+  // --- Greedy chained segmentation. ------------------------------------------
+  const geometries: OdrGeometry[] = []
+  const stations: number[] = new Array(m)
+  stations[0] = 0
+  let pose: GeomPose = { x: pts[0].x, y: pts[0].y, hdg: hdg[0] }
+  let sCum = 0
+  let i = 0
+  while (i < m - 1) {
+    const chained = geometries.length > 0
+    let fit = bestFit(pose, i, i + 1, chained)
+    let j = i + 1
+    if (fit) {
+      // Exponential probing for the longest fitting span, then binary search
+      // between the last success and the first failure.
+      let step = 1
+      while (j < m - 1) {
+        step *= 2
+        const probe = Math.min(j + step, m - 1)
+        const f = bestFit(pose, i, probe, chained)
+        if (f) {
+          j = probe
+          fit = f
+          continue
+        }
+        let lo = j
+        let hi = probe
+        while (hi - lo > 1) {
+          const mid = (lo + hi) >> 1
+          const fm = bestFit(pose, i, mid, chained)
+          if (fm) {
+            lo = mid
+            fit = fm
+          } else {
+            hi = mid
+          }
+        }
+        j = lo
+        break
+      }
+    } else {
+      // Sharp corner / pathological step: degrade to the plain chord line
+      // (position-continuous; the heading break stays at the corner).
+      const cdx = pts[i + 1].x - pose.x
+      const cdy = pts[i + 1].y - pose.y
+      const chord = Math.hypot(cdx, cdy)
+      if (chord < MIN_EMIT_LENGTH) {
+        // A sub-millimeter leftover (e.g. chain drift at the very end) is not
+        // worth a geometry record; snap the point onto the chain instead.
+        stations[i + 1] = sCum
+        i++
+        continue
+      }
+      const chordHdg = Math.atan2(cdy, cdx)
+      fit = { kind: 'line', s: 0, x: pose.x, y: pose.y, hdg: chordHdg, length: chord }
+    }
+    fit.s = sCum
+    geometries.push(fit)
+    const span = u[j] - u[i]
+    for (let k = i + 1; k <= j; k++) {
+      stations[k] = span > 0 ? sCum + (fit.length * (u[k] - u[i])) / span : sCum
+    }
+    pose = evalGeometry(fit, fit.length)
+    sCum += fit.length
+    i = j
+  }
+
+  // --- Poses on the fitted curve for every input sample. ---------------------
+  const posesByDedup: FittedSamplePose[] = new Array(m)
+  let gIdx = 0
+  for (let k = 0; k < m; k++) {
+    const s = Math.min(stations[k], sCum)
+    while (gIdx < geometries.length - 1 && geometries[gIdx + 1].s <= s + 1e-12) gIdx++
+    const g = geometries[gIdx]
+    const p = evalGeometry(g, Math.min(Math.max(s - g.s, 0), g.length))
+    posesByDedup[k] = { s, x: p.x, y: p.y, hdg: p.hdg }
+  }
+
+  return {
+    geometries,
+    samplePoses: dedupIndex.map(d => posesByDedup[d]),
+    length: sCum,
+  }
+}

--- a/packages/drawtonomy-sdk/src/exporter/odrToShapes.ts
+++ b/packages/drawtonomy-sdk/src/exporter/odrToShapes.ts
@@ -35,7 +35,7 @@ import type {
   OdrSignalValidity,
 } from './opendriveParser'
 import { evalPoly3, sampleReferenceLine, type ReferenceSample } from './odrGeometry'
-import { sampleAtParam } from './laneCenterline'
+import { sampleAtParam, type Point2D } from './laneCenterline'
 import {
   createShapeIdAllocator,
   type ImportBounds,
@@ -48,12 +48,26 @@ import {
   type ShapeIdAllocator,
 } from './osmToShapes'
 import { PIXELS_PER_METER } from './units'
+import {
+  hashRoadState,
+  type CarryLaneState,
+  type CarryRegulatoryState,
+  type OdrRoadRecord,
+} from './odrCarryThrough'
+
+export type { OdrRoadRecord } from './odrCarryThrough'
 
 /** Sidecar captured at OpenDRIVE import time (for verbatim round-trip export). */
 export interface OdrSidecar {
   rawXml: string
   originLat: number | null
   originLon: number | null
+  /**
+   * Per source road: the lane shape ids it materialized and a hash of their
+   * editable state at import time. `exportToOpenDrive({ sidecar })` re-emits
+   * roads whose hash still matches verbatim from `rawXml` (carry-through).
+   */
+  roadRecords?: Record<string, OdrRoadRecord>
 }
 
 export interface OdrImportResult extends ImportedShapes {
@@ -320,32 +334,59 @@ export function odrToShapes(map: OdrMap, options: OdrToShapesOptions = {}): OdrI
   const roadById = new Map<string, OdrRoad>()
   /** Roads (with their reference samples) whose signals are converted after all lanes exist. */
   const signalRoads: { road: OdrRoad; samples: ReferenceSample[] }[] = []
-  /** Lane attributes restored from <userData code="laneAttributes"> per road. */
-  const restoredAttrCache = new Map<string, Record<string, string> | null>()
+  /**
+   * Lane attributes restored from <userData code="laneAttributes">.
+   * Current exporters key the stash by ODR lane id ({"-1": {...}, "-2": ...});
+   * legacy files carried one flat map applied to every lane of the road.
+   */
+  interface RestoredLaneAttrs {
+    flat: Record<string, string> | null
+    perLane: Map<number, Record<string, string>> | null
+  }
+  const restoredAttrCache = new Map<string, RestoredLaneAttrs>()
 
-  const restoredLaneAttributes = (road: OdrRoad): Record<string, string> | null => {
-    const cached = restoredAttrCache.get(road.id)
-    if (cached !== undefined) return cached
-    let parsed: Record<string, string> | null = null
-    const raw = road.userData['laneAttributes']
-    if (raw) {
-      try {
-        const obj = JSON.parse(raw) as unknown
-        if (obj && typeof obj === 'object' && !Array.isArray(obj)) {
-          parsed = {}
-          for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
-            // `type` is fixed to 'lanelet' and odr_* meta is regenerated.
-            if (typeof v !== 'string' || k === 'type' || k.startsWith('odr_')) continue
-            parsed[k] = v
-          }
-          if (Object.keys(parsed).length === 0) parsed = null
-        }
-      } catch {
-        // Malformed userData JSON is ignored (third-party files).
-      }
+  const pickStringAttrs = (obj: Record<string, unknown>): Record<string, string> | null => {
+    const out: Record<string, string> = {}
+    for (const [k, v] of Object.entries(obj)) {
+      // `type` is fixed to 'lanelet' and odr_* meta is regenerated.
+      if (typeof v !== 'string' || k === 'type' || k.startsWith('odr_')) continue
+      out[k] = v
     }
-    restoredAttrCache.set(road.id, parsed)
-    return parsed
+    return Object.keys(out).length > 0 ? out : null
+  }
+
+  const restoredLaneAttributes = (road: OdrRoad, odrLaneId: number): Record<string, string> | null => {
+    let entry = restoredAttrCache.get(road.id)
+    if (entry === undefined) {
+      entry = { flat: null, perLane: null }
+      const raw = road.userData['laneAttributes']
+      if (raw) {
+        try {
+          const obj = JSON.parse(raw) as unknown
+          if (obj && typeof obj === 'object' && !Array.isArray(obj)) {
+            const flat: Record<string, unknown> = {}
+            for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+              if (v && typeof v === 'object' && !Array.isArray(v) && /^-?\d+$/.test(k)) {
+                const laneAttrs = pickStringAttrs(v as Record<string, unknown>)
+                if (laneAttrs) {
+                  entry.perLane = entry.perLane ?? new Map()
+                  entry.perLane.set(parseInt(k, 10), laneAttrs)
+                }
+              } else {
+                flat[k] = v
+              }
+            }
+            entry.flat = pickStringAttrs(flat)
+          }
+        } catch {
+          // Malformed userData JSON is ignored (third-party files).
+        }
+      }
+      restoredAttrCache.set(road.id, entry)
+    }
+    const perLane = entry.perLane?.get(odrLaneId) ?? null
+    if (!entry.flat && !perLane) return null
+    return { ...(entry.flat ?? {}), ...(perLane ?? {}) }
   }
 
   const registryKey = (roadId: string, sectionIdx: number, odrLaneId: number): string =>
@@ -606,6 +647,32 @@ export function odrToShapes(map: OdrMap, options: OdrToShapesOptions = {}): OdrI
     return out
   }
 
+  /** Shape ids of a specific (road, ODR lane id) pair, across all sections. */
+  const lanesOfRoadLane = (roadId: string, odrLaneId: number): string[] => {
+    const out: string[] = []
+    for (const reg of lanesByRoad.get(roadId) ?? []) {
+      if (reg.odrLaneId === odrLaneId && !out.includes(reg.shapeId)) out.push(reg.shapeId)
+    }
+    return out
+  }
+
+  /** Resolve a [[roadId, laneId], ...] JSON record to lane shape ids. */
+  const resolveLanePairs = (pairs: unknown): string[] => {
+    const out: string[] = []
+    if (!Array.isArray(pairs)) return out
+    for (const entry of pairs) {
+      if (!Array.isArray(entry) || entry.length < 2) continue
+      const [rid, lid] = entry
+      if (typeof rid !== 'string' || typeof lid !== 'string') continue
+      const odrLaneId = parseInt(lid, 10)
+      if (!Number.isFinite(odrLaneId)) continue
+      for (const shapeId of lanesOfRoadLane(rid, odrLaneId)) {
+        if (!out.includes(shapeId)) out.push(shapeId)
+      }
+    }
+    return out
+  }
+
   /**
    * Convert crosswalk objects into crosswalk shapes. The band center is the
    * (s, t) station on the reference line; the walking axis follows the
@@ -637,8 +704,18 @@ export function odrToShapes(map: OdrMap, options: OdrToShapesOptions = {}): OdrI
       const rawLinks = obj.userData['crosswalkLinks']
       if (rawLinks) {
         try {
-          const links = JSON.parse(rawLinks) as { affectedRoads?: unknown; stopLine?: unknown }
-          if (Array.isArray(links.affectedRoads)) {
+          const links = JSON.parse(rawLinks) as {
+            affectedLanes?: unknown
+            affectedRoads?: unknown
+            stopLine?: unknown
+          }
+          // Current exports carry lane-precise [[roadId, laneId], ...] pairs;
+          // legacy files only listed road ids (=> every driving lane).
+          if (Array.isArray(links.affectedLanes)) {
+            for (const shapeId of resolveLanePairs(links.affectedLanes)) {
+              if (!affected.includes(shapeId)) affected.push(shapeId)
+            }
+          } else if (Array.isArray(links.affectedRoads)) {
             for (const rid of links.affectedRoads) {
               if (typeof rid !== 'string') continue
               for (const shapeId of drivingLanesOf(rid)) {
@@ -681,10 +758,33 @@ export function odrToShapes(map: OdrMap, options: OdrToShapesOptions = {}): OdrI
     materializeCrosswalks(road, samples)
   }
 
-  // Restore right-of-way links stashed by the exporter in
-  // <userData code="yieldRoads">: every driving lane of the carrying road
-  // yields priority over the driving lanes of the listed roads.
+  // Restore right-of-way links stashed by the exporter.
+  // Current exports carry <userData code="yieldLanes"> with per-lane
+  // { ownLaneId: [[roadId, laneId], ...] } records; legacy files carried
+  // <userData code="yieldRoads"> (every driving lane of the carrying road
+  // yields over the driving lanes of the listed roads).
   for (const road of roads) {
+    const rawYieldLanes = road.userData['yieldLanes']
+    if (rawYieldLanes) {
+      let byLane: unknown
+      try {
+        byLane = JSON.parse(rawYieldLanes)
+      } catch {
+        continue
+      }
+      if (!byLane || typeof byLane !== 'object' || Array.isArray(byLane)) continue
+      for (const [laneIdStr, pairs] of Object.entries(byLane as Record<string, unknown>)) {
+        const odrLaneId = parseInt(laneIdStr, 10)
+        if (!Number.isFinite(odrLaneId)) continue
+        const yieldLaneIds = resolveLanePairs(pairs)
+        if (yieldLaneIds.length === 0) continue
+        for (const shapeId of lanesOfRoadLane(road.id, odrLaneId)) {
+          const lane = laneShapeById.get(shapeId)
+          if (lane) lane.yieldLaneIds = [...yieldLaneIds]
+        }
+      }
+      continue
+    }
     const rawYield = road.userData['yieldRoads']
     if (!rawYield) continue
     let yieldRoadIds: unknown
@@ -810,7 +910,7 @@ export function odrToShapes(map: OdrMap, options: OdrToShapesOptions = {}): OdrI
           // Lanelet tags stashed by the exporter in <userData
           // code="laneAttributes"> (speed_limit, turn_direction, location,
           // one_way=no, exact subtype, custom tags) override the defaults.
-          ...restoredLaneAttributes(road),
+          ...restoredLaneAttributes(road, lane.id),
           odr_type: lane.type,
           odr_road_id: road.id,
           odr_lane_id: String(lane.id),
@@ -889,6 +989,82 @@ export function odrToShapes(map: OdrMap, options: OdrToShapesOptions = {}): OdrI
   }
 
   /**
+   * A materialized lane standing in for a (road, contact, lane id) endpoint.
+   * `odrLaneId` / `contact` describe the endpoint in the road the lane was
+   * found in (which may differ from the queried road after bridging), so
+   * travel-direction checks in `linkLanes` stay correct.
+   */
+  interface LaneEndpoint {
+    reg: RegisteredLane
+    odrLaneId: number
+    contact: 'start' | 'end'
+  }
+
+  /**
+   * Resolve a (road, contact, lane id) endpoint to materialized lanes.
+   *
+   * Within a road this is `lanesAt` (which already bridges skipped micro
+   * sections). When the whole road was skipped — e.g. the short synthesized
+   * junction connecting roads this exporter emits, or any sub-threshold road
+   * in third-party files — the resolution continues across the road: lane
+   * links are walked through its (skipped) sections to the far end, and the
+   * road-level link there is followed into the neighbouring road, recursively,
+   * so connectivity is bridged across skipped roads instead of being lost.
+   */
+  const resolveLaneEndpoints = (
+    roadId: string,
+    contact: 'start' | 'end',
+    odrLaneId: number,
+    depth: number = 0
+  ): LaneEndpoint[] => {
+    const direct = lanesAt(roadId, contact, odrLaneId)
+    if (direct.length > 0) return direct.map(reg => ({ reg, odrLaneId, contact }))
+    const road = roadById.get(roadId)
+    if (!road || depth > 4) return []
+    // Only bridge across roads with no materialized lanes at all; partially
+    // materialized roads are fully handled by the in-road resolution above.
+    if ((lanesByRoad.get(roadId) ?? []).length > 0) return []
+    const n = road.laneSections.length
+    if (n === 0) return []
+    // Walk lane-level links through the skipped sections to the far end.
+    const farContact: 'start' | 'end' = contact === 'start' ? 'end' : 'start'
+    const dir = contact === 'start' ? 1 : -1
+    let idx = contact === 'start' ? 0 : n - 1
+    let ids = [odrLaneId]
+    for (let step = 0; step < n - 1 && ids.length > 0; step++) {
+      const sec = road.laneSections[idx]
+      const nextIds: number[] = []
+      for (const id of ids) {
+        const lane = [...sec.left, ...sec.right].find(l => l.id === id)
+        if (!lane) continue
+        for (const linked of dir === 1 ? lane.successorIds : lane.predecessorIds) {
+          if (!nextIds.includes(linked)) nextIds.push(linked)
+        }
+      }
+      ids = nextIds
+      idx += dir
+    }
+    const farSec = road.laneSections[farContact === 'start' ? 0 : n - 1]
+    const link = farContact === 'end' ? road.successor : road.predecessor
+    if (!farSec || !link || link.elementType !== 'road') return []
+    const cpB = link.contactPoint ?? (farContact === 'end' ? 'start' : 'end')
+    const out: LaneEndpoint[] = []
+    for (const id of ids) {
+      const lane = [...farSec.left, ...farSec.right].find(l => l.id === id)
+      if (!lane) continue
+      const targetIds = farContact === 'end' ? lane.successorIds : lane.predecessorIds
+      for (const tid of targetIds) {
+        for (const ep of resolveLaneEndpoints(link.elementId, cpB, tid, depth + 1)) {
+          if (!out.some(o => o.reg === ep.reg && o.odrLaneId === ep.odrLaneId && o.contact === ep.contact)) {
+            out.push(ep)
+          }
+        }
+      }
+    }
+    return out
+  }
+
+  /**
    * Link two lanes meeting at a shared contact, respecting travel direction:
    * right lanes (id < 0) travel toward the road's end, left lanes (id > 0)
    * toward its start. A connection is `a -> b` when a's travel exits at the
@@ -957,10 +1133,10 @@ export function odrToShapes(map: OdrMap, options: OdrToShapesOptions = {}): OdrI
     if (!sec) return
     for (const lane of [...sec.left, ...sec.right]) {
       const targetIds = cpA === 'end' ? lane.successorIds : lane.predecessorIds
-      for (const a of lanesAt(roadA.id, cpA, lane.id)) {
+      for (const a of resolveLaneEndpoints(roadA.id, cpA, lane.id)) {
         for (const toId of targetIds) {
-          for (const b of lanesAt(roadB.id, cpB, toId)) {
-            linkLanes(a, lane.id, cpA, b, toId, cpB)
+          for (const b of resolveLaneEndpoints(roadB.id, cpB, toId)) {
+            linkLanes(a.reg, a.odrLaneId, a.contact, b.reg, b.odrLaneId, b.contact)
           }
         }
       }
@@ -988,12 +1164,87 @@ export function odrToShapes(map: OdrMap, options: OdrToShapesOptions = {}): OdrI
       if (contacts.length === 0) contacts.push('end') // Tolerant default.
       for (const cpA of contacts) {
         for (const ll of conn.laneLinks) {
-          for (const a of lanesAt(roadA.id, cpA, ll.from)) {
-            for (const b of lanesAt(roadC.id, conn.contactPoint, ll.to)) {
-              linkLanes(a, ll.from, cpA, b, ll.to, conn.contactPoint)
+          for (const a of resolveLaneEndpoints(roadA.id, cpA, ll.from)) {
+            for (const b of resolveLaneEndpoints(roadC.id, conn.contactPoint, ll.to)) {
+              linkLanes(a.reg, a.odrLaneId, a.contact, b.reg, b.odrLaneId, b.contact)
             }
           }
         }
+      }
+    }
+  }
+
+  // Hidden lane links: edges the exporter could not express as standard
+  // <link>/<laneLink> records because a contact width is zero (the OpenDRIVE
+  // zero-width / appearing-lane link rules), stashed per road as
+  // <userData code="hiddenLaneLinks" value="[{fr,fl,tr,tl},...]"> with
+  // from-road / from-lane / to-road / to-lane ids (from end -> to start in
+  // travel direction). Restored here into next/prev like any other link.
+  for (const road of roads) {
+    const raw = road.userData['hiddenLaneLinks']
+    if (!raw) continue
+    let recs: unknown
+    try {
+      recs = JSON.parse(raw)
+    } catch {
+      continue // Malformed userData JSON is ignored (third-party files).
+    }
+    if (!Array.isArray(recs)) continue
+    for (const rec of recs) {
+      if (!rec || typeof rec !== 'object') continue
+      const { fr, fl, tr, tl } = rec as Record<string, unknown>
+      if (typeof fl !== 'number' || typeof tl !== 'number') continue
+      const fromRoad = fr === undefined ? road.id : String(fr)
+      const toRoad = tr === undefined ? road.id : String(tr)
+      for (const a of resolveLaneEndpoints(fromRoad, 'end', fl)) {
+        for (const b of resolveLaneEndpoints(toRoad, 'start', tl)) {
+          linkLanes(a.reg, a.odrLaneId, a.contact, b.reg, b.odrLaneId, b.contact)
+        }
+      }
+    }
+  }
+
+  // Junction <priority high low> records restore right-of-way links: the
+  // lanes standing in for the prioritized connecting road gain yieldLaneIds
+  // over the lanes standing in for the yielding one. A materialized
+  // connecting road is represented by its own lanes; a skipped (short
+  // synthesized) one resolves through its predecessor link to the incoming
+  // lanes the maneuver started from — the lanes the exporter originally read
+  // the yieldLaneIds off. Merged with any userData-restored links above.
+  const priorityRoadLanes = (roadId: string): string[] => {
+    const own = lanesByRoad.get(roadId) ?? []
+    if (own.length > 0) {
+      const out: string[] = []
+      for (const reg of own) {
+        if (!out.includes(reg.shapeId)) out.push(reg.shapeId)
+      }
+      return out
+    }
+    const road = roadById.get(roadId)
+    if (!road) return []
+    const lastSec = road.laneSections[road.laneSections.length - 1]
+    if (!lastSec) return []
+    const out: string[] = []
+    for (const lane of [...lastSec.left, ...lastSec.right]) {
+      for (const ep of resolveLaneEndpoints(roadId, 'end', lane.id)) {
+        if (!out.includes(ep.reg.shapeId)) out.push(ep.reg.shapeId)
+      }
+    }
+    return out
+  }
+  for (const junction of map.junctions) {
+    for (const pr of junction.priorities) {
+      const highLanes = priorityRoadLanes(pr.high)
+      const lowLanes = priorityRoadLanes(pr.low)
+      if (highLanes.length === 0 || lowLanes.length === 0) continue
+      for (const shapeId of highLanes) {
+        const lane = laneShapeById.get(shapeId)
+        if (!lane) continue
+        const merged = lane.yieldLaneIds ?? []
+        for (const lowId of lowLanes) {
+          if (lowId !== shapeId && !merged.includes(lowId)) merged.push(lowId)
+        }
+        if (merged.length > 0) lane.yieldLaneIds = merged
       }
     }
   }
@@ -1008,6 +1259,99 @@ export function odrToShapes(map: OdrMap, options: OdrToShapesOptions = {}): OdrI
   dedupeSharedBoundaries(result)
   weldConnectedLaneContacts(result)
   removeOrphanPoints(result)
+
+  // ---- Carry-through records ----
+  // Per-road state hashes for `exportToOpenDrive({ sidecar })`: a road whose
+  // hash still matches at export time was not edited and is re-emitted
+  // verbatim from the sidecar XML. Hashes are taken AFTER all post-processing
+  // (dedupe / weld / orphan removal) so they describe exactly the shapes the
+  // editor will hold; the exporter recomputes them from the live shapes.
+  {
+    const recPointById = new Map(result.points.map(p => [p.id as string, p]))
+    const recLsById = new Map(result.linestrings.map(l => [l.id as string, l]))
+    const boundaryPts = (lsId: string | null, invert: boolean): Point2D[] | null => {
+      if (!lsId) return null
+      const ls = recLsById.get(lsId)
+      if (!ls) return null
+      const ids = invert ? [...ls.pointIds].reverse() : ls.pointIds
+      const pts: Point2D[] = []
+      for (const pid of ids) {
+        const p = recPointById.get(pid)
+        if (p) pts.push({ x: p.x, y: p.y })
+      }
+      return pts.length >= 2 ? pts : null
+    }
+    const laneRoadOf = new Map<string, string>()
+    for (const [roadId, regs] of lanesByRoad) {
+      for (const reg of regs) laneRoadOf.set(reg.shapeId, roadId)
+    }
+    // Regulatory shapes touching a road: attached to it (odr_road_id) or
+    // affecting any of its lanes. Mirrored by the exporter's hash builder.
+    const regStatesByRoad = new Map<string, CarryRegulatoryState[]>()
+    const addRegState = (state: CarryRegulatoryState, affected: readonly string[], own: string | undefined): void => {
+      const touching = new Set<string>()
+      if (own && roadById.has(own)) touching.add(own)
+      for (const lid of affected) {
+        const rid = laneRoadOf.get(lid)
+        if (rid) touching.add(rid)
+      }
+      for (const rid of touching) {
+        const list = regStatesByRoad.get(rid) ?? []
+        list.push(state)
+        regStatesByRoad.set(rid, list)
+      }
+    }
+    for (const tl of result.trafficLights) {
+      addRegState(
+        {
+          kind: 'traffic_light',
+          shapeId: tl.id as string,
+          numbers: [tl.x, tl.y, tl.w, tl.h, 0],
+          attributes: tl.attributes,
+          affectedLaneIds: tl.affectedLaneIds,
+          stopLinePts: boundaryPts(tl.stopLineId, false),
+          controllerId: '',
+        },
+        tl.affectedLaneIds,
+        tl.attributes['odr_road_id']
+      )
+    }
+    for (const cw of result.crosswalks) {
+      addRegState(
+        {
+          kind: 'crosswalk',
+          shapeId: cw.id as string,
+          numbers: [cw.x, cw.y, cw.startX, cw.startY, cw.endX, cw.endY, cw.crosswalkWidth, 0],
+          attributes: cw.attributes,
+          affectedLaneIds: cw.affectedLaneIds,
+          stopLinePts: boundaryPts(cw.stopLineId, false),
+          controllerId: '',
+        },
+        cw.affectedLaneIds,
+        cw.attributes['odr_road_id']
+      )
+    }
+    const roadRecords: Record<string, OdrRoadRecord> = {}
+    for (const road of roads) {
+      const regLanes = lanesByRoad.get(road.id) ?? []
+      const laneStates: CarryLaneState[] = regLanes.map(reg => {
+        const lane = laneShapeById.get(reg.shapeId)!
+        return {
+          leftPts: boundaryPts(lane.leftBoundaryId, lane.invertLeft),
+          rightPts: boundaryPts(lane.rightBoundaryId, lane.invertRight),
+          attributes: lane.attributes,
+          next: lane.next,
+          prev: lane.prev,
+          yieldLaneIds: lane.yieldLaneIds ?? [],
+        }
+      })
+      roadRecords[road.id] = {
+        laneShapeIds: regLanes.map(r => r.shapeId),
+        stateHash: hashRoadState(laneStates, regStatesByRoad.get(road.id) ?? []),
+      }
+    }
+    result.sidecar.roadRecords = roadRecords
+  }
 
   // ---- Aggregated warnings ----
   if (elevationRoads > 0) {

--- a/packages/drawtonomy-sdk/src/exporter/opendrive.ts
+++ b/packages/drawtonomy-sdk/src/exporter/opendrive.ts
@@ -2,14 +2,24 @@
 // No external library dependencies.
 //
 // Design:
-// - Each lane is emitted as an independent <road>
-// - Reference line is the midpoints of the left/right boundary samples
-// - Each segment is a <line> geometry; lane width is a per-sample <width>
-// - Lane connectivity (next/prev) is written into <link>; branch/merge edges
-//   that a single road link cannot express are synthesized into <junction>
-//   elements (see planJunctions)
-// - Lanelet-only lane tags are stashed in <userData code="laneAttributes">
-//   and restored on import; multi-road signal validity uses <signalReference>
+// - Laterally adjacent same-direction lanes (detected through shared boundary
+//   linestrings) are grouped into one road bundle and emitted as a single
+//   <road> with lanes -1, -2, ... (inner to outer)
+// - The road reference line is the bundle's leftmost boundary (the left edge
+//   in travel direction), so lane 0 sits on it and no laneOffset is needed
+// - The reference polyline is fitted into analytic primitives (<line>, <arc>,
+//   <paramPoly3>) by odrGeometryFit; lane widths are piecewise-linear <width>
+//   records measured along the fitted reference normals (the exact inverse of
+//   the importer's offset-along-normal reconstruction)
+// - Lane connectivity (next/prev) is written into road/lane <link> records;
+//   branch/merge edges that road links cannot express are synthesized into
+//   <junction> elements with short connecting roads (one per lane edge, each
+//   carrying predecessor/successor road links) so the standard
+//   incoming -> connecting -> outgoing structure holds (see planConnectivity)
+// - Lanelet-only lane tags are stashed per lane in
+//   <userData code="laneAttributes"> and restored on import; signal validity
+//   uses <validity fromLane toLane> lane ranges within a road and
+//   <signalReference> only when a signal spans several roads
 // - Coordinate frame: canvas (x right, y down) → ENU (x right, y up); y is flipped
 
 import type {
@@ -22,9 +32,23 @@ import type {
   PolygonProps,
   TrafficLightProps,
 } from '../types'
-import { computeCenterlineWithWidth, type Point2D, type CenterlineSample } from './laneCenterline'
+import { sampleAtParam, type Point2D } from './laneCenterline'
+import { evalGeometry } from './odrGeometry'
+import { fitPlanView, type FittedSamplePose } from './odrGeometryFit'
+import type { OdrGeometry } from './opendriveParser'
 import { originToProjString } from './projection'
-import { escapeXml, fmt, pxToEnuX, pxToEnuY, pxToMeter } from './units'
+import { escapeXml, fmt, fmtPrecise, pxToEnuX, pxToEnuY, pxToMeter } from './units'
+import {
+  extractOdrDocument,
+  hashRoadState,
+  rewriteRoadLinkTargets,
+  type CarryLaneState,
+  type CarryRegulatoryState,
+  type OdrDocRoad,
+  type OdrDocument,
+  type OdrRoadRecord,
+} from './odrCarryThrough'
+import type { OdrSidecar } from './odrToShapes'
 
 type LaneShape = BaseShape<'lane', LaneProps>
 type LinestringShape = BaseShape<'linestring', LinestringProps>
@@ -33,13 +57,28 @@ type TrafficLightShape = BaseShape<'traffic_light', TrafficLightProps>
 type CrosswalkShape = BaseShape<'crosswalk', CrosswalkProps>
 type PolygonShape = BaseShape<'polygon', PolygonProps>
 
-interface RoadGeometry {
-  laneId: string
-  samples: CenterlineSample[]
-  /** Centerline samples in OpenDRIVE meters. */
-  odrSamples: { x: number; y: number; width: number; s: number }[]
-  /** Total arc length (m). */
+interface BundleGeometry {
+  /**
+   * Fitted plan-view primitives for the reference line (the bundle's leftmost
+   * boundary), contiguous stations starting at s = 0, OpenDRIVE meters.
+   */
+  planView: OdrGeometry[]
+  /** Station + pose on the fitted reference line at every width station. */
+  samplePoses: FittedSamplePose[]
+  /**
+   * Full lane width (m) per lane (bundle order, left→right) at each
+   * reference-line station (index-aligned with `samplePoses`).
+   */
+  laneWidths: number[][]
+  /** Total fitted reference-line arc length (m). */
   length: number
+}
+
+/** A road bundle: laterally adjacent lanes emitted as one <road>. */
+interface ExportBundle {
+  /** Lanes ordered left→right in travel direction; index i ⇒ ODR lane -(i+1). */
+  lanes: LaneShape[]
+  geom: BundleGeometry
 }
 
 /** O(1) shape lookup by id. */
@@ -47,42 +86,6 @@ function buildShapeMap(shapes: readonly BaseShape[]): Map<string, BaseShape> {
   const map = new Map<string, BaseShape>()
   for (const s of shapes) map.set(s.id, s)
   return map
-}
-
-/**
- * Build the centerline + width samples for a lane from its two boundaries.
- * If pointOverrides is provided, those point ids are read from the override
- * map instead of from the shape map (used for boundary alignment snapping).
- */
-function buildRoadGeometry(
-  shapeMap: Map<string, BaseShape>,
-  lane: LaneShape,
-  pointOverrides: Map<string, Point2D>
-): RoadGeometry | null {
-  const leftId = lane.props.leftBoundaryId
-  const rightId = lane.props.rightBoundaryId
-  if (!leftId || !rightId) return null
-
-  const left = shapeMap.get(leftId) as unknown as LinestringShape | undefined
-  const right = shapeMap.get(rightId) as unknown as LinestringShape | undefined
-  if (!left || !right) return null
-
-  const leftPts = collectPoints(shapeMap, left.props.pointIds, lane.props.invertLeft, pointOverrides)
-  const rightPts = collectPoints(shapeMap, right.props.pointIds, lane.props.invertRight, pointOverrides)
-  if (leftPts.length < 2 || rightPts.length < 2) return null
-
-  const samples = computeCenterlineWithWidth(leftPts, rightPts)
-  if (samples.length < 2) return null
-
-  const odrSamples = samples.map((s) => ({
-    x: pxToEnuX(s.x),
-    y: pxToEnuY(s.y),
-    width: pxToMeter(s.width),
-    s: pxToMeter(s.s),
-  }))
-  const length = odrSamples[odrSamples.length - 1].s
-
-  return { laneId: lane.id, samples, odrSamples, length }
 }
 
 function collectPoints(
@@ -105,6 +108,263 @@ function collectPoints(
   return pts
 }
 
+/** Boundary polyline of a linestring in travel order, or null when unusable. */
+function boundaryPointsOf(
+  shapeMap: Map<string, BaseShape>,
+  boundaryId: string | null,
+  invert: boolean,
+  pointOverrides: Map<string, Point2D>
+): Point2D[] | null {
+  if (!boundaryId) return null
+  const ls = shapeMap.get(boundaryId) as unknown as LinestringShape | undefined
+  if (!ls) return null
+  const pts = collectPoints(shapeMap, ls.props.pointIds, invert, pointOverrides)
+  return pts.length >= 2 ? pts : null
+}
+
+/**
+ * Group lanes into road bundles by lateral adjacency.
+ *
+ * Lane B is the direct right neighbour of lane A when A's right boundary IS
+ * B's left boundary — the same linestring traversed in the same direction
+ * (`A.invertRight === B.invertLeft`); a direction mismatch means the
+ * neighbour travels the other way (e.g. the two sides of a two-way road) and
+ * belongs in its own bundle. The relation must be unique on both sides so
+ * pathological data (several lanes claiming one boundary side) degrades to
+ * separate bundles instead of guessing.
+ *
+ * Because adjacency requires sharing the whole linestring, every lane of a
+ * bundle spans the same longitudinal extent by construction.
+ */
+function detectBundles(lanes: LaneShape[]): LaneShape[][] {
+  const byLeft = new Map<string, LaneShape[]>()
+  const byRight = new Map<string, LaneShape[]>()
+  for (const lane of lanes) {
+    const l = lane.props.leftBoundaryId
+    const r = lane.props.rightBoundaryId
+    if (l) byLeft.set(l, [...(byLeft.get(l) ?? []), lane])
+    if (r) byRight.set(r, [...(byRight.get(r) ?? []), lane])
+  }
+
+  const rightNeighbor = new Map<string, LaneShape>()
+  const hasLeftNeighbor = new Set<string>()
+  for (const lane of lanes) {
+    const rb = lane.props.rightBoundaryId
+    if (!rb) continue
+    const candidates = (byLeft.get(rb) ?? []).filter(
+      b => b.id !== lane.id && b.props.invertLeft === lane.props.invertRight
+    )
+    if (candidates.length !== 1) continue
+    const b = candidates[0]
+    const owners = (byRight.get(rb) ?? []).filter(
+      a => a.props.invertRight === b.props.invertLeft
+    )
+    if (owners.length !== 1 || owners[0].id !== lane.id) continue
+    rightNeighbor.set(lane.id, b)
+    hasLeftNeighbor.add(b.id)
+  }
+
+  const bundles: LaneShape[][] = []
+  const visited = new Set<string>()
+  const walk = (start: LaneShape): void => {
+    const bundle: LaneShape[] = []
+    let cur: LaneShape | undefined = start
+    while (cur && !visited.has(cur.id)) {
+      visited.add(cur.id)
+      bundle.push(cur)
+      cur = rightNeighbor.get(cur.id)
+    }
+    if (bundle.length > 0) bundles.push(bundle)
+  }
+  // Start from the leftmost lane of each chain ...
+  for (const lane of lanes) {
+    if (!visited.has(lane.id) && !hasLeftNeighbor.has(lane.id)) walk(lane)
+  }
+  // ... and break adjacency cycles (degenerate ring data) deterministically.
+  for (const lane of lanes) {
+    if (!visited.has(lane.id)) walk(lane)
+  }
+  return bundles
+}
+
+/** Distance from `p` to the polyline `pts` (projection onto each segment). */
+function distancePointToPolyline(p: Point2D, pts: readonly Point2D[]): number {
+  let best = Infinity
+  for (let i = 0; i < pts.length - 1; i++) {
+    const a = pts[i]
+    const b = pts[i + 1]
+    const dx = b.x - a.x
+    const dy = b.y - a.y
+    const len2 = dx * dx + dy * dy
+    let t = len2 > 1e-18 ? ((p.x - a.x) * dx + (p.y - a.y) * dy) / len2 : 0
+    if (t < 0) t = 0
+    if (t > 1) t = 1
+    const d = Math.hypot(p.x - (a.x + t * dx), p.y - (a.y + t * dy))
+    if (d < best) best = d
+  }
+  return best
+}
+
+/**
+ * Signed lateral offset (m, positive toward -t / the right of the travel
+ * direction) from each fitted reference pose to a boundary polyline, measured
+ * along the pose normal — the exact inverse of the importer's
+ * offset-along-normal boundary reconstruction. Among multiple normal/boundary
+ * intersections the one closest to the previous station's offset wins
+ * (continuity); stations whose normal misses the boundary entirely (e.g. the
+ * very ends, where boundary extents differ slightly) fall back to the
+ * closest-point distance.
+ */
+/**
+ * Largest believable offset change between neighbouring width stations (m).
+ * An intersection jumping further than this is the normal ray hitting a far
+ * branch of the boundary (e.g. the opposite end of a ~180° ramp), not the
+ * adjacent lane edge, and is discarded for the closest-point fallback.
+ */
+const OFFSET_JUMP_TOL_M = 5
+
+function normalOffsets(poses: readonly FittedSamplePose[], bnd: readonly Point2D[]): number[] {
+  const out: number[] = []
+  let prev: number | null = null
+  for (const pose of poses) {
+    // Right normal of heading h in ENU: (sin h, -cos h).
+    const nx = Math.sin(pose.hdg)
+    const ny = -Math.cos(pose.hdg)
+    const fallback = distancePointToPolyline({ x: pose.x, y: pose.y }, bnd)
+    const refVal = prev ?? fallback
+    let best: number | null = null
+    for (let i = 0; i < bnd.length - 1; i++) {
+      const dx = bnd[i + 1].x - bnd[i].x
+      const dy = bnd[i + 1].y - bnd[i].y
+      // Solve pose + t·n = bnd[i] + w·(bnd[i+1]-bnd[i]) for (t, w).
+      const det = dx * ny - dy * nx
+      if (Math.abs(det) < 1e-12) continue
+      const rx = bnd[i].x - pose.x
+      const ry = bnd[i].y - pose.y
+      const w = (nx * ry - ny * rx) / det
+      if (w < -1e-9 || w > 1 + 1e-9) continue
+      const t = (dx * ry - dy * rx) / det
+      if (best === null || Math.abs(t - refVal) < Math.abs(best - refVal)) best = t
+    }
+    if (best === null || Math.abs(best - refVal) > OFFSET_JUMP_TOL_M) best = fallback
+    prev = best
+    out.push(best)
+  }
+  return out
+}
+
+/**
+ * Build the bundle geometry: the fitted reference line (leftmost boundary)
+ * plus per-lane width samples.
+ *
+ * The reference polyline keeps the boundary's own vertices and is refined
+ * with uniform arc-length stations so the width grid is at least as dense as
+ * the densest boundary of the bundle. The polyline is then fitted into
+ * analytic plan-view primitives (line / arc / paramPoly3), and the width of
+ * lane i at station j is the gap between its inner and outer boundary
+ * measured along the fitted reference normal at that station, so the
+ * importer's offset-along-normal reconstruction reproduces the original
+ * boundaries with no longitudinal skew.
+ */
+function buildBundleGeometry(
+  shapeMap: Map<string, BaseShape>,
+  bundleLanes: LaneShape[],
+  pointOverrides: Map<string, Point2D>
+): BundleGeometry | null {
+  const first = bundleLanes[0]
+  const boundaries: Point2D[][] = []
+  const left = boundaryPointsOf(shapeMap, first.props.leftBoundaryId, first.props.invertLeft, pointOverrides)
+  if (!left) return null
+  boundaries.push(left)
+  for (const lane of bundleLanes) {
+    const right = boundaryPointsOf(shapeMap, lane.props.rightBoundaryId, lane.props.invertRight, pointOverrides)
+    if (!right) return null
+    boundaries.push(right)
+  }
+
+  // Boundaries in OpenDRIVE meters (ENU).
+  const bndOdr = boundaries.map(b => b.map(p => ({ x: pxToEnuX(p.x), y: pxToEnuY(p.y) })))
+
+  // The plan view is fitted to the reference boundary's own vertices only:
+  // they are true samples of the drawn curve, so the fitter's tangent
+  // estimates are sound there. Densifying the polyline before the fit would
+  // insert points along its chords, whose collinear runs masquerade as
+  // straight stretches and corrupt the tangent estimates (worst at the road
+  // ends, where the start/end heading defines the contact cross-section
+  // shared with the neighbouring roads).
+  const ref = bndOdr[0]
+  const fit = fitPlanView(ref)
+  if (fit.geometries.length === 0 || !(fit.length > 0)) return null
+
+  // Width stations: the reference vertices (corners must survive into the
+  // width records) merged with a uniform grid as dense as the densest
+  // boundary (inner-boundary detail must survive too). Grid stations are
+  // placed by chord-length interpolation between the fitted stations of the
+  // surrounding reference vertices and posed on the fitted curve.
+  let n = 2
+  for (const b of bndOdr) n = Math.max(n, b.length)
+  const cum: number[] = [0]
+  for (let i = 1; i < ref.length; i++) {
+    cum.push(cum[i - 1] + Math.hypot(ref[i].x - ref[i - 1].x, ref[i].y - ref[i - 1].y))
+  }
+  const total = cum[cum.length - 1]
+  if (!(total > 0)) return null
+  const params = cum.map(c => c / total)
+  for (let j = 0; j < n; j++) params.push(j / (n - 1))
+  params.sort((a, b) => a - b)
+  const stationOf = (t: number): number => {
+    const target = t * total
+    let i = 1
+    while (i < cum.length - 1 && cum[i] < target) i++
+    const c0 = cum[i - 1]
+    const c1 = cum[i]
+    const s0 = fit.samplePoses[i - 1].s
+    const s1 = fit.samplePoses[i].s
+    const f = c1 > c0 ? (target - c0) / (c1 - c0) : 0
+    return s0 + (s1 - s0) * f
+  }
+  const poseAtStation = (s: number): FittedSamplePose => {
+    const clamped = Math.min(Math.max(s, 0), fit.length)
+    let g = fit.geometries[0]
+    for (const geom of fit.geometries) {
+      if (geom.s <= clamped + 1e-12) g = geom
+      else break
+    }
+    const p = evalGeometry(g, Math.min(Math.max(clamped - g.s, 0), g.length))
+    return { s: clamped, x: p.x, y: p.y, hdg: p.hdg }
+  }
+  const samplePoses: FittedSamplePose[] = []
+  for (const t of params) {
+    const pose = poseAtStation(stationOf(t))
+    const last = samplePoses[samplePoses.length - 1]
+    if (!last || pose.s > last.s + 1e-9 || samplePoses.length === 0) samplePoses.push(pose)
+  }
+  if (samplePoses.length < 2) return null
+
+  const offsets = bndOdr.map(b => normalOffsets(samplePoses, b))
+  // Contact stations measure each boundary's own endpoint (projected onto
+  // the contact normal) instead of the ray/polyline crossing: the endpoints
+  // are the welded corners shared with the neighbouring road, so both sides
+  // of a contact derive their border positions from the same drawn points
+  // and meet without a lateral step. (The ray crossing drifts by up to a few
+  // centimeters when a boundary meets the contact at a skew.)
+  const projectEndpoint = (pose: FittedSamplePose, p: Point2D, fallback: number): number => {
+    const t = (p.x - pose.x) * Math.sin(pose.hdg) - (p.y - pose.y) * Math.cos(pose.hdg)
+    return Math.abs(t - fallback) <= 0.5 ? t : fallback
+  }
+  const lastIdx = samplePoses.length - 1
+  for (let b = 0; b < bndOdr.length; b++) {
+    const bnd = bndOdr[b]
+    offsets[b][0] = projectEndpoint(samplePoses[0], bnd[0], offsets[b][0])
+    offsets[b][lastIdx] = projectEndpoint(samplePoses[lastIdx], bnd[bnd.length - 1], offsets[b][lastIdx])
+  }
+  const laneWidths = bundleLanes.map((_, i) =>
+    samplePoses.map((_, j) => Math.max(0, offsets[i + 1][j] - offsets[i][j]))
+  )
+
+  return { planView: fit.geometries, samplePoses, laneWidths, length: fit.length }
+}
+
 /**
  * Snap together boundary endpoints of connected lanes by clustering nearby
  * points and using the centroid as the canonical position.
@@ -121,7 +381,14 @@ function buildBoundaryAlignmentOverrides(
   lanes: LaneShape[],
   epsilonPx: number = 30
 ): Map<string, Point2D> {
-  type Endpoint = { pointId: string; laneId: string; side: 'start' | 'end'; x: number; y: number }
+  type Endpoint = {
+    pointId: string
+    laneId: string
+    side: 'start' | 'end'
+    boundary: 'left' | 'right'
+    x: number
+    y: number
+  }
   const endpoints: Endpoint[] = []
   const laneIds = new Set(lanes.map((l) => l.id))
 
@@ -138,7 +405,14 @@ function buildBoundaryAlignmentOverrides(
       const pid = side === 'start' ? ids[0] : ids[ids.length - 1]
       const pt = shapeMap.get(pid) as unknown as PointShape | undefined
       if (!pt) continue
-      endpoints.push({ pointId: pid, laneId: lane.id, side, x: pt.x, y: pt.y })
+      endpoints.push({
+        pointId: pid,
+        laneId: lane.id,
+        side,
+        boundary: sideKey === 'leftBoundaryId' ? 'left' : 'right',
+        x: pt.x,
+        y: pt.y,
+      })
     }
   }
 
@@ -150,35 +424,87 @@ function buildBoundaryAlignmentOverrides(
     if (hasPrev) collectEndpoints(lane, 'start')
   }
 
-  // Greedy clustering: group points within epsilon of each other, with two
+  // Forbidden point pairs: a lane's start-side and end-side endpoint Points
+  // must never land in the same cluster. A connecting lane shorter than
+  // epsilon would otherwise get its start and end merged into one cluster,
+  // collapsing its boundaries below the degenerate-road export guard and
+  // silently dropping the lane (and its next/prev chain). The constraint is
+  // tracked by point id — not by the owning lane entry — because boundary
+  // endpoints are often Point shapes shared with the neighbouring lanes, and
+  // a neighbour's entry could otherwise pull both of a short lane's end
+  // points into one cluster.
+  const sidePids = new Map<string, { start: Set<string>; end: Set<string> }>()
+  for (const ep of endpoints) {
+    const entry = sidePids.get(ep.laneId) ?? { start: new Set(), end: new Set() }
+    entry[ep.side].add(ep.pointId)
+    sidePids.set(ep.laneId, entry)
+  }
+  const forbidden = new Map<string, Set<string>>()
+  const forbid = (a: string, b: string): void => {
+    forbidden.set(a, (forbidden.get(a) ?? new Set()).add(b))
+    forbidden.set(b, (forbidden.get(b) ?? new Set()).add(a))
+  }
+  for (const { start, end } of sidePids.values()) {
+    for (const s of start) {
+      for (const e of end) {
+        if (s !== e) forbid(s, e)
+      }
+    }
+  }
+  // A lane's left-boundary endpoint must never merge with its right-boundary
+  // endpoint on the same side: lanes narrower than epsilon would be pinched
+  // to zero width at the contact (and the welded neighbours dragged along).
+  // Tracked by point id like above, so a genuine zero-width taper — where
+  // left and right already share one Point — is unaffected.
+  const boundaryPids = new Map<string, { left: Set<string>; right: Set<string> }>()
+  for (const ep of endpoints) {
+    const key = `${ep.laneId}|${ep.side}`
+    const entry = boundaryPids.get(key) ?? { left: new Set(), right: new Set() }
+    entry[ep.boundary].add(ep.pointId)
+    boundaryPids.set(key, entry)
+  }
+  for (const { left, right } of boundaryPids.values()) {
+    for (const l of left) {
+      for (const r of right) {
+        if (l !== r) forbid(l, r)
+      }
+    }
+  }
+
+  // Greedy clustering: group points within epsilon of each other, with three
   // refinements over plain first-fit grouping:
-  // 1. An endpoint never joins a cluster that already holds the opposite end
-  //    of the same lane. A connecting lane shorter than epsilon would
-  //    otherwise get its start and end merged into one cluster, collapsing
-  //    its centerline below the degenerate-road export guard and silently
-  //    dropping the lane (and its next/prev chain).
+  // 1. An endpoint never joins a cluster holding a point its point id is
+  //    forbidden against (see above).
   // 2. Among the eligible clusters the nearest one wins, so the far end of a
   //    short lane clusters with its true counterpart rather than with the
   //    first cluster found within epsilon.
+  // 3. An endpoint whose nearest in-range cluster is a forbidden one never
+  //    hops to a farther eligible cluster: the forbidden cluster marks a
+  //    neighbouring corner of the same contact (narrow lane / short lane),
+  //    so anything beyond it belongs to a different corner entirely and
+  //    merging would drag the contact sideways. It opens its own cluster.
   const clusters: Endpoint[][] = []
   const eps2 = epsilonPx * epsilonPx
   for (const ep of endpoints) {
     let best: Endpoint[] | null = null
     let bestD2 = Infinity
+    let blockedD2 = Infinity
+    const epForbidden = forbidden.get(ep.pointId)
     for (const cluster of clusters) {
       const c0 = cluster[0]
       const dx = ep.x - c0.x
       const dy = ep.y - c0.y
       const d2 = dx * dx + dy * dy
-      if (d2 > eps2 || d2 >= bestD2) continue
-      const conflictsOwnLane = cluster.some(
-        (m) => m.laneId === ep.laneId && m.side !== ep.side
-      )
-      if (conflictsOwnLane) continue
+      if (d2 > eps2) continue
+      if (epForbidden && cluster.some((m) => epForbidden.has(m.pointId))) {
+        if (d2 < blockedD2) blockedD2 = d2
+        continue
+      }
+      if (d2 >= bestD2) continue
       best = cluster
       bestD2 = d2
     }
-    if (best) best.push(ep)
+    if (best && bestD2 <= blockedD2) best.push(ep)
     else clusters.push([ep])
   }
 
@@ -202,21 +528,24 @@ function buildBoundaryAlignmentOverrides(
   return overrides
 }
 
-function emitPlanView(geom: RoadGeometry): string {
+function emitPlanView(geom: BundleGeometry): string {
   const lines: string[] = []
   lines.push(`    <planView>`)
-  for (let i = 0; i < geom.odrSamples.length - 1; i++) {
-    const a = geom.odrSamples[i]
-    const b = geom.odrSamples[i + 1]
-    const dx = b.x - a.x
-    const dy = b.y - a.y
-    const segLen = Math.hypot(dx, dy)
-    if (segLen < 1e-9) continue
-    const hdg = Math.atan2(dy, dx)
+  for (const g of geom.planView) {
+    if (g.length < 1e-9) continue
     lines.push(
-      `      <geometry s="${fmt(a.s)}" x="${fmt(a.x)}" y="${fmt(a.y)}" hdg="${fmt(hdg)}" length="${fmt(segLen)}">`
+      `      <geometry s="${fmt(g.s)}" x="${fmt(g.x)}" y="${fmt(g.y)}" hdg="${fmt(g.hdg)}" length="${fmt(g.length)}">`
     )
-    lines.push(`        <line/>`)
+    if (g.kind === 'arc') {
+      lines.push(`        <arc curvature="${fmtPrecise(g.curvature)}"/>`)
+    } else if (g.kind === 'paramPoly3') {
+      lines.push(
+        `        <paramPoly3 aU="${fmtPrecise(g.aU)}" bU="${fmtPrecise(g.bU)}" cU="${fmtPrecise(g.cU)}" dU="${fmtPrecise(g.dU)}" ` +
+          `aV="${fmtPrecise(g.aV)}" bV="${fmtPrecise(g.bV)}" cV="${fmtPrecise(g.cV)}" dV="${fmtPrecise(g.dV)}" pRange="arcLength"/>`
+      )
+    } else {
+      lines.push(`        <line/>`)
+    }
     lines.push(`      </geometry>`)
   }
   lines.push(`    </planView>`)
@@ -256,119 +585,348 @@ function roadMarkTypeFor(shapeMap: Map<string, BaseShape>, boundaryId: string | 
 }
 
 function emitLanes(
-  geom: RoadGeometry,
-  hasPrev: boolean,
-  hasNext: boolean,
-  laneType: string,
-  centerMark: string,
-  outerMark: string
+  bundle: ExportBundle,
+  plan: ConnectivityPlan,
+  shapeMap: Map<string, BaseShape>
 ): string {
+  const geom = bundle.geom
   const lines: string[] = []
   lines.push(`    <lanes>`)
-  // The plan view follows the lane centerline; shifting the lane reference by
-  // +width/2 puts center lane 0 on the lane's left boundary, so a single
-  // right lane (-1) spans the full lane width. One drawtonomy lane therefore
-  // maps to exactly one OpenDRIVE driving lane (not two half-width lanes).
-  emitLaneOffsetEntries(geom, lines)
+  // The plan view follows the bundle's leftmost boundary, so lane 0 (center)
+  // lies on the left edge of lane -1 and no laneOffset is required. Lanes are
+  // emitted -1, -2, ... from the reference line outward (left→right in travel
+  // direction), each spanning its full drawn width.
   lines.push(`      <laneSection s="0">`)
-  // Center reference line (= left boundary after the laneOffset shift).
   lines.push(`        <center>`)
   lines.push(`          <lane id="0" type="none" level="false">`)
   lines.push(`            <link/>`)
+  const centerMark = roadMarkTypeFor(shapeMap, bundle.lanes[0].props.leftBoundaryId)
   lines.push(`            <roadMark sOffset="0" type="${centerMark}" weight="standard" color="white" width="0.13"/>`)
   lines.push(`          </lane>`)
   lines.push(`        </center>`)
   lines.push(`        <right>`)
-  lines.push(`          <lane id="-1" type="${laneType}" level="false">`)
-  emitLaneLink(lines, hasPrev, hasNext, -1)
-  emitWidthEntries(geom, lines)
-  lines.push(`            <roadMark sOffset="0" type="${outerMark}" weight="standard" color="white" width="0.13"/>`)
-  lines.push(`          </lane>`)
+  bundle.lanes.forEach((lane, i) => {
+    const odrId = -(i + 1)
+    lines.push(`          <lane id="${odrId}" type="${odrLaneTypeFor(lane)}" level="false">`)
+    emitLaneLink(lines, plan.lanePredecessor.get(lane.id), plan.laneSuccessor.get(lane.id))
+    emitWidthEntries(geom, i, lines)
+    const outerMark = roadMarkTypeFor(shapeMap, lane.props.rightBoundaryId)
+    lines.push(`            <roadMark sOffset="0" type="${outerMark}" weight="standard" color="white" width="0.13"/>`)
+    lines.push(`          </lane>`)
+  })
   lines.push(`        </right>`)
   lines.push(`      </laneSection>`)
   lines.push(`    </lanes>`)
   return lines.join('\n')
 }
 
-function emitLaneLink(out: string[], hasPrev: boolean, hasNext: boolean, laneId: number): void {
-  if (!hasPrev && !hasNext) {
+function emitLaneLink(out: string[], predId: number | undefined, succId: number | undefined): void {
+  if (predId === undefined && succId === undefined) {
     out.push(`            <link/>`)
     return
   }
   out.push(`            <link>`)
-  if (hasPrev) {
-    out.push(`              <predecessor id="${laneId}"/>`)
+  if (predId !== undefined) {
+    out.push(`              <predecessor id="${predId}"/>`)
   }
-  if (hasNext) {
-    out.push(`              <successor id="${laneId}"/>`)
+  if (succId !== undefined) {
+    out.push(`              <successor id="${succId}"/>`)
   }
   out.push(`            </link>`)
 }
 
-/** Piecewise-linear laneOffset records: +width/2 toward the left boundary. */
-function emitLaneOffsetEntries(geom: RoadGeometry, out: string[]): void {
-  for (let i = 0; i < geom.odrSamples.length - 1; i++) {
-    const s = geom.odrSamples[i].s
-    const halfA = geom.odrSamples[i].width / 2
-    const halfB = geom.odrSamples[i + 1].width / 2
-    const segLen = geom.odrSamples[i + 1].s - s
-    const b = segLen > 1e-9 ? (halfB - halfA) / segLen : 0
-    out.push(`      <laneOffset s="${fmt(s)}" a="${fmt(halfA)}" b="${fmt(b)}" c="0" d="0"/>`)
+/**
+ * Maximum width error (m) tolerated when folding stations into one record.
+ * Width samples carry chordal noise of the same order (the boundary polyline
+ * is a chordal approximation of the original curve), so a 1 cm band mostly
+ * absorbs that noise while staying far below the 5 cm position tolerance.
+ */
+const WIDTH_SIMPLIFY_TOL_M = 0.01
+
+/**
+ * Piecewise-linear full lane width records: a + b*ds (c=d=0). Station runs
+ * are simplified greedily: a record absorbs every following station whose
+ * widths stay within WIDTH_SIMPLIFY_TOL_M of the straight ramp between the
+ * record start and the run end, so constant-width lanes collapse to a single
+ * record and smoothly varying lanes to a few.
+ */
+function emitWidthEntries(geom: BundleGeometry, laneIndex: number, out: string[]): void {
+  const allWidths = geom.laneWidths[laneIndex]
+  const poses = geom.samplePoses
+  // Strictly increasing stations (duplicates share one width sample).
+  const sArr: number[] = []
+  const wArr: number[] = []
+  for (let i = 0; i < poses.length; i++) {
+    if (sArr.length === 0 || poses[i].s > sArr[sArr.length - 1] + 1e-9) {
+      sArr.push(poses[i].s)
+      wArr.push(allWidths[i])
+    }
+  }
+  const recs: { s: number; a: number; b: number }[] = []
+  if (sArr.length < 2) {
+    recs.push({ s: 0, a: wArr[0] ?? 0, b: 0 })
+  }
+  let i0 = 0
+  while (i0 < sArr.length - 1) {
+    let end = i0 + 1
+    for (let j = i0 + 2; j < sArr.length; j++) {
+      const slope = (wArr[j] - wArr[i0]) / (sArr[j] - sArr[i0])
+      let ok = true
+      for (let k = i0 + 1; k < j; k++) {
+        if (Math.abs(wArr[i0] + slope * (sArr[k] - sArr[i0]) - wArr[k]) > WIDTH_SIMPLIFY_TOL_M) {
+          ok = false
+          break
+        }
+      }
+      if (!ok) break
+      end = j
+    }
+    recs.push({ s: sArr[i0], a: wArr[i0], b: (wArr[end] - wArr[i0]) / (sArr[end] - sArr[i0]) })
+    i0 = end
+  }
+  for (const r of recs) {
+    out.push(`            <width sOffset="${fmt(r.s)}" a="${fmt(r.a)}" b="${fmtPrecise(r.b)}" c="0" d="0"/>`)
   }
 }
 
-/** Piecewise-linear full lane width records: a + b*ds (c=d=0). */
-function emitWidthEntries(geom: RoadGeometry, out: string[]): void {
-  for (let i = 0; i < geom.odrSamples.length - 1; i++) {
-    const s = geom.odrSamples[i].s
-    const wA = geom.odrSamples[i].width
-    const wB = geom.odrSamples[i + 1].width
-    const segLen = geom.odrSamples[i + 1].s - s
-    const b = segLen > 1e-9 ? (wB - wA) / segLen : 0
-    out.push(`            <width sOffset="${fmt(s)}" a="${fmt(wA)}" b="${fmt(b)}" c="0" d="0"/>`)
-  }
-}
+type RoadLinkTarget = { kind: 'road' | 'junction'; id: number }
 
-interface JunctionPlan {
-  /** Junction id routing a lane's outgoing (next) edges, when present. */
-  nextJunction: Map<string, number>
-  /** Junction id routing a lane's incoming (prev) edges, when present. */
-  prevJunction: Map<string, number>
-  /** Junction id stamped on a connecting road (<road junction="...">). */
-  roadJunction: Map<string, number>
-  junctions: { id: number; connections: { incoming: number; connecting: number }[] }[]
+/** Length (m) of a synthesized junction connecting road. Kept below the
+ * importer's micro-section threshold so re-imports skip it and bridge the
+ * lane links across instead of materializing an extra sliver lane. Also kept
+ * below the 1 cm contact-point gap tolerance of ASAM quality checkers: the
+ * incoming lane end and the outgoing lane start coincide in the drawing, so
+ * the stub necessarily overlaps the outgoing road and its whole length shows
+ * up as a contact-point discontinuity to gap checks. */
+const CONNECTING_ROAD_LENGTH_M = 0.005
+
+/**
+ * Contact widths below this (m) count as zero for lane linking: OpenDRIVE
+ * forbids predecessor/successor records on lanes that have zero width at the
+ * linked contact (zero-width / appearing-lane semantics). Welded taper lanes
+ * produce exact zeros; the epsilon also covers values that round to zero in
+ * the 6-decimal output.
+ */
+const ZERO_WIDTH_LINK_EPS_M = 1e-3
+
+/** Wrap an angle to (-pi, pi]. */
+function wrapAngleRad(a: number): number {
+  while (a > Math.PI) a -= 2 * Math.PI
+  while (a < -Math.PI) a += 2 * Math.PI
+  return a
 }
 
 /**
- * Plan synthesized <junction> elements for branch / merge connectivity.
+ * A zero-length(ish) connecting road synthesized for one branch / merge lane
+ * edge, giving junctions the standard incoming -> connecting -> outgoing
+ * structure (the mainline roads keep junction="-1").
+ */
+interface ConnectingRoadSpec {
+  roadId: number
+  junctionId: number
+  incomingRoadId: number
+  outgoingRoadId: number
+  /** ODR lane id of the source lane on the incoming road. */
+  fromOdrLaneId: number
+  /** ODR lane id of the target lane on the outgoing road. */
+  toOdrLaneId: number
+  /** Geometry seed at the source lane's end (see ConnectingSource). */
+  source: ConnectingSource
+  /** Heading / width of the target lane at its start (see ConnectingTarget). */
+  target: ConnectingTarget | null
+}
+
+/**
+ * Pose / width / type of the lane a connecting road starts from: the inner
+ * boundary endpoint of the source lane (ENU meters), the travel heading
+ * there, the lane's end width, and its OpenDRIVE lane type.
+ */
+interface ConnectingSource {
+  x: number
+  y: number
+  hdg: number
+  width: number
+  laneType: string
+}
+
+/**
+ * Pose / width of the lane a connecting road ends on, at its start contact:
+ * the lane's inner-border point as the outgoing road actually emits it
+ * (reference pose + accumulated widths), its travel heading and width there.
+ * The stub blends onto them (Hermite onto the exact border point when it is
+ * ahead of the source, else an arc sweep, plus a linear width ramp) so both
+ * of its contacts stay gap-free even when the drawing kinks or staggers at
+ * the branch point.
+ */
+interface ConnectingTarget {
+  x: number
+  y: number
+  hdg: number
+  width: number
+}
+
+interface ConnectivityPlan {
+  /** Road-level predecessor / successor per road id. */
+  roadPredecessor: Map<number, RoadLinkTarget>
+  roadSuccessor: Map<number, RoadLinkTarget>
+  /** ODR lane id of the linked lane, per lane shape id (road-linked roads only). */
+  lanePredecessor: Map<string, number>
+  laneSuccessor: Map<string, number>
+  junctions: {
+    id: number
+    connections: { incoming: number; connecting: number; laneLinks: { from: number; to: number }[] }[]
+    /** <priority high low> records between connecting roads (right of way). */
+    priorities: { high: number; low: number }[]
+  }[]
+  /** Synthesized connecting roads, one per junction-routed lane edge. */
+  connectingRoads: ConnectingRoadSpec[]
+  /**
+   * yieldLaneIds pairs ("rowLaneShapeId|yieldLaneShapeId") expressed as
+   * junction <priority> records; excluded from the userData fallback stash.
+   */
+  handledYieldPairs: Set<string>
+  /**
+   * Lane edges whose contact width is (near) zero on either side. OpenDRIVE
+   * forbids linking lanes that have zero width at the linked contact (the
+   * "appearing lane" rules), so these edges are kept out of every standard
+   * <link> / <laneLink> record and stashed as
+   * <userData code="hiddenLaneLinks"> on the road of `home` instead, from
+   * where the importer restores the next/prev relationship.
+   */
+  hiddenLaneEdges: { from: string; to: string; home: string }[]
+}
+
+/**
+ * Plan road links, lane links and synthesized <junction> elements.
  *
- * A road <link> can name only one predecessor and one successor, so an edge
- * is representable as plain road links only when it is its source's only
- * `next` AND its target's only `prev`. Every other edge (branching or
- * merging) is routed through a synthesized junction: the target roads become
- * connecting roads (their <road junction> attribute is set) and each edge is
- * emitted as a <connection incomingRoad connectingRoad contactPoint="start">
- * carrying a <laneLink from="-1" to="-1"/> (the exporter emits exactly one
- * driving lane -1 per road). Edges that share a lane collapse into the same
+ * A road <link> can name only one predecessor and one successor, so a road
+ * pair (P → Q) is representable as a plain road link only when Q is P's only
+ * successor road AND P is Q's only predecessor road AND every lane edge
+ * between them is 1:1 (its source's only `next` and its target's only
+ * `prev`). Every other lane edge is routed through a synthesized junction
+ * with the standard structure: a short connecting road (junction-stamped,
+ * with a guaranteed road-level predecessor=incoming / successor=outgoing
+ * link) is synthesized at the contact point for each lane edge, and the
+ * junction's <connection incomingRoad connectingRoad contactPoint="start">
+ * carries the per-lane <laneLink>. The mainline roads stay junction="-1" and
+ * link to the junction by id. Edges that share a road collapse into the same
  * junction (connected components), so a 2-in x 2-out diamond becomes one
  * junction with four connections.
+ *
+ * Right-of-way lane pairs (`yieldLaneIds`) whose two lanes both feed
+ * connecting roads of the same junction are emitted as standard
+ * <priority high low> records between those connecting roads.
  */
-function planJunctions(
-  lanes: LaneShape[],
-  laneIdToRoadId: Map<string, number>,
-  firstJunctionId: number
-): JunctionPlan {
+function planConnectivity(
+  exportBundles: ExportBundle[],
+  roadIdOf: Map<string, number>,
+  odrIdOf: Map<string, number>,
+  firstJunctionId: number,
+  connectingSourceFor: (laneShapeId: string) => ConnectingSource | null,
+  connectingTargetFor: (laneShapeId: string) => ConnectingTarget | null,
+  contactWidth: (laneShapeId: string, contact: 'start' | 'end') => number | null,
+  externalLanes: Map<string, LaneShape> = new Map()
+): ConnectivityPlan {
   const validNext = new Map<string, string[]>()
   const validPrev = new Map<string, string[]>()
-  for (const lane of lanes) {
-    if (!laneIdToRoadId.has(lane.id)) continue
-    validNext.set(lane.id, (lane.props.next ?? []).filter((id) => laneIdToRoadId.has(id)))
-    validPrev.set(lane.id, (lane.props.prev ?? []).filter((id) => laneIdToRoadId.has(id)))
+  for (const bundle of exportBundles) {
+    for (const lane of bundle.lanes) {
+      validNext.set(lane.id, (lane.props.next ?? []).filter(id => roadIdOf.has(id)))
+      validPrev.set(lane.id, (lane.props.prev ?? []).filter(id => roadIdOf.has(id)))
+    }
+  }
+  // Carry-through: lanes of verbatim (unedited) roads participate as link
+  // endpoints — their roads are never re-emitted here, but regenerated roads
+  // must still link to / from them. Edges between two external lanes are
+  // covered by the verbatim XML and are skipped below.
+  for (const [id, lane] of externalLanes) {
+    validNext.set(id, (lane.props.next ?? []).filter(t => roadIdOf.has(t)))
+    validPrev.set(id, (lane.props.prev ?? []).filter(t => roadIdOf.has(t)))
   }
 
-  // Union-find over the lanes participating in junction-routed edges.
-  const parent = new Map<string, string>()
-  const find = (x: string): string => {
+  // Lanes with (near) zero width at a linked contact must not carry standard
+  // link records there (zero-width / appearing-lane rules), so those edges
+  // are diverted into the hiddenLaneLinks userData stash. The stash lives on
+  // the `from` road when it is re-emitted in this export, else on the `to`
+  // road (one of the two always is: external-external edges stay verbatim).
+  const hiddenLaneEdges: ConnectivityPlan['hiddenLaneEdges'] = []
+  for (const [laneId, nexts] of validNext) {
+    if (nexts.length === 0) continue
+    const kept: string[] = []
+    for (const to of nexts) {
+      if (externalLanes.has(laneId) && externalLanes.has(to)) {
+        kept.push(to)
+        continue
+      }
+      const wFrom = contactWidth(laneId, 'end')
+      const wTo = contactWidth(to, 'start')
+      if (
+        (wFrom !== null && wFrom < ZERO_WIDTH_LINK_EPS_M) ||
+        (wTo !== null && wTo < ZERO_WIDTH_LINK_EPS_M)
+      ) {
+        hiddenLaneEdges.push({ from: laneId, to, home: externalLanes.has(laneId) ? to : laneId })
+        const prevs = validPrev.get(to)
+        if (prevs) validPrev.set(to, prevs.filter(p => p !== laneId))
+        continue
+      }
+      kept.push(to)
+    }
+    if (kept.length !== nexts.length) validNext.set(laneId, kept)
+  }
+
+  interface LaneEdge {
+    from: string
+    to: string
+  }
+  const succRoads = new Map<number, Set<number>>()
+  const predRoads = new Map<number, Set<number>>()
+  const edgesByPair = new Map<string, LaneEdge[]>()
+  for (const [laneId, nexts] of validNext) {
+    const fromRoad = roadIdOf.get(laneId)!
+    for (const to of nexts) {
+      if (externalLanes.has(laneId) && externalLanes.has(to)) continue
+      const toRoad = roadIdOf.get(to)!
+      succRoads.set(fromRoad, (succRoads.get(fromRoad) ?? new Set()).add(toRoad))
+      predRoads.set(toRoad, (predRoads.get(toRoad) ?? new Set()).add(fromRoad))
+      const key = `${fromRoad}->${toRoad}`
+      edgesByPair.set(key, [...(edgesByPair.get(key) ?? []), { from: laneId, to }])
+    }
+  }
+
+  const plan: ConnectivityPlan = {
+    roadPredecessor: new Map(),
+    roadSuccessor: new Map(),
+    lanePredecessor: new Map(),
+    laneSuccessor: new Map(),
+    junctions: [],
+    connectingRoads: [],
+    handledYieldPairs: new Set(),
+    hiddenLaneEdges,
+  }
+
+  const junctionPairs: { incoming: number; outgoing: number; laneEdges: LaneEdge[] }[] = []
+  for (const [key, laneEdges] of edgesByPair) {
+    const [fromRoad, toRoad] = key.split('->').map(Number)
+    const uniquePair = succRoads.get(fromRoad)!.size === 1 && predRoads.get(toRoad)!.size === 1
+    const lanesOneToOne = laneEdges.every(
+      e => (validNext.get(e.from) ?? []).length === 1 && (validPrev.get(e.to) ?? []).length === 1
+    )
+    if (uniquePair && lanesOneToOne) {
+      plan.roadSuccessor.set(fromRoad, { kind: 'road', id: toRoad })
+      plan.roadPredecessor.set(toRoad, { kind: 'road', id: fromRoad })
+      for (const e of laneEdges) {
+        plan.laneSuccessor.set(e.from, odrIdOf.get(e.to)!)
+        plan.lanePredecessor.set(e.to, odrIdOf.get(e.from)!)
+      }
+    } else {
+      junctionPairs.push({ incoming: fromRoad, outgoing: toRoad, laneEdges })
+    }
+  }
+
+  // Union-find over road ids: junction-routed pairs sharing a road merge into
+  // one junction.
+  const parent = new Map<number, number>()
+  const find = (x: number): number => {
     let root = x
     while (true) {
       const p = parent.get(root)
@@ -383,83 +941,258 @@ function planJunctions(
     }
     return root
   }
-  const union = (a: string, b: string): void => {
+  const union = (a: number, b: number): void => {
     if (!parent.has(a)) parent.set(a, a)
     if (!parent.has(b)) parent.set(b, b)
     const ra = find(a)
     const rb = find(b)
     if (ra !== rb) parent.set(rb, ra)
   }
+  for (const pair of junctionPairs) union(pair.incoming, pair.outgoing)
 
-  const junctionEdges: { from: string; to: string }[] = []
-  for (const [laneId, nexts] of validNext) {
-    for (const to of nexts) {
-      const prevsOfTarget = validPrev.get(to) ?? []
-      if (nexts.length === 1 && prevsOfTarget.length === 1) continue // plain road link
-      junctionEdges.push({ from: laneId, to })
-      union(laneId, to)
-    }
-  }
-
-  const plan: JunctionPlan = {
-    nextJunction: new Map(),
-    prevJunction: new Map(),
-    roadJunction: new Map(),
-    junctions: [],
-  }
-  const junctionByRoot = new Map<string, JunctionPlan['junctions'][number]>()
+  // Pass 1: one junction per connected component (ids first, so junction ids
+  // and connecting road ids stay sequential and collision-free).
+  const junctionByRoot = new Map<number, ConnectivityPlan['junctions'][number]>()
   let nextId = firstJunctionId
-  for (const e of junctionEdges) {
-    const root = find(e.from)
-    let junction = junctionByRoot.get(root)
-    if (!junction) {
-      junction = { id: nextId++, connections: [] }
+  for (const pair of junctionPairs) {
+    const root = find(pair.incoming)
+    if (!junctionByRoot.has(root)) {
+      const junction = { id: nextId++, connections: [], priorities: [] }
       junctionByRoot.set(root, junction)
       plan.junctions.push(junction)
     }
-    junction.connections.push({
-      incoming: laneIdToRoadId.get(e.from)!,
-      connecting: laneIdToRoadId.get(e.to)!,
-    })
-    plan.nextJunction.set(e.from, junction.id)
-    plan.prevJunction.set(e.to, junction.id)
-    plan.roadJunction.set(e.to, junction.id)
+  }
+
+  // Pass 2: synthesize one short connecting road per junction-routed lane
+  // edge and register it as a <connection> of its junction.
+  const connectingByLane = new Map<string, ConnectingRoadSpec[]>()
+  for (const pair of junctionPairs) {
+    const junction = junctionByRoot.get(find(pair.incoming))!
+    for (const e of pair.laneEdges.slice().sort((a, b) => odrIdOf.get(b.from)! - odrIdOf.get(a.from)! || odrIdOf.get(b.to)! - odrIdOf.get(a.to)!)) {
+      const source = connectingSourceFor(e.from)
+      if (!source) continue
+      const spec: ConnectingRoadSpec = {
+        roadId: nextId++,
+        junctionId: junction.id,
+        incomingRoadId: pair.incoming,
+        outgoingRoadId: pair.outgoing,
+        fromOdrLaneId: odrIdOf.get(e.from)!,
+        toOdrLaneId: odrIdOf.get(e.to)!,
+        source,
+        target: connectingTargetFor(e.to),
+      }
+      plan.connectingRoads.push(spec)
+      junction.connections.push({
+        incoming: pair.incoming,
+        connecting: spec.roadId,
+        laneLinks: [{ from: spec.fromOdrLaneId, to: -1 }],
+      })
+      const list = connectingByLane.get(e.from) ?? []
+      list.push(spec)
+      connectingByLane.set(e.from, list)
+    }
+    plan.roadSuccessor.set(pair.incoming, { kind: 'junction', id: junction.id })
+    plan.roadPredecessor.set(pair.outgoing, { kind: 'junction', id: junction.id })
+  }
+
+  // Right-of-way: a lane pair (X has priority, Y yields) whose maneuvers both
+  // run through connecting roads of one junction becomes <priority high low>
+  // records between those connecting roads.
+  const junctionById = new Map(plan.junctions.map(j => [j.id, j]))
+  for (const bundle of exportBundles) {
+    for (const lane of bundle.lanes) {
+      const highSpecs = connectingByLane.get(lane.id)
+      if (!highSpecs?.length) continue
+      for (const yieldShapeId of lane.props.yieldLaneIds ?? []) {
+        const lowSpecs = connectingByLane.get(yieldShapeId)
+        if (!lowSpecs?.length) continue
+        let expressed = false
+        for (const hi of highSpecs) {
+          for (const lo of lowSpecs) {
+            if (hi.junctionId !== lo.junctionId) continue
+            const junction = junctionById.get(hi.junctionId)!
+            if (!junction.priorities.some(p => p.high === hi.roadId && p.low === lo.roadId)) {
+              junction.priorities.push({ high: hi.roadId, low: lo.roadId })
+            }
+            expressed = true
+          }
+        }
+        if (expressed) plan.handledYieldPairs.add(`${lane.id}|${yieldShapeId}`)
+      }
+    }
   }
   return plan
 }
 
-function emitLink(
-  lane: LaneShape,
-  laneIdToRoadId: Map<string, number>,
-  junctionPlan: JunctionPlan
-): string {
-  const lines: string[] = []
-  lines.push(`    <link>`)
-  const prevJunction = junctionPlan.prevJunction.get(lane.id)
-  if (prevJunction !== undefined) {
-    lines.push(`      <predecessor elementType="junction" elementId="${prevJunction}"/>`)
-  } else {
-    const prevLane = (lane.props.prev ?? []).find((id) => laneIdToRoadId.has(id))
-    if (prevLane) {
-      const rid = laneIdToRoadId.get(prevLane)!
-      lines.push(`      <predecessor elementType="road" elementId="${rid}" contactPoint="end"/>`)
+/**
+ * Emit a synthesized junction connecting road: a single short segment
+ * starting at the incoming lane's inner-boundary endpoint, heading along the
+ * incoming road's end direction, carrying one right lane as wide as the
+ * source lane. When the outgoing lane starts with a different heading or
+ * width (drawn branch points may kink), the stub blends onto them — an <arc>
+ * sweeping the heading difference and a linear width ramp — so the borders
+ * meet both neighbours without a lateral step. The road always links
+ * predecessor=incoming(road, end) and successor=outgoing(road, start), so
+ * standard consumers can traverse incoming -> connecting -> outgoing without
+ * dead ends.
+ */
+function emitConnectingRoad(spec: ConnectingRoadSpec): string {
+  const { x, y, hdg, width } = spec.source
+  const dHdg = spec.target ? wrapAngleRad(spec.target.hdg - hdg) : 0
+  // Target border point in the source frame: when the outgoing lane's
+  // emitted start sits measurably ahead of the source corner (drawn branch
+  // points stagger by centimeters), a cubic Hermite interpolates both end
+  // poses exactly; otherwise a minimum-length arc (or line) blends the
+  // heading in place.
+  let geometry = ''
+  let len = CONNECTING_ROAD_LENGTH_M
+  if (spec.target) {
+    const cosH = Math.cos(hdg)
+    const sinH = Math.sin(hdg)
+    const ex = spec.target.x - x
+    const ey = spec.target.y - y
+    const u1 = ex * cosH + ey * sinH
+    const v1 = -ex * sinH + ey * cosH
+    const dist = Math.hypot(ex, ey)
+    // A target at or behind the source corner (the outgoing road's emitted
+    // start can sit a few millimeters behind the drawn weld) is unreachable
+    // by a forward curve; an in-place blend as short as representable keeps
+    // the leftover contact offset at the stagger itself.
+    if (u1 < CONNECTING_ROAD_LENGTH_M) len = 0.001
+    if (dist >= CONNECTING_ROAD_LENGTH_M && u1 >= 0.7 * dist && Math.abs(dHdg) <= 1.45) {
+      // Hermite with parameter domain [0, L]: u(0)=0,u'(0)=1,v(0)=0,v'(0)=0,
+      // u(L)=u1, u'(L)=cosθ, v(L)=v1, v'(L)=sinθ (same construction as the
+      // plan-view fitter, emitted as paramPoly3 pRange="arcLength").
+      let L = Math.max(dist, u1)
+      let cU = 0
+      let dU = 0
+      let cV = 0
+      let dV = 0
+      const cosT = Math.cos(dHdg)
+      const sinT = Math.sin(dHdg)
+      const solve = (dom: number): void => {
+        const A = u1 - dom
+        const B = cosT - 1
+        cU = (3 * A - B * dom) / (dom * dom)
+        dU = (B * dom - 2 * A) / (dom * dom * dom)
+        cV = (3 * v1 - sinT * dom) / (dom * dom)
+        dV = (sinT * dom - 2 * v1) / (dom * dom * dom)
+      }
+      const arcLength = (dom: number): number => {
+        const n = 32
+        let acc = 0
+        let px = 0
+        let py = 0
+        for (let k = 1; k <= n; k++) {
+          const p = (dom * k) / n
+          const lu = p * (1 + p * (cU + p * dU))
+          const lv = p * p * (cV + p * dV)
+          acc += Math.hypot(lu - px, lv - py)
+          px = lu
+          py = lv
+        }
+        return acc
+      }
+      for (let iter = 0; iter < 3; iter++) {
+        solve(L)
+        const actual = arcLength(L)
+        if (!(actual > 1e-6)) break
+        if (Math.abs(actual - L) < 1e-6) break
+        L = actual
+      }
+      solve(L)
+      // Stay below the importer's micro-section threshold (0.3 m) so the
+      // stub keeps being bridged on re-import instead of materializing as a
+      // sliver lane; larger staggers fall back to the in-place blend.
+      if (L > 1e-6 && L <= 0.25) {
+        len = L
+        geometry = `        <paramPoly3 aU="0" bU="1" cU="${fmtPrecise(cU)}" dU="${fmtPrecise(dU)}" aV="0" bV="0" cV="${fmtPrecise(cV)}" dV="${fmtPrecise(dV)}" pRange="arcLength"/>`
+      }
     }
   }
-  const nextJunction = junctionPlan.nextJunction.get(lane.id)
-  if (nextJunction !== undefined) {
-    lines.push(`      <successor elementType="junction" elementId="${nextJunction}"/>`)
-  } else {
-    const nextLane = (lane.props.next ?? []).find((id) => laneIdToRoadId.has(id))
-    if (nextLane) {
-      const rid = laneIdToRoadId.get(nextLane)!
-      lines.push(`      <successor elementType="road" elementId="${rid}" contactPoint="start"/>`)
-    }
+  if (!geometry) {
+    geometry =
+      Math.abs(dHdg) > 1e-4
+        ? `        <arc curvature="${fmtPrecise(dHdg / len)}"/>`
+        : `        <line/>`
+  }
+  const widthSlope =
+    spec.target !== null && Math.abs(spec.target.width - width) > 1e-6
+      ? (spec.target.width - width) / len
+      : 0
+  const lines: string[] = []
+  lines.push(
+    `  <road name="connecting" length="${fmt(len)}" id="${spec.roadId}" junction="${spec.junctionId}">`
+  )
+  lines.push(`    <link>`)
+  lines.push(
+    `      <predecessor elementType="road" elementId="${spec.incomingRoadId}" contactPoint="end"/>`
+  )
+  lines.push(
+    `      <successor elementType="road" elementId="${spec.outgoingRoadId}" contactPoint="start"/>`
+  )
+  lines.push(`    </link>`)
+  lines.push(`    <planView>`)
+  lines.push(
+    `      <geometry s="0" x="${fmt(x)}" y="${fmt(y)}" hdg="${fmt(hdg)}" length="${fmt(len)}">`
+  )
+  lines.push(geometry)
+  lines.push(`      </geometry>`)
+  lines.push(`    </planView>`)
+  lines.push(`    <elevationProfile/>`)
+  lines.push(`    <lateralProfile/>`)
+  lines.push(`    <lanes>`)
+  lines.push(`      <laneSection s="0">`)
+  lines.push(`        <center>`)
+  lines.push(`          <lane id="0" type="none" level="false">`)
+  lines.push(`            <link/>`)
+  lines.push(`            <roadMark sOffset="0" type="none" weight="standard" color="white" width="0.13"/>`)
+  lines.push(`          </lane>`)
+  lines.push(`        </center>`)
+  lines.push(`        <right>`)
+  lines.push(`          <lane id="-1" type="${spec.source.laneType}" level="false">`)
+  lines.push(`            <link>`)
+  lines.push(`              <predecessor id="${spec.fromOdrLaneId}"/>`)
+  lines.push(`              <successor id="${spec.toOdrLaneId}"/>`)
+  lines.push(`            </link>`)
+  lines.push(
+    `            <width sOffset="0" a="${fmt(width)}" b="${widthSlope === 0 ? '0' : fmtPrecise(widthSlope)}" c="0" d="0"/>`
+  )
+  lines.push(`            <roadMark sOffset="0" type="none" weight="standard" color="white" width="0.13"/>`)
+  lines.push(`          </lane>`)
+  lines.push(`        </right>`)
+  lines.push(`      </laneSection>`)
+  lines.push(`    </lanes>`)
+  lines.push(`    <objects/>`)
+  lines.push(`    <signals/>`)
+  lines.push(`  </road>`)
+  return lines.join('\n')
+}
+
+function emitLink(roadId: number, plan: ConnectivityPlan): string {
+  const lines: string[] = []
+  lines.push(`    <link>`)
+  const pred = plan.roadPredecessor.get(roadId)
+  if (pred) {
+    lines.push(
+      pred.kind === 'junction'
+        ? `      <predecessor elementType="junction" elementId="${pred.id}"/>`
+        : `      <predecessor elementType="road" elementId="${pred.id}" contactPoint="end"/>`
+    )
+  }
+  const succ = plan.roadSuccessor.get(roadId)
+  if (succ) {
+    lines.push(
+      succ.kind === 'junction'
+        ? `      <successor elementType="junction" elementId="${succ.id}"/>`
+        : `      <successor elementType="road" elementId="${succ.id}" contactPoint="start"/>`
+    )
   }
   lines.push(`    </link>`)
   return lines.join('\n')
 }
 
-function projectToRoad(geom: RoadGeometry, xG: number, yG: number): {
+function projectToRoad(geom: BundleGeometry, xG: number, yG: number): {
   s: number
   t: number
   hdg: number
@@ -471,7 +1204,9 @@ function projectToRoad(geom: RoadGeometry, xG: number, yG: number): {
   let bestDist = Infinity
   let bestHdg = 0
   let bestClamped = false
-  const samples = geom.odrSamples
+  // The fitted sample poses lie on the analytic reference line, so chord
+  // projection between them yields stations directly in the emitted s domain.
+  const samples = geom.samplePoses
   for (let i = 0; i < samples.length - 1; i++) {
     const a = samples[i]
     const b = samples[i + 1]
@@ -498,7 +1233,7 @@ function projectToRoad(geom: RoadGeometry, xG: number, yG: number): {
     const dist = Math.hypot(xG - projX, yG - projY)
     if (dist < bestDist) {
       bestDist = dist
-      bestS = a.s + tNorm
+      bestS = a.s + (tNorm / segLen) * (b.s - a.s)
       const nx = -uy
       const ny = ux
       bestT = px * nx + py * ny
@@ -507,6 +1242,33 @@ function projectToRoad(geom: RoadGeometry, xG: number, yG: number): {
     }
   }
   return { s: bestS, t: bestT, hdg: bestHdg, distance: bestDist, clampedAtEnd: bestClamped }
+}
+
+/** Inclusive lane id range a signal applies to. */
+interface ValidityRange {
+  fromLane: number
+  toLane: number
+}
+
+/** Contiguous <validity> ranges from a set of ODR lane ids. */
+function laneIdRanges(ids: number[]): ValidityRange[] {
+  const sorted = [...new Set(ids)].sort((a, b) => a - b)
+  const ranges: ValidityRange[] = []
+  if (sorted.length === 0) return ranges
+  let start = sorted[0]
+  let prev = sorted[0]
+  for (let i = 1; i < sorted.length; i++) {
+    const v = sorted[i]
+    if (v === prev + 1) {
+      prev = v
+      continue
+    }
+    ranges.push({ fromLane: start, toLane: prev })
+    start = v
+    prev = v
+  }
+  ranges.push({ fromLane: start, toLane: prev })
+  return ranges
 }
 
 interface SignalEntry {
@@ -521,8 +1283,8 @@ interface SignalEntry {
   subtype: string
   dynamic: 'yes' | 'no'
   orientation: '+' | '-'
-  /** Lane range the signal applies to (regulatory layer); omitted = whole road. */
-  validity?: { fromLane: number; toLane: number }
+  /** Lane ranges the signal applies to (regulatory layer); omitted = whole road. */
+  validity?: ValidityRange[]
   /**
    * Stop line polyline in ENU meters, carried as <userData code="stopLine">
    * so the importer can rebuild the stop-line linestring and re-link it.
@@ -539,6 +1301,7 @@ interface SignalReferenceEntry {
   s: number
   t: number
   orientation: '+' | '-'
+  validity: ValidityRange[]
 }
 
 interface ObjectEntry {
@@ -563,9 +1326,11 @@ function attachShapesToRoads(
   trafficLights: TrafficLightShape[],
   crosswalks: CrosswalkShape[],
   polygons: { shape: PolygonShape; vertices: { x: number; y: number }[] }[],
-  laneToGeom: Map<string, RoadGeometry>,
+  roads: { roadId: number; geom: BundleGeometry }[],
   laneIdToRoadId: Map<string, number>,
-  maxAttachDistanceMeter: number = 50
+  laneIdToOdrLaneId: Map<string, number>,
+  maxAttachDistanceMeter: number = 50,
+  signalIdStart: number = 1
 ): {
   roadSignals: Map<number, SignalEntry[]>
   roadObjects: Map<number, ObjectEntry[]>
@@ -578,34 +1343,39 @@ function attachShapesToRoads(
   const roadObjects = new Map<number, ObjectEntry[]>()
   const roadSignalRefs = new Map<number, SignalReferenceEntry[]>()
   const signalIdByShape = new Map<string, number>()
-  let signalIdCounter = 1
+  let signalIdCounter = signalIdStart
   let objectIdCounter = 1
 
-  const roads: { laneId: string; geom: RoadGeometry; roadId: number }[] = []
-  laneToGeom.forEach((geom, laneId) => {
-    const roadId = laneIdToRoadId.get(laneId)
-    if (roadId !== undefined) roads.push({ laneId, geom, roadId })
-  })
-  const geomByRoadId = new Map<number, RoadGeometry>()
+  const geomByRoadId = new Map<number, BundleGeometry>()
   for (const r of roads) geomByRoadId.set(r.roadId, r.geom)
+
+  /** Affected lanes grouped per road: road id -> ODR lane ids. */
+  const affectedLanesByRoad = (laneShapeIds: readonly string[] | undefined): Map<number, number[]> => {
+    const byRoad = new Map<number, number[]>()
+    for (const laneShapeId of laneShapeIds ?? []) {
+      const rid = laneIdToRoadId.get(laneShapeId)
+      const oid = laneIdToOdrLaneId.get(laneShapeId)
+      if (rid === undefined || oid === undefined) continue
+      const list = byRoad.get(rid) ?? []
+      if (!list.includes(oid)) list.push(oid)
+      byRoad.set(rid, list)
+    }
+    return byRoad
+  }
 
   for (const tl of trafficLights) {
     const xG = pxToEnuX(tl.x)
     const yG = pxToEnuY(tl.y)
 
     // Regulatory layer: a signal that names affected lanes attaches to the
-    // nearest of those lanes' roads and carries a <validity> record for the
-    // road's single driving lane (-1). Distance gating does not apply — the
-    // assignment is explicit.
-    const affectedRoadIds = new Set<number>()
-    for (const laneShapeId of tl.props.affectedLaneIds ?? []) {
-      const rid = laneIdToRoadId.get(laneShapeId)
-      if (rid !== undefined) affectedRoadIds.add(rid)
-    }
+    // nearest of those lanes' roads and carries <validity> records for the
+    // affected lane range. Distance gating does not apply — the assignment is
+    // explicit.
+    const affectedByRoad = affectedLanesByRoad(tl.props.affectedLaneIds)
     let best: { roadId: number; proj: ReturnType<typeof projectToRoad> } | null = null
-    if (affectedRoadIds.size > 0) {
+    if (affectedByRoad.size > 0) {
       for (const r of roads) {
-        if (!affectedRoadIds.has(r.roadId)) continue
+        if (!affectedByRoad.has(r.roadId)) continue
         const proj = projectToRoad(r.geom, xG, yG)
         if (!best || proj.distance < best.proj.distance) best = { roadId: r.roadId, proj }
       }
@@ -638,21 +1408,20 @@ function attachShapesToRoads(
       dynamic: 'yes',
       orientation: best.proj.t >= 0 ? '+' : '-',
     }
-    if (affectedRoadIds.size > 0) {
-      // The exporter emits one driving lane (-1) per road.
-      entry.validity = { fromLane: -1, toLane: -1 }
+    if (affectedByRoad.size > 0) {
+      entry.validity = laneIdRanges(affectedByRoad.get(best.roadId)!)
     }
     list.push(entry)
     roadSignals.set(best.roadId, list)
     signalIdByShape.set(tl.id, entry.id)
 
-    // A signal controlling several lanes spans several roads in the
-    // 1-lane-per-road model. The remaining affected roads get a standard
-    // <signalReference> pointing back at the signal so the validity links
-    // survive a round trip (and ODR consumers see the full coverage).
-    if (affectedRoadIds.size > 1) {
+    // A signal controlling lanes in several road bundles cannot carry a
+    // single <validity> (it cannot cross roads); the remaining affected roads
+    // get a standard <signalReference> pointing back at the signal with their
+    // own lane ranges, so the validity links survive a round trip.
+    if (affectedByRoad.size > 1) {
       for (const r of roads) {
-        if (r.roadId === best.roadId || !affectedRoadIds.has(r.roadId)) continue
+        if (r.roadId === best.roadId || !affectedByRoad.has(r.roadId)) continue
         const proj = projectToRoad(r.geom, xG, yG)
         const refs = roadSignalRefs.get(r.roadId) ?? []
         refs.push({
@@ -660,6 +1429,7 @@ function attachShapesToRoads(
           s: proj.s,
           t: proj.t,
           orientation: proj.t >= 0 ? '+' : '-',
+          validity: laneIdRanges(affectedByRoad.get(r.roadId)!),
         })
         roadSignalRefs.set(r.roadId, refs)
       }
@@ -717,15 +1487,11 @@ function attachShapesToRoads(
     // Regulatory layer: a crosswalk that names affected lanes attaches to the
     // nearest of those lanes' roads (no distance gate — the assignment is
     // explicit), mirroring the signal behavior above.
-    const affectedRoadIds = new Set<number>()
-    for (const laneShapeId of cw.props.affectedLaneIds ?? []) {
-      const rid = laneIdToRoadId.get(laneShapeId)
-      if (rid !== undefined) affectedRoadIds.add(rid)
-    }
+    const affectedByRoad = affectedLanesByRoad(cw.props.affectedLaneIds)
     let best: { roadId: number; proj: ReturnType<typeof projectToRoad> } | null = null
-    if (affectedRoadIds.size > 0) {
+    if (affectedByRoad.size > 0) {
       for (const r of roads) {
-        if (!affectedRoadIds.has(r.roadId)) continue
+        if (!affectedByRoad.has(r.roadId)) continue
         const proj = projectToRoad(r.geom, xG, yG)
         if (!best || proj.distance < best.proj.distance) best = { roadId: r.roadId, proj }
       }
@@ -755,13 +1521,19 @@ function attachShapesToRoads(
     // π/2 regardless of the user-drawn axis direction.
     void relativeHdg
     const crosswalkHdg = Math.PI / 2
-    // Regulatory links (affected roads + stop line polyline) ride along as
+    // Regulatory links (affected lanes + stop line polyline) ride along as
     // <userData> — OpenDRIVE's standard extension mechanism — so they survive
     // an .xodr round trip. Coordinates are ENU meters.
     const userData: { code: string; value: string }[] = []
-    if (affectedRoadIds.size > 0) {
-      const links: { affectedRoads: string[]; stopLine?: number[][] } = {
-        affectedRoads: [...affectedRoadIds].sort((a, b) => a - b).map(String),
+    if (affectedByRoad.size > 0) {
+      const affectedLanes: [string, string][] = []
+      for (const [rid, ids] of [...affectedByRoad.entries()].sort((a, b) => a[0] - b[0])) {
+        for (const oid of [...ids].sort((a, b) => a - b)) {
+          affectedLanes.push([String(rid), String(oid)])
+        }
+      }
+      const links: { affectedLanes: [string, string][]; stopLine?: number[][] } = {
+        affectedLanes,
       }
       if (cw.props.stopLineId) {
         const stopLs = shapeMap.get(cw.props.stopLineId) as unknown as LinestringShape | undefined
@@ -804,21 +1576,23 @@ function attachShapesToRoads(
     cy /= vertices.length
     const xG = pxToEnuX(cx)
     const yG = pxToEnuY(cy)
-    let best: { roadId: number; proj: ReturnType<typeof projectToRoad> } | null = null
-    let fallback: { roadId: number; proj: ReturnType<typeof projectToRoad> } | null = null
+    let best: { roadId: number; geom: BundleGeometry; proj: ReturnType<typeof projectToRoad> } | null = null
+    let fallback: { roadId: number; geom: BundleGeometry; proj: ReturnType<typeof projectToRoad> } | null = null
     for (const r of roads) {
       const proj = projectToRoad(r.geom, xG, yG)
       if (proj.clampedAtEnd) {
-        if (!fallback || proj.distance < fallback.proj.distance) fallback = { roadId: r.roadId, proj }
+        if (!fallback || proj.distance < fallback.proj.distance) {
+          fallback = { roadId: r.roadId, geom: r.geom, proj }
+        }
         continue
       }
-      if (!best || proj.distance < best.proj.distance) best = { roadId: r.roadId, proj }
+      if (!best || proj.distance < best.proj.distance) best = { roadId: r.roadId, geom: r.geom, proj }
     }
     if (!best) best = fallback
     if (!best || best.proj.distance > maxAttachDistanceMeter) continue
     const cosH = Math.cos(best.proj.hdg)
     const sinH = Math.sin(best.proj.hdg)
-    const samples = laneToGeom.get([...laneToGeom.keys()].find((k) => laneIdToRoadId.get(k) === best!.roadId)!)!.odrSamples
+    const samples = best.geom.samplePoses
     const anchorPoint = best.proj.clampedAtEnd && best.proj.s >= samples[samples.length - 1].s - 1e-6
       ? samples[samples.length - 1]
       : samples[0]
@@ -865,12 +1639,10 @@ function emitSignals(signals: SignalEntry[], references: SignalReferenceEntry[])
   lines.push(`    <signals>`)
   for (const s of signals) {
     const attrs = `id="${s.id}" s="${fmt(s.s)}" t="${fmt(s.t)}" zOffset="${fmt(s.zOffset)}" name="${escapeXml(s.name)}" dynamic="${s.dynamic}" orientation="${s.orientation}" type="${s.type}" subtype="${s.subtype}" country="OpenDRIVE" value="0" height="${fmt(s.height)}" width="${fmt(s.width)}"`
-    if (s.validity || s.stopLinePoints) {
+    if (s.validity?.length || s.stopLinePoints) {
       lines.push(`      <signal ${attrs}>`)
-      if (s.validity) {
-        lines.push(
-          `        <validity fromLane="${s.validity.fromLane}" toLane="${s.validity.toLane}"/>`
-        )
+      for (const v of s.validity ?? []) {
+        lines.push(`        <validity fromLane="${v.fromLane}" toLane="${v.toLane}"/>`)
       }
       if (s.stopLinePoints) {
         const json = JSON.stringify(
@@ -887,7 +1659,9 @@ function emitSignals(signals: SignalEntry[], references: SignalReferenceEntry[])
     lines.push(
       `      <signalReference s="${fmt(ref.s)}" t="${fmt(ref.t)}" id="${ref.id}" orientation="${ref.orientation}">`
     )
-    lines.push(`        <validity fromLane="-1" toLane="-1"/>`)
+    for (const v of ref.validity) {
+      lines.push(`        <validity fromLane="${v.fromLane}" toLane="${v.toLane}"/>`)
+    }
     lines.push(`      </signalReference>`)
   }
   lines.push(`    </signals>`)
@@ -940,38 +1714,89 @@ function emitObjects(objects: ObjectEntry[]): string {
 /**
  * Lane attributes that have no OpenDRIVE representation (speed_limit only
  * partially maps, one_way / turn_direction / location and custom tags not at
- * all) are stashed verbatim as JSON in <userData code="laneAttributes"> —
- * OpenDRIVE's standard extension mechanism — and restored by the importer.
+ * all) are stashed as JSON in <userData code="laneAttributes"> — OpenDRIVE's
+ * standard extension mechanism — keyed by the lane's ODR id so per-lane
+ * attributes stay separate in multi-lane roads, and restored by the importer.
  * `odr_*` meta attributes are excluded: they are regenerated on import.
  */
-function emitLaneAttributesUserData(lane: LaneShape): string | null {
-  const stash: Record<string, string> = {}
-  for (const [k, v] of Object.entries(lane.props.attributes ?? {})) {
-    if (k === 'type' || k.startsWith('odr_')) continue
-    if (v === undefined || v === null || v === '') continue
-    stash[k] = String(v)
-  }
-  if (Object.keys(stash).length === 0) return null
-  return `    <userData code="laneAttributes" value="${escapeXml(JSON.stringify(stash))}"/>`
+function emitLaneAttributesUserData(bundleLanes: LaneShape[]): string | null {
+  const byLane: Record<string, Record<string, string>> = {}
+  bundleLanes.forEach((lane, i) => {
+    const stash: Record<string, string> = {}
+    for (const [k, v] of Object.entries(lane.props.attributes ?? {})) {
+      if (k === 'type' || k.startsWith('odr_')) continue
+      if (v === undefined || v === null || v === '') continue
+      stash[k] = String(v)
+    }
+    if (Object.keys(stash).length > 0) byLane[String(-(i + 1))] = stash
+  })
+  if (Object.keys(byLane).length === 0) return null
+  return `    <userData code="laneAttributes" value="${escapeXml(JSON.stringify(byLane))}"/>`
 }
 
 /**
- * Right-of-way links (`yieldLaneIds`) have no canonical OpenDRIVE road-level
- * representation in this exporter (junction <priority> mapping is out of
- * scope), so the yielding lanes' road ids are stashed in
- * <userData code="yieldRoads"> and restored by the importer.
+ * Right-of-way links (`yieldLaneIds`) between two lanes that both feed a
+ * connecting road of the same junction are expressed as standard junction
+ * <priority> records (see planConnectivity); every remaining link is stashed
+ * in <userData code="yieldLanes"> as { ownLaneId: [[roadId, laneId], ...] }
+ * and restored by the importer.
  */
-function emitYieldRoadsUserData(lane: LaneShape, laneIdToRoadId: Map<string, number>): string | null {
-  const yieldRoadIds: number[] = []
-  for (const yieldShapeId of lane.props.yieldLaneIds ?? []) {
-    const rid = laneIdToRoadId.get(yieldShapeId)
-    if (rid !== undefined && !yieldRoadIds.includes(rid)) yieldRoadIds.push(rid)
-  }
-  if (yieldRoadIds.length === 0) return null
-  const json = JSON.stringify(yieldRoadIds.sort((a, b) => a - b).map(String))
-  return `    <userData code="yieldRoads" value="${escapeXml(json)}"/>`
+function emitYieldLanesUserData(
+  bundleLanes: LaneShape[],
+  laneIdToRoadId: Map<string, number>,
+  laneIdToOdrLaneId: Map<string, number>,
+  handledYieldPairs: Set<string>
+): string | null {
+  const byLane: Record<string, [string, string][]> = {}
+  bundleLanes.forEach((lane, i) => {
+    const targets: [string, string][] = []
+    for (const yieldShapeId of lane.props.yieldLaneIds ?? []) {
+      if (handledYieldPairs.has(`${lane.id}|${yieldShapeId}`)) continue
+      const rid = laneIdToRoadId.get(yieldShapeId)
+      const oid = laneIdToOdrLaneId.get(yieldShapeId)
+      if (rid === undefined || oid === undefined) continue
+      if (!targets.some(t => t[0] === String(rid) && t[1] === String(oid))) {
+        targets.push([String(rid), String(oid)])
+      }
+    }
+    if (targets.length > 0) {
+      targets.sort((a, b) => Number(a[0]) - Number(b[0]) || Number(a[1]) - Number(b[1]))
+      byLane[String(-(i + 1))] = targets
+    }
+  })
+  if (Object.keys(byLane).length === 0) return null
+  return `    <userData code="yieldLanes" value="${escapeXml(JSON.stringify(byLane))}"/>`
 }
 
+/**
+ * Zero-width-contact lane edges homed on this road (see
+ * ConnectivityPlan.hiddenLaneEdges), stashed as
+ * <userData code="hiddenLaneLinks"> records of
+ * { fr, fl, tr, tl } = from road id / from ODR lane id / to road id /
+ * to ODR lane id (from end -> to start in travel direction), and restored
+ * into next/prev by the importer.
+ */
+function emitHiddenLinksUserData(
+  bundleLanes: LaneShape[],
+  plan: ConnectivityPlan,
+  laneIdToRoadId: Map<string, number>,
+  laneIdToOdrLaneId: Map<string, number>
+): string | null {
+  const inBundle = new Set(bundleLanes.map(l => l.id))
+  const recs: { fr: number; fl: number; tr: number; tl: number }[] = []
+  for (const e of plan.hiddenLaneEdges) {
+    if (!inBundle.has(e.home)) continue
+    const fr = laneIdToRoadId.get(e.from)
+    const fl = laneIdToOdrLaneId.get(e.from)
+    const tr = laneIdToRoadId.get(e.to)
+    const tl = laneIdToOdrLaneId.get(e.to)
+    if (fr === undefined || fl === undefined || tr === undefined || tl === undefined) continue
+    recs.push({ fr, fl, tr, tl })
+  }
+  if (recs.length === 0) return null
+  recs.sort((a, b) => a.fr - b.fr || a.fl - b.fl || a.tr - b.tr || a.tl - b.tl)
+  return `    <userData code="hiddenLaneLinks" value="${escapeXml(JSON.stringify(recs))}"/>`
+}
 
 /**
  * Road length attribute. The plan-view geometries are emitted with rounded
@@ -979,72 +1804,399 @@ function emitYieldRoadsUserData(lane: LaneShape, laneIdToRoadId: Map<string, num
  * road length by ~1e-6, which strict consumers flag as "s too large". Use the
  * emitted extent plus a tiny pad so the length always covers the geometry.
  */
-function emittedRoadLength(geom: RoadGeometry): number {
+function emittedRoadLength(geom: BundleGeometry): number {
   let extent = geom.length
-  for (let i = 0; i < geom.odrSamples.length - 1; i++) {
-    const a = geom.odrSamples[i]
-    const b = geom.odrSamples[i + 1]
-    const segLen = Math.hypot(b.x - a.x, b.y - a.y)
-    if (segLen < 1e-9) continue
-    const end = parseFloat(fmt(a.s)) + parseFloat(fmt(segLen))
+  for (const g of geom.planView) {
+    const end = parseFloat(fmt(g.s)) + parseFloat(fmt(g.length))
     if (end > extent) extent = end
   }
   return extent + 1e-4
 }
 
 function emitRoad(
-  lane: LaneShape,
-  geom: RoadGeometry,
+  bundle: ExportBundle,
   roadId: number,
-  laneIdToRoadId: Map<string, number>,
-  junctionPlan: JunctionPlan,
+  plan: ConnectivityPlan,
   signals: SignalEntry[],
   signalRefs: SignalReferenceEntry[],
   objects: ObjectEntry[],
-  shapeMap: Map<string, BaseShape>
+  shapeMap: Map<string, BaseShape>,
+  laneIdToRoadId: Map<string, number>,
+  laneIdToOdrLaneId: Map<string, number>
 ): string {
-  const speed = lane.props.attributes?.speed_limit
-  const name = escapeXml(lane.props.attributes?.subtype || 'road')
-  const hasPrev = (lane.props.prev ?? []).some((id) => laneIdToRoadId.has(id))
-  const hasNext = (lane.props.next ?? []).some((id) => laneIdToRoadId.has(id))
-  const junctionAttr = junctionPlan.roadJunction.get(lane.id) ?? -1
+  const first = bundle.lanes[0]
+  const speed = bundle.lanes.find(l => l.props.attributes?.speed_limit)?.props.attributes?.speed_limit
+  const name = escapeXml(first.props.attributes?.subtype || 'road')
   const lines: string[] = []
+  // Mainline (bundle) roads never belong to a junction; junction membership
+  // is carried by the synthesized connecting roads (emitConnectingRoad).
   lines.push(
-    `  <road name="${name}" length="${fmt(emittedRoadLength(geom))}" id="${roadId}" junction="${junctionAttr}">`
+    `  <road name="${name}" length="${fmt(emittedRoadLength(bundle.geom))}" id="${roadId}" junction="-1">`
   )
-  lines.push(emitLink(lane, laneIdToRoadId, junctionPlan))
+  lines.push(emitLink(roadId, plan))
   if (speed) {
     lines.push(`    <type s="0" type="town">`)
     lines.push(`      <speed max="${escapeXml(speed)}" unit="km/h"/>`)
     lines.push(`    </type>`)
   }
-  lines.push(emitPlanView(geom))
+  lines.push(emitPlanView(bundle.geom))
   lines.push(`    <elevationProfile/>`)
   lines.push(`    <lateralProfile/>`)
-  lines.push(
-    emitLanes(
-      geom,
-      hasPrev,
-      hasNext,
-      odrLaneTypeFor(lane),
-      roadMarkTypeFor(shapeMap, lane.props.leftBoundaryId),
-      roadMarkTypeFor(shapeMap, lane.props.rightBoundaryId)
-    )
-  )
+  lines.push(emitLanes(bundle, plan, shapeMap))
   lines.push(emitObjects(objects))
   lines.push(emitSignals(signals, signalRefs))
-  const userData = emitLaneAttributesUserData(lane)
+  const userData = emitLaneAttributesUserData(bundle.lanes)
   if (userData) lines.push(userData)
-  const yieldUserData = emitYieldRoadsUserData(lane, laneIdToRoadId)
+  const yieldUserData = emitYieldLanesUserData(
+    bundle.lanes,
+    laneIdToRoadId,
+    laneIdToOdrLaneId,
+    plan.handledYieldPairs
+  )
   if (yieldUserData) lines.push(yieldUserData)
+  const hiddenLinksUserData = emitHiddenLinksUserData(
+    bundle.lanes,
+    plan,
+    laneIdToRoadId,
+    laneIdToOdrLaneId
+  )
+  if (hiddenLinksUserData) lines.push(hiddenLinksUserData)
   lines.push(`  </road>`)
   return lines.join('\n')
 }
 
+/** Empty point-override map (raw stored coordinates). */
+const NO_OVERRIDES: Map<string, Point2D> = new Map()
+
+export interface OpenDriveExportOptions {
+  /**
+   * Sidecar captured by the OpenDRIVE importer. When present (with road
+   * records), roads whose shapes were not edited since import are re-emitted
+   * verbatim from the original XML (carry-through) and only edited roads are
+   * regenerated. Without a sidecar the export is fully regenerated.
+   */
+  sidecar?: OdrSidecar | null
+}
+
+/** Carry-through plan: which original elements stay verbatim. */
+interface CarryPlan {
+  doc: OdrDocument
+  records: Record<string, OdrRoadRecord>
+  /** Recorded road ids whose state hash still matches (emitted verbatim). */
+  cleanRoadIds: Set<string>
+  /** Recorded road ids that must be regenerated. */
+  dirtyRecordedIds: Set<string>
+  /** Lane shape ids covered by verbatim roads (excluded from regeneration). */
+  verbatimLaneIds: Set<string>
+  /** Traffic light / crosswalk shape ids covered by verbatim roads. */
+  consumedShapeIds: Set<string>
+  headerText: string | null
+  verbatimRoads: OdrDocRoad[]
+  /** Original junction ids that must be regenerated (members changed). */
+  dirtyJunctionIds: Set<string>
+  verbatimJunctionTexts: string[]
+  verbatimControllerTexts: string[]
+  /** First id for regenerated roads / junctions (above every original id). */
+  idBase: number
+  signalIdBase: number
+  controllerIdBase: number
+}
+
+/**
+ * Decide which original roads can be re-emitted verbatim.
+ *
+ * A recorded road is clean when every lane shape it produced still exists and
+ * the state hash recomputed from the live shapes equals the import-time hash
+ * (geometry, attributes, connectivity, right-of-way, and the regulatory
+ * shapes touching the road — see odrCarryThrough.ts).
+ *
+ * Dirtiness then propagates until stable:
+ * - A junction is dirty when any member road (connecting roads, incoming /
+ *   outgoing roads, roads linking to the junction) is dirty or unrecorded.
+ *   A dirty junction regenerates together with its CONNECTING
+ *   (junction-stamped) roads, whose connection table it replaces; clean
+ *   incoming / outgoing roads stay verbatim and their junction link
+ *   elementIds are re-pointed at the regenerated junction on emission.
+ * - Regulatory shapes are atomic: a traffic light / crosswalk touching a
+ *   dirty road dirties every road it touches, so its signal + references are
+ *   either all verbatim or all regenerated.
+ *
+ * Roads referencing unrecorded elements (e.g. a selective import) are never
+ * carried verbatim, so verbatim output cannot dangle into missing roads.
+ */
+function planCarryThrough(
+  sidecar: OdrSidecar | null | undefined,
+  shapeMap: Map<string, BaseShape>,
+  trafficLights: TrafficLightShape[],
+  crosswalks: CrosswalkShape[]
+): CarryPlan | null {
+  const records = sidecar?.roadRecords
+  if (!sidecar || !records || Object.keys(records).length === 0) return null
+  const doc = extractOdrDocument(sidecar.rawXml)
+  if (!doc) return null
+  const docRoadById = new Map(doc.roads.map(r => [r.id, r]))
+  const docJunctionById = new Map(doc.junctions.map(j => [j.id, j]))
+
+  // laneShapeId -> recorded road id (over every record).
+  const laneRoadOf = new Map<string, string>()
+  for (const [rid, rec] of Object.entries(records)) {
+    for (const lid of rec.laneShapeIds) laneRoadOf.set(lid, rid)
+  }
+
+  const stopLinePts = (lsId: string | null | undefined): Point2D[] | null => {
+    if (!lsId) return null
+    const ls = shapeMap.get(lsId) as unknown as LinestringShape | undefined
+    if (!ls) return null
+    const pts = collectPoints(shapeMap, ls.props.pointIds, false, NO_OVERRIDES)
+    return pts.length >= 2 ? pts : null
+  }
+
+  // Regulatory shapes: state + the set of recorded roads each one touches
+  // (mirrors the importer's record builder).
+  const regStatesByRoad = new Map<string, CarryRegulatoryState[]>()
+  const regShapes: { shapeId: string; touching: Set<string> }[] = []
+  const addRegState = (
+    state: CarryRegulatoryState,
+    affected: readonly string[],
+    own: string | undefined
+  ): void => {
+    const touching = new Set<string>()
+    if (own && records[own]) touching.add(own)
+    for (const lid of affected) {
+      const rid = laneRoadOf.get(lid)
+      if (rid) touching.add(rid)
+    }
+    for (const rid of touching) {
+      const list = regStatesByRoad.get(rid) ?? []
+      list.push(state)
+      regStatesByRoad.set(rid, list)
+    }
+    regShapes.push({ shapeId: state.shapeId, touching })
+  }
+  for (const tl of trafficLights) {
+    addRegState(
+      {
+        kind: 'traffic_light',
+        shapeId: tl.id,
+        numbers: [tl.x, tl.y, tl.props.w, tl.props.h, tl.rotation || 0],
+        attributes: tl.props.attributes ?? {},
+        affectedLaneIds: tl.props.affectedLaneIds ?? [],
+        stopLinePts: stopLinePts(tl.props.stopLineId),
+        controllerId: tl.props.controllerId ?? '',
+      },
+      tl.props.affectedLaneIds ?? [],
+      tl.props.attributes?.odr_road_id
+    )
+  }
+  for (const cw of crosswalks) {
+    addRegState(
+      {
+        kind: 'crosswalk',
+        shapeId: cw.id,
+        numbers: [
+          cw.x,
+          cw.y,
+          cw.props.startX,
+          cw.props.startY,
+          cw.props.endX,
+          cw.props.endY,
+          cw.props.crosswalkWidth,
+          cw.rotation || 0,
+        ],
+        attributes: cw.props.attributes ?? {},
+        affectedLaneIds: cw.props.affectedLaneIds ?? [],
+        stopLinePts: stopLinePts(cw.props.stopLineId),
+        controllerId: '',
+      },
+      cw.props.affectedLaneIds ?? [],
+      cw.props.attributes?.odr_road_id
+    )
+  }
+
+  // Export-side lane states (null when any recorded lane shape is missing).
+  const exportLaneStates = (rec: OdrRoadRecord): CarryLaneState[] | null => {
+    const states: CarryLaneState[] = []
+    for (const lid of rec.laneShapeIds) {
+      const shape = shapeMap.get(lid)
+      if (!shape || shape.type !== 'lane') return null
+      const lane = shape as unknown as LaneShape
+      states.push({
+        leftPts: boundaryPointsOf(shapeMap, lane.props.leftBoundaryId, lane.props.invertLeft, NO_OVERRIDES),
+        rightPts: boundaryPointsOf(shapeMap, lane.props.rightBoundaryId, lane.props.invertRight, NO_OVERRIDES),
+        attributes: lane.props.attributes ?? {},
+        next: lane.props.next ?? [],
+        prev: lane.props.prev ?? [],
+        yieldLaneIds: lane.props.yieldLaneIds ?? [],
+      })
+    }
+    return states
+  }
+
+  // Seed dirtiness: hash mismatch, missing shapes, or references that leave
+  // the recorded set.
+  const dirty = new Set<string>()
+  for (const [rid, rec] of Object.entries(records)) {
+    const docRoad = docRoadById.get(rid)
+    if (!docRoad) {
+      dirty.add(rid)
+      continue
+    }
+    if (
+      docRoad.linkRoadRefs.some(ref => !records[ref]) ||
+      docRoad.linkJunctionRefs.some(ref => !docJunctionById.has(ref))
+    ) {
+      dirty.add(rid)
+      continue
+    }
+    const laneStates = exportLaneStates(rec)
+    if (!laneStates || hashRoadState(laneStates, regStatesByRoad.get(rid) ?? []) !== rec.stateHash) {
+      dirty.add(rid)
+    }
+  }
+
+  // Junction membership: connection roads, junction-stamped roads (plus
+  // their link targets — the maneuver's incoming/outgoing roads), and roads
+  // whose link references the junction.
+  const members = new Map<string, Set<string>>()
+  const junctionStamped = new Map<string, Set<string>>()
+  for (const j of doc.junctions) {
+    members.set(j.id, new Set(j.memberRoadIds))
+    junctionStamped.set(j.id, new Set())
+  }
+  for (const r of doc.roads) {
+    if (r.junction !== '-1') {
+      const set = members.get(r.junction)
+      if (set) {
+        set.add(r.id)
+        for (const ref of r.linkRoadRefs) set.add(ref)
+        junctionStamped.get(r.junction)!.add(r.id)
+      }
+    }
+    for (const jref of r.linkJunctionRefs) members.get(jref)?.add(r.id)
+  }
+
+  // Propagate to a fixpoint. A dirty junction drags only its connecting
+  // (junction-stamped) roads into regeneration — clean incoming / outgoing
+  // roads keep their verbatim text (with the junction link id rewritten) —
+  // so a single edited road regenerates its own junctions, not the whole
+  // junction graph. Regulatory shapes are atomic across the roads they touch.
+  const dirtyJunctionIds = new Set<string>()
+  let changed = true
+  while (changed) {
+    changed = false
+    for (const [jid, memberSet] of members) {
+      let bad = false
+      for (const m of memberSet) {
+        if (!records[m] || dirty.has(m)) {
+          bad = true
+          break
+        }
+      }
+      if (!bad) continue
+      if (!dirtyJunctionIds.has(jid)) {
+        dirtyJunctionIds.add(jid)
+        changed = true
+      }
+      for (const m of junctionStamped.get(jid) ?? []) {
+        if (records[m] && !dirty.has(m)) {
+          dirty.add(m)
+          changed = true
+        }
+      }
+    }
+    for (const reg of regShapes) {
+      let bad = false
+      for (const rid of reg.touching) {
+        if (dirty.has(rid)) {
+          bad = true
+          break
+        }
+      }
+      if (!bad) continue
+      for (const rid of reg.touching) {
+        if (!dirty.has(rid)) {
+          dirty.add(rid)
+          changed = true
+        }
+      }
+    }
+  }
+
+  const cleanRoadIds = new Set<string>()
+  for (const rid of Object.keys(records)) {
+    if (!dirty.has(rid) && docRoadById.has(rid)) cleanRoadIds.add(rid)
+  }
+
+  const verbatimLaneIds = new Set<string>()
+  for (const rid of cleanRoadIds) {
+    for (const lid of records[rid].laneShapeIds) verbatimLaneIds.add(lid)
+  }
+
+  const consumedShapeIds = new Set<string>()
+  for (const reg of regShapes) {
+    if (reg.touching.size === 0) continue
+    let allClean = true
+    for (const rid of reg.touching) {
+      if (!cleanRoadIds.has(rid)) {
+        allClean = false
+        break
+      }
+    }
+    if (allClean) consumedShapeIds.add(reg.shapeId)
+  }
+
+  const verbatimRoads: OdrDocRoad[] = []
+  for (const r of doc.roads) {
+    if (cleanRoadIds.has(r.id)) verbatimRoads.push(r)
+  }
+
+  const verbatimJunctionTexts: string[] = []
+  for (const j of doc.junctions) {
+    if (!dirtyJunctionIds.has(j.id)) verbatimJunctionTexts.push(j.text)
+  }
+
+  // A controller stays verbatim when every signal it controls is defined in
+  // a verbatim road.
+  const signalRoadOf = new Map<string, string>()
+  for (const r of doc.roads) {
+    for (const sid of r.signalIds) signalRoadOf.set(sid, r.id)
+  }
+  const verbatimControllerTexts: string[] = []
+  for (const c of doc.controllers) {
+    const ok =
+      c.signalIds.length > 0 &&
+      c.signalIds.every(sid => {
+        const rid = signalRoadOf.get(sid)
+        return rid !== undefined && cleanRoadIds.has(rid)
+      })
+    if (ok) verbatimControllerTexts.push(c.text)
+  }
+
+  return {
+    doc,
+    records,
+    cleanRoadIds,
+    dirtyRecordedIds: dirty,
+    verbatimLaneIds,
+    consumedShapeIds,
+    headerText: doc.headerText,
+    verbatimRoads,
+    dirtyJunctionIds,
+    verbatimJunctionTexts,
+    verbatimControllerTexts,
+    idBase: Math.max(doc.maxNumericElementId, 0) + 1,
+    signalIdBase: Math.max(doc.maxNumericSignalId, 0) + 1,
+    controllerIdBase: Math.max(doc.maxNumericControllerId, 0) + 1,
+  }
+}
+
 /**
  * Build an OpenDRIVE 1.8 XML document from a snapshot.
+ *
+ * With `options.sidecar` (captured by the OpenDRIVE importer), unedited
+ * roads are re-emitted verbatim from the original XML; see planCarryThrough.
  */
-export function exportToOpenDrive(snapshot: DrawtonomySnapshot): string {
+export function exportToOpenDrive(snapshot: DrawtonomySnapshot, options: OpenDriveExportOptions = {}): string {
   const shapes = snapshot.shapes
   const shapeMap = buildShapeMap(shapes)
   const lanes: LaneShape[] = []
@@ -1066,9 +2218,16 @@ export function exportToOpenDrive(snapshot: DrawtonomySnapshot): string {
     }
   }
 
-  // Road ids are assigned after geometry construction so degenerate lanes
-  // (zero-length centerlines) neither emit empty roads nor occupy link ids.
-  const laneIdToRoadId = new Map<string, number>()
+  // Carry-through: with an importer sidecar, unedited original roads are
+  // re-emitted verbatim and excluded from regeneration.
+  const carry = planCarryThrough(options.sidecar, shapeMap, trafficLights, crosswalks)
+  const regenLanes = carry ? lanes.filter(l => !carry.verbatimLaneIds.has(l.id)) : lanes
+  const regenTrafficLights = carry
+    ? trafficLights.filter(t => !carry.consumedShapeIds.has(t.id))
+    : trafficLights
+  const regenCrosswalks = carry
+    ? crosswalks.filter(c => !carry.consumedShapeIds.has(c.id))
+    : crosswalks
 
   const dateStr = new Date().toISOString()
   const bbox = computeEnuBoundingBox(shapeMap)
@@ -1076,58 +2235,304 @@ export function exportToOpenDrive(snapshot: DrawtonomySnapshot): string {
   const lines: string[] = []
   lines.push(`<?xml version="1.0" encoding="UTF-8"?>`)
   lines.push(`<OpenDRIVE>`)
-  // OpenDRIVE 1.8 expects <geoReference> inside <header>. We always emit one —
-  // tmerc-at-origin when snapshot.origin is set, WGS84 longlat as a fallback —
-  // so downstream tools (esmini, RoadRunner, asam-qc-opendrive) see a defined
-  // coordinate reference system rather than nothing. The N/S/E/W attributes
-  // are populated from the actual point cloud so the header bbox reflects the
-  // map extent in ENU metres.
-  lines.push(
-    `  <header revMajor="1" revMinor="8" name="drawtonomy" version="1.0" date="${dateStr}" ` +
-      `north="${fmt(bbox.north)}" south="${fmt(bbox.south)}" east="${fmt(bbox.east)}" west="${fmt(bbox.west)}" vendor="drawtonomy">`
-  )
-  lines.push(`    <geoReference><![CDATA[${escapeCdata(geoRefProj)}]]></geoReference>`)
-  lines.push(`  </header>`)
+  if (carry?.headerText) {
+    // Carry-through keeps the original header (geoReference, bbox, vendor)
+    // so an unedited round trip preserves the source coordinate frame.
+    lines.push(carry.headerText)
+  } else {
+    // OpenDRIVE 1.8 expects <geoReference> inside <header>. We always emit one —
+    // tmerc-at-origin when snapshot.origin is set, WGS84 longlat as a fallback —
+    // so downstream tools (esmini, RoadRunner, asam-qc-opendrive) see a defined
+    // coordinate reference system rather than nothing. The N/S/E/W attributes
+    // are populated from the actual point cloud so the header bbox reflects the
+    // map extent in ENU metres.
+    lines.push(
+      `  <header revMajor="1" revMinor="8" name="drawtonomy" version="1.0" date="${dateStr}" ` +
+        `north="${fmt(bbox.north)}" south="${fmt(bbox.south)}" east="${fmt(bbox.east)}" west="${fmt(bbox.west)}" vendor="drawtonomy">`
+    )
+    lines.push(`    <geoReference><![CDATA[${escapeCdata(geoRefProj)}]]></geoReference>`)
+    lines.push(`  </header>`)
+  }
 
   const pointOverrides = buildBoundaryAlignmentOverrides(shapeMap, lanes)
 
-  const laneToGeom = new Map<string, RoadGeometry>()
-  for (const lane of lanes) {
-    const geom = buildRoadGeometry(shapeMap, lane, pointOverrides)
-    if (geom && geom.length >= 0.01 && geom.odrSamples.length >= 2) {
-      laneToGeom.set(lane.id, geom)
+  // Group laterally adjacent lanes into road bundles and build their
+  // geometry. Degenerate bundles (zero-length reference lines) are dropped;
+  // a multi-lane bundle whose geometry cannot be built (broken boundary
+  // references) degrades to per-lane bundles so one bad lane does not drop
+  // its neighbours.
+  const exportBundles: ExportBundle[] = []
+  for (const bundleLanes of detectBundles(regenLanes)) {
+    const geom = buildBundleGeometry(shapeMap, bundleLanes, pointOverrides)
+    if (geom && geom.length >= 0.01) {
+      exportBundles.push({ lanes: bundleLanes, geom })
+    } else if (bundleLanes.length > 1) {
+      for (const lane of bundleLanes) {
+        const g = buildBundleGeometry(shapeMap, [lane], pointOverrides)
+        if (g && g.length >= 0.01) exportBundles.push({ lanes: [lane], geom: g })
+      }
     }
   }
-  let nextRoadId = 1
-  for (const lane of lanes) {
-    if (laneToGeom.has(lane.id)) laneIdToRoadId.set(lane.id, nextRoadId++)
+
+  // Stable road id assignment: bundles ordered by their first lane's position
+  // in the snapshot. Lane ids count -1, -2, ... left→right within a bundle.
+  // Carry-through: a regenerated bundle covering exactly the lane set of a
+  // dirty original road keeps that road's id, so links inside verbatim
+  // neighbours stay valid without rewriting; other bundles take fresh ids
+  // above every original id.
+  const laneOrder = new Map<string, number>()
+  lanes.forEach((lane, i) => laneOrder.set(lane.id, i))
+  exportBundles.sort(
+    (a, b) => Math.min(...a.lanes.map(l => laneOrder.get(l.id)!)) - Math.min(...b.lanes.map(l => laneOrder.get(l.id)!))
+  )
+  const reuseKey = (ids: readonly string[]): string => [...ids].sort().join('\n')
+  const reusableRoadIds = new Map<string, number>()
+  if (carry) {
+    for (const rid of carry.dirtyRecordedIds) {
+      const rec = carry.records[rid]
+      if (!rec || rec.laneShapeIds.length === 0 || !/^\d+$/.test(rid)) continue
+      reusableRoadIds.set(reuseKey(rec.laneShapeIds), parseInt(rid, 10))
+    }
   }
-  const junctionPlan = planJunctions(lanes, laneIdToRoadId, nextRoadId)
+  const laneIdToRoadId = new Map<string, number>()
+  const laneIdToOdrLaneId = new Map<string, number>()
+  const roadIdByBundle = new Map<ExportBundle, number>()
+  let nextRoadId = carry ? carry.idBase : 1
+  for (const bundle of exportBundles) {
+    const key = reuseKey(bundle.lanes.map(l => l.id))
+    const reused = reusableRoadIds.get(key)
+    if (reused !== undefined) reusableRoadIds.delete(key)
+    const roadId = reused ?? nextRoadId++
+    roadIdByBundle.set(bundle, roadId)
+    bundle.lanes.forEach((lane, i) => {
+      laneIdToRoadId.set(lane.id, roadId)
+      laneIdToOdrLaneId.set(lane.id, -(i + 1))
+    })
+  }
+
+  // Carry-through: lanes of verbatim roads join the connectivity id maps as
+  // external endpoints, so regenerated roads link to / from them.
+  const externalLanes = new Map<string, LaneShape>()
+  if (carry) {
+    for (const rid of carry.cleanRoadIds) {
+      if (!/^\d+$/.test(rid)) continue
+      for (const lid of carry.records[rid].laneShapeIds) {
+        const shape = shapeMap.get(lid) as unknown as LaneShape | undefined
+        if (!shape) continue
+        const odrLaneId = parseInt(shape.props.attributes?.odr_lane_id ?? '', 10)
+        if (!Number.isFinite(odrLaneId)) continue
+        laneIdToRoadId.set(lid, parseInt(rid, 10))
+        laneIdToOdrLaneId.set(lid, odrLaneId)
+        externalLanes.set(lid, shape)
+      }
+    }
+  }
+
+  // Geometry seed for synthesized connecting roads: bundle lanes read it off
+  // their fitted bundle geometry; external (verbatim) lanes off their drawn
+  // boundary endpoints.
+  const laneLocation = new Map<string, { bundle: ExportBundle; index: number }>()
+  for (const bundle of exportBundles) {
+    bundle.lanes.forEach((lane, index) => laneLocation.set(lane.id, { bundle, index }))
+  }
+  const connectingSourceFor = (laneShapeId: string): ConnectingSource | null => {
+    const loc = laneLocation.get(laneShapeId)
+    if (loc) {
+      const geom = loc.bundle.geom
+      const lastGeom = geom.planView[geom.planView.length - 1]
+      const endPose = evalGeometry(lastGeom, lastGeom.length)
+      // Lane boundaries sit toward -t (right of the reference direction): the
+      // inner boundary of lane -(i+1) is offset by the widths of lanes 0..i-1.
+      const lastIdx = geom.samplePoses.length - 1
+      let offset = 0
+      for (let m = 0; m < loc.index; m++) offset += geom.laneWidths[m][lastIdx]
+      return {
+        x: endPose.x + Math.sin(endPose.hdg) * offset,
+        y: endPose.y - Math.cos(endPose.hdg) * offset,
+        hdg: endPose.hdg,
+        width: geom.laneWidths[loc.index][lastIdx],
+        laneType: odrLaneTypeFor(loc.bundle.lanes[loc.index]),
+      }
+    }
+    const lane = externalLanes.get(laneShapeId)
+    if (!lane) return null
+    const left = boundaryPointsOf(shapeMap, lane.props.leftBoundaryId, lane.props.invertLeft, NO_OVERRIDES)
+    const right = boundaryPointsOf(shapeMap, lane.props.rightBoundaryId, lane.props.invertRight, NO_OVERRIDES)
+    if (!left || !right) return null
+    const ex = pxToEnuX(left[left.length - 1].x)
+    const ey = pxToEnuY(left[left.length - 1].y)
+    const px = pxToEnuX(left[left.length - 2].x)
+    const py = pxToEnuY(left[left.length - 2].y)
+    const rx = pxToEnuX(right[right.length - 1].x)
+    const ry = pxToEnuY(right[right.length - 1].y)
+    return {
+      x: ex,
+      y: ey,
+      hdg: Math.atan2(ey - py, ex - px),
+      width: Math.hypot(rx - ex, ry - ey),
+      laneType: odrLaneTypeFor(lane),
+    }
+  }
+
+  // Travel heading / width of a connecting road's target lane at its start,
+  // for blending the stub onto the outgoing road (see ConnectingTarget).
+  const connectingTargetFor = (laneShapeId: string): ConnectingTarget | null => {
+    const loc = laneLocation.get(laneShapeId)
+    if (loc) {
+      const geom = loc.bundle.geom
+      if (geom.samplePoses.length === 0) return null
+      const pose = geom.samplePoses[0]
+      // Lane boundaries sit toward -t (right of the reference direction).
+      let offset = 0
+      for (let m = 0; m < loc.index; m++) offset += geom.laneWidths[m][0]
+      return {
+        x: pose.x + Math.sin(pose.hdg) * offset,
+        y: pose.y - Math.cos(pose.hdg) * offset,
+        hdg: pose.hdg,
+        width: geom.laneWidths[loc.index][0],
+      }
+    }
+    const lane = externalLanes.get(laneShapeId)
+    if (!lane) return null
+    const left = boundaryPointsOf(shapeMap, lane.props.leftBoundaryId, lane.props.invertLeft, NO_OVERRIDES)
+    const right = boundaryPointsOf(shapeMap, lane.props.rightBoundaryId, lane.props.invertRight, NO_OVERRIDES)
+    if (!left || !right || left.length < 2 || right.length < 1) return null
+    const ax = pxToEnuX(left[0].x)
+    const ay = pxToEnuY(left[0].y)
+    const bx = pxToEnuX(left[1].x)
+    const by = pxToEnuY(left[1].y)
+    const rx = pxToEnuX(right[0].x)
+    const ry = pxToEnuY(right[0].y)
+    return {
+      x: ax,
+      y: ay,
+      hdg: Math.atan2(by - ay, bx - ax),
+      width: Math.hypot(rx - ax, ry - ay),
+    }
+  }
+
+  // Full lane width at a linked contact, for the zero-width link rules:
+  // bundle lanes read their fitted width samples, external (verbatim) lanes
+  // measure their drawn boundary endpoints.
+  const contactWidth = (laneShapeId: string, contact: 'start' | 'end'): number | null => {
+    const loc = laneLocation.get(laneShapeId)
+    if (loc) {
+      const widths = loc.bundle.geom.laneWidths[loc.index]
+      if (!widths || widths.length === 0) return null
+      return contact === 'start' ? widths[0] : widths[widths.length - 1]
+    }
+    const lane = externalLanes.get(laneShapeId)
+    if (!lane) return null
+    const left = boundaryPointsOf(shapeMap, lane.props.leftBoundaryId, lane.props.invertLeft, NO_OVERRIDES)
+    const right = boundaryPointsOf(shapeMap, lane.props.rightBoundaryId, lane.props.invertRight, NO_OVERRIDES)
+    if (!left || !right || left.length === 0 || right.length === 0) return null
+    const li = contact === 'start' ? left[0] : left[left.length - 1]
+    const ri = contact === 'start' ? right[0] : right[right.length - 1]
+    return pxToMeter(Math.hypot(ri.x - li.x, ri.y - li.y))
+  }
+
+  const plan = planConnectivity(
+    exportBundles,
+    laneIdToRoadId,
+    laneIdToOdrLaneId,
+    nextRoadId,
+    connectingSourceFor,
+    connectingTargetFor,
+    contactWidth,
+    externalLanes
+  )
+  const roads = exportBundles.map(b => ({ roadId: roadIdByBundle.get(b)!, geom: b.geom }))
   const { roadSignals, roadObjects, roadSignalRefs, signalIdByShape } = attachShapesToRoads(
     shapeMap,
-    trafficLights,
-    crosswalks,
+    regenTrafficLights,
+    regenCrosswalks,
     polygons,
-    laneToGeom,
-    laneIdToRoadId
+    roads,
+    laneIdToRoadId,
+    laneIdToOdrLaneId,
+    undefined,
+    carry?.signalIdBase
   )
 
-  for (const lane of lanes) {
-    const geom = laneToGeom.get(lane.id)
-    if (!geom) continue
-    const roadId = laneIdToRoadId.get(lane.id)!
-    const signals = roadSignals.get(roadId) ?? []
-    const signalRefs = roadSignalRefs.get(roadId) ?? []
-    const objects = roadObjects.get(roadId) ?? []
+  // Verbatim road blocks first (original document order). Two minimal
+  // rewrites keep their links valid; nothing else is touched:
+  // - road links to a dirty road whose lanes regenerated into exactly one
+  //   bundle under a different id are re-pointed at that bundle;
+  // - junction links to a dirty (regenerated) junction are re-pointed at the
+  //   synthesized junction this road participates in (junction-routed pairs
+  //   sharing a road always merge, so the target is unique per road).
+  if (carry) {
+    const rewriteMap = new Map<string, string>()
+    const bundleRoadOfLane = new Map<string, number>()
+    for (const bundle of exportBundles) {
+      const rid = roadIdByBundle.get(bundle)!
+      for (const l of bundle.lanes) bundleRoadOfLane.set(l.id, rid)
+    }
+    for (const rid of carry.dirtyRecordedIds) {
+      const rec = carry.records[rid]
+      if (!rec) continue
+      const newIds = new Set<number>()
+      for (const lid of rec.laneShapeIds) {
+        const nid = bundleRoadOfLane.get(lid)
+        if (nid !== undefined) newIds.add(nid)
+      }
+      if (newIds.size === 1) {
+        const nid = String([...newIds][0])
+        if (nid !== rid) rewriteMap.set(rid, nid)
+      }
+    }
+    const newJunctionOfRoad = new Map<number, number>()
+    for (const spec of plan.connectingRoads) {
+      newJunctionOfRoad.set(spec.incomingRoadId, spec.junctionId)
+      newJunctionOfRoad.set(spec.outgoingRoadId, spec.junctionId)
+    }
+    for (const r of carry.verbatimRoads) {
+      let junctionMap: Map<string, string> | undefined
+      for (const jref of r.linkJunctionRefs) {
+        if (!carry.dirtyJunctionIds.has(jref)) continue
+        const exportedId = /^\d+$/.test(r.id) ? parseInt(r.id, 10) : NaN
+        const replacement = newJunctionOfRoad.get(exportedId)
+        if (replacement !== undefined) {
+          junctionMap = junctionMap ?? new Map()
+          junctionMap.set(jref, String(replacement))
+        }
+      }
+      lines.push(rewriteRoadLinkTargets(r.text, rewriteMap, junctionMap ?? new Map()))
+    }
+  }
+
+  for (const bundle of exportBundles) {
+    const roadId = roadIdByBundle.get(bundle)!
     lines.push(
-      emitRoad(lane, geom, roadId, laneIdToRoadId, junctionPlan, signals, signalRefs, objects, shapeMap)
+      emitRoad(
+        bundle,
+        roadId,
+        plan,
+        roadSignals.get(roadId) ?? [],
+        roadSignalRefs.get(roadId) ?? [],
+        roadObjects.get(roadId) ?? [],
+        shapeMap,
+        laneIdToRoadId,
+        laneIdToOdrLaneId
+      )
     )
+  }
+
+  // Synthesized junction connecting roads (standard incoming -> connecting ->
+  // outgoing structure; see planConnectivity).
+  for (const spec of plan.connectingRoads) {
+    lines.push(emitConnectingRoad(spec))
+  }
+
+  // Verbatim controllers (every controlled signal lives in a verbatim road).
+  if (carry) {
+    for (const text of carry.verbatimControllerTexts) lines.push(text)
   }
 
   // Signal groups: traffic lights sharing a controllerId (one intersection)
   // become a <controller> listing their emitted signals as <control> records.
   const controllerGroups = new Map<string, number[]>()
-  for (const tl of trafficLights) {
+  for (const tl of regenTrafficLights) {
     const groupId = tl.props.controllerId
     if (!groupId) continue
     const signalId = signalIdByShape.get(tl.id)
@@ -1136,7 +2541,7 @@ export function exportToOpenDrive(snapshot: DrawtonomySnapshot): string {
     group.push(signalId)
     controllerGroups.set(groupId, group)
   }
-  let controllerIdCounter = 1
+  let controllerIdCounter = carry ? carry.controllerIdBase : 1
   for (const [groupId, signalIds] of controllerGroups) {
     lines.push(`  <controller id="${controllerIdCounter++}" name="${escapeXml(groupId)}" sequence="0">`)
     for (const signalId of signalIds) {
@@ -1145,16 +2550,26 @@ export function exportToOpenDrive(snapshot: DrawtonomySnapshot): string {
     lines.push(`  </controller>`)
   }
 
-  // Synthesized junctions for branch / merge connectivity (see planJunctions).
-  for (const junction of junctionPlan.junctions) {
+  // Verbatim junctions (all member roads verbatim).
+  if (carry) {
+    for (const text of carry.verbatimJunctionTexts) lines.push(text)
+  }
+
+  // Synthesized junctions for branch / merge connectivity (see planConnectivity).
+  for (const junction of plan.junctions) {
     lines.push(`  <junction id="${junction.id}" name="junction${junction.id}">`)
     junction.connections.forEach((conn, idx) => {
       lines.push(
         `    <connection id="${idx}" incomingRoad="${conn.incoming}" connectingRoad="${conn.connecting}" contactPoint="start">`
       )
-      lines.push(`      <laneLink from="-1" to="-1"/>`)
+      for (const ll of conn.laneLinks) {
+        lines.push(`      <laneLink from="${ll.from}" to="${ll.to}"/>`)
+      }
       lines.push(`    </connection>`)
     })
+    for (const pr of junction.priorities) {
+      lines.push(`    <priority high="${pr.high}" low="${pr.low}"/>`)
+    }
     lines.push(`  </junction>`)
   }
 

--- a/packages/drawtonomy-sdk/src/exporter/opendriveParser.ts
+++ b/packages/drawtonomy-sdk/src/exporter/opendriveParser.ts
@@ -8,7 +8,7 @@
 //                         geometries (line/arc/spiral/paramPoly3/poly3),
 //                         <lanes> (laneOffset + laneSections with widths and
 //                         road marks), minimal <signals>/<objects> records
-//   - <junction>        : connections with laneLinks
+//   - <junction>        : connections with laneLinks, priorities
 //
 // Like the Lanelet2 OSM parser, this is hand-written so it works in a plain
 // Node runtime without a DOM. When a global `DOMParser` is available (browser
@@ -198,10 +198,19 @@ export interface OdrJunctionConnection {
   laneLinks: OdrJunctionLaneLink[]
 }
 
+/** <priority> record: right-of-way between two connecting roads of a junction. */
+export interface OdrJunctionPriority {
+  /** Connecting road id with priority. */
+  high: string
+  /** Connecting road id that yields. */
+  low: string
+}
+
 export interface OdrJunction {
   id: string
   name: string
   connections: OdrJunctionConnection[]
+  priorities: OdrJunctionPriority[]
 }
 
 export interface OdrMap {
@@ -638,7 +647,10 @@ function parseJunction(el: XmlNode): OdrJunction {
       })),
     }
   })
-  return { id, name: el.attrs.name ?? '', connections }
+  const priorities = children(el, 'priority')
+    .map(pr => ({ high: pr.attrs.high ?? '', low: pr.attrs.low ?? '' }))
+    .filter(pr => pr.high !== '' && pr.low !== '')
+  return { id, name: el.attrs.name ?? '', connections, priorities }
 }
 
 /** Parse an OpenDRIVE XML string into the intermediate `OdrMap` model. */

--- a/packages/drawtonomy-sdk/src/exporter/units.ts
+++ b/packages/drawtonomy-sdk/src/exporter/units.ts
@@ -31,6 +31,17 @@ export function fmt(n: number): string {
   return n.toFixed(6)
 }
 
+/**
+ * Full-precision number formatting (shortest round-trip representation) for
+ * attributes whose magnitude can sit far below the 6-decimal grid, e.g. arc
+ * curvatures and paramPoly3 cubic coefficients. xsd:double accepts both plain
+ * and exponent notation.
+ */
+export function fmtPrecise(n: number): string {
+  if (!Number.isFinite(n)) return '0'
+  return String(n)
+}
+
 /** XML attribute / text escaping. */
 export function escapeXml(s: string): string {
   return s


### PR DESCRIPTION
## Summary

Reworks the OpenDRIVE exporter from a one-road-per-lane writer into a standards-aligned road-network writer, verified end to end with ASAM qc-opendrive and esmini 3.3.0.

### Road bundling
Laterally adjacent lanes (detected through shared boundary linestrings) are emitted as one multi-lane `<road>`: the reference line follows the leftmost boundary, lanes are numbered -1..-n with piecewise-linear widths, and signals get real `<validity fromLane toLane>` ranges. Road counts drop to 1/2–1/7 of the previous output, and left/right adjacency now survives an OpenDRIVE round-trip structurally (no longer relying on import-side deduplication).

### Standard junction structure
Branch/merge connectivity is carried by short synthesized connecting roads with complete predecessor/successor links; mainline roads return to `junction="-1"`. Right-of-way links become `<junction><priority>` records. The importer bridges the synthesized stubs, keeping lane counts and edge sets round-trip stable. Structural violations on a sample-map suite went from 84 to 0, and the previous esmini "connecting road lacks successor" warnings are gone.

### Analytic plan-view geometry
A curvature-classifying fitter (derived from first principles: discrete heading estimation, greedy longest-span search with line→arc→paramPoly3 preference, C1 chaining, chord-line fallback) replaces raw polyline decomposition. On a spiral-heavy sample, max boundary deviation drops from 27.2 m to 0.073 m while the file shrinks 10x and geometry-record counts drop ~9x; straight roads still emit a single `<line/>`.

### Carry-through export
`exportToOpenDrive(snapshot, { sidecar })` re-emits unedited roads verbatim from the originally imported XML (only link element ids are rewritten — nothing else changes by a single byte). Editing one lane regenerates only the affected roads (e.g. 13 of 98 on a large sample instead of all of them). An unedited import→export round-trip reproduces the original road/junction elements exactly.

### Quality gate
Exports now pass `asam-qc-opendrive` with zero errors on round-trip and drawn scenes (fixes included: zero-width contact links moved to `<userData>`, an endpoint-snap pinch that collapsed narrow lanes, exact fitted endpoint landing). A label-gated CI job downloads public sample maps, runs the round-trip pipeline, and fails on any QC error.

## Testing

- 260 unit tests (vitest), including a round-trip fidelity matrix (lane counts, next/prev edge sets, adjacency pairs, attributes) over esmini and CARLA sample maps and a carry-through suite
- ASAM qc-opendrive: 0 errors on fabriksgatan/Town01/two_plus_one/curves/e6mini round-trips and drawn scenes
- esmini 3.3.0 headless: all outputs load without road warnings

## Known limitations

- One CARLA map (Town04, spiral-heavy with sub-resolution lane sections) still loses a minority of lanes on import, which surfaces as residual QC gap errors on its round-trip; the exporter-side output for the imported subset is clean
- Opposite-direction adjacent lanes remain separate roads (single-road `<left>`-lane emission is future work)
- Connecting roads are synthesized per lane edge; multi-lane maneuver grouping is a future optimization