### PR TITLE
feat(exporter): traffic sign regulatory elements

### DIFF
--- a/packages/drawtonomy-sdk/__tests__/exporter/opendriveParser.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/opendriveParser.test.ts
@@ -123,7 +123,7 @@ describe('parseOpenDriveXml', () => {
     const road = parseOpenDriveXml(SAMPLE).roads[0]
     expect(road.hasElevation).toBe(true)
     expect(road.signals).toEqual([
-      { id: 'sig1', s: 95, t: -6, type: '1000001', subtype: '-1', name: 'tl', width: 0, height: 0, validity: [], userData: {} },
+      { id: 'sig1', s: 95, t: -6, type: '1000001', subtype: '-1', name: 'tl', dynamic: '', country: '', width: 0, height: 0, validity: [], userData: {} },
     ])
     expect(road.objects[0].type).toBe('crosswalk')
   })

--- a/packages/drawtonomy-sdk/__tests__/exporter/roundtripFidelity.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/roundtripFidelity.test.ts
@@ -427,6 +427,25 @@ function snapshotFrom(imported: ImportedShapes): DrawtonomySnapshot {
       },
     })
   }
+  for (const ts of imported.trafficSigns ?? []) {
+    shapes.push({
+      id: ts.id,
+      type: 'traffic_sign',
+      x: ts.x,
+      y: ts.y,
+      rotation: 0,
+      zIndex: 0,
+      props: {
+        w: ts.w,
+        h: ts.h,
+        color: 'default',
+        attributes: ts.attributes,
+        osmId: ts.osmId,
+        affectedLaneIds: ts.affectedLaneIds,
+        stopLineId: ts.stopLineId,
+      },
+    })
+  }
   for (const cw of imported.crosswalks ?? []) {
     shapes.push({
       id: cw.id,

--- a/packages/drawtonomy-sdk/__tests__/exporter/trafficSignRegulatory.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/trafficSignRegulatory.test.ts
@@ -1,0 +1,484 @@
+// Traffic sign regulatory element tests:
+// Lanelet2 traffic_sign / speed_limit export/import round-trips and
+// OpenDRIVE static signal (dynamic="no") carry-through.
+
+import { describe, it, expect } from 'vitest'
+import { exportToLanelet2 } from '../../src/exporter/lanelet2'
+import { parseOsmXml } from '../../src/exporter/osmParser'
+import { osmToShapes, type ImportedShapes } from '../../src/exporter/osmToShapes'
+import { exportToOpenDrive } from '../../src/exporter/opendrive'
+import { parseOpenDriveXml } from '../../src/exporter/opendriveParser'
+import { odrToShapes } from '../../src/exporter/odrToShapes'
+import { PIXELS_PER_METER } from '../../src/exporter/units'
+import type { DrawtonomySnapshot } from '../../src/types'
+
+function snapshot(shapes: any[]): DrawtonomySnapshot {
+  return { version: '1.1', timestamp: new Date().toISOString(), shapes }
+}
+
+function point(id: string, x: number, y: number, osmId = '') {
+  return { id, type: 'point', x, y, rotation: 0, zIndex: 0, props: { color: 'black', visible: true, osmId } }
+}
+
+function linestring(id: string, pointIds: string[], osmId = '', attrs: Record<string, string> = {}) {
+  return {
+    id,
+    type: 'linestring',
+    x: 0,
+    y: 0,
+    rotation: 0,
+    zIndex: 0,
+    props: { pointIds, color: 'black', strokeWidth: 2, attributes: { type: 'line_thin', subtype: 'solid', ...attrs }, osmId },
+  }
+}
+
+function lane(id: string, leftId: string, rightId: string, osmId = '') {
+  return {
+    id,
+    type: 'lane',
+    x: 0,
+    y: 0,
+    rotation: 0,
+    zIndex: 0,
+    props: {
+      leftBoundaryId: leftId,
+      rightBoundaryId: rightId,
+      invertLeft: false,
+      invertRight: false,
+      color: 'default',
+      size: 'm',
+      attributes: { type: 'lanelet', subtype: 'road', speed_limit: '30' },
+      next: [],
+      prev: [],
+      osmId,
+    },
+  }
+}
+
+function trafficSign(id: string, x: number, y: number, extra: Record<string, unknown> = {}) {
+  return {
+    id,
+    type: 'traffic_sign',
+    x,
+    y,
+    rotation: 0,
+    zIndex: 0,
+    props: {
+      w: 20,
+      h: 20,
+      color: 'black',
+      size: 'm',
+      attributes: { sign_code: 'de274' },
+      osmId: '',
+      ...extra,
+    },
+  }
+}
+
+/** A single lane (x: 0..100), a vertical stop line at x=80, and a sign. */
+function laneWithSignShapes() {
+  return [
+    point('p0', 0, 0),
+    point('p1', 100, 0),
+    point('p2', 0, 50),
+    point('p3', 100, 50),
+    linestring('left', ['p0', 'p1']),
+    linestring('right', ['p2', 'p3']),
+    lane('lane0', 'left', 'right'),
+    point('ps0', 80, 2),
+    point('ps1', 80, 48),
+    linestring('stop0', ['ps0', 'ps1']),
+    trafficSign('ts0', 80, -40, { affectedLaneIds: ['lane0'], stopLineId: 'stop0' }),
+  ]
+}
+
+/** Rebuild snapshot shapes from an import result, as the editor would. */
+function shapesFromImport(imported: ImportedShapes): any[] {
+  const shapes: any[] = []
+  for (const p of imported.points) shapes.push(point(p.id, p.x, p.y, p.osmId))
+  for (const ls of imported.linestrings) {
+    const shape = linestring(ls.id, ls.pointIds, ls.osmId)
+    shape.props.attributes = ls.attributes as any
+    shapes.push(shape)
+  }
+  for (const l of imported.lanes) {
+    const shape = lane(l.id, l.leftBoundaryId, l.rightBoundaryId, l.osmId)
+    shape.props.attributes = l.attributes as any
+    shapes.push(shape)
+  }
+  for (const ts of imported.trafficSigns) {
+    shapes.push(
+      trafficSign(ts.id, ts.x, ts.y, {
+        w: ts.w,
+        h: ts.h,
+        osmId: ts.osmId,
+        attributes: ts.attributes,
+        affectedLaneIds: ts.affectedLaneIds,
+        stopLineId: ts.stopLineId,
+      })
+    )
+  }
+  return shapes
+}
+
+describe('exportToLanelet2 traffic_sign regulatory elements', () => {
+  it('emits a traffic_sign regulatory element with refers / ref_line members', () => {
+    const xml = exportToLanelet2(snapshot(laneWithSignShapes()), { mapOrigin: { lat: 35, lon: 139 } })
+    const data = parseOsmXml(xml)
+
+    const re = data.relations.find(r => r.tags.type === 'regulatory_element')
+    expect(re).toBeDefined()
+    expect(re!.tags.subtype).toBe('traffic_sign')
+
+    // refers: synthesized 2-node way at the sign position, tagged
+    // type=traffic_sign with the sign code as its subtype.
+    const refers = re!.members.find(m => m.role === 'refers')
+    expect(refers?.type).toBe('way')
+    const refersWay = data.ways.get(refers!.ref)!
+    expect(refersWay.tags.type).toBe('traffic_sign')
+    expect(refersWay.tags.subtype).toBe('de274')
+    expect(refersWay.nodeRefs).toHaveLength(2)
+
+    // ref_line: the stop line way is forced to type=stop_line.
+    const refLine = re!.members.find(m => m.role === 'ref_line')
+    expect(refLine?.type).toBe('way')
+    expect(data.ways.get(refLine!.ref)?.tags.type).toBe('stop_line')
+
+    // The affected lanelet references the regulatory element back.
+    const lanelet = data.relations.find(r => r.tags.type === 'lanelet')!
+    const reMember = lanelet.members.find(m => m.role === 'regulatory_element')
+    expect(reMember).toEqual({ type: 'relation', ref: re!.id, role: 'regulatory_element' })
+  })
+
+  it('emits subtype=speed_limit with a sign_type tag for speed limit signs', () => {
+    const shapes = laneWithSignShapes().filter(s => s.id !== 'ts0')
+    shapes.push(
+      trafficSign('ts0', 80, -40, {
+        affectedLaneIds: ['lane0'],
+        attributes: { sign_code: 'de274-60', sign_type: '60 km/h' },
+      })
+    )
+    const xml = exportToLanelet2(snapshot(shapes), { mapOrigin: { lat: 35, lon: 139 } })
+    const data = parseOsmXml(xml)
+
+    const re = data.relations.find(r => r.tags.type === 'regulatory_element')!
+    expect(re.tags.subtype).toBe('speed_limit')
+    expect(re.tags.sign_type).toBe('60 km/h')
+    const refersWay = data.ways.get(re.members.find(m => m.role === 'refers')!.ref)!
+    expect(refersWay.tags.type).toBe('traffic_sign')
+    expect(refersWay.tags.subtype).toBe('de274-60')
+  })
+
+  it('falls back to attributes.subtype, then "unknown", for the sign code', () => {
+    const shapes = laneWithSignShapes().filter(s => s.id !== 'ts0')
+    shapes.push(trafficSign('ts0', 80, -40, { affectedLaneIds: ['lane0'], attributes: { subtype: 'usR1-1' } }))
+    shapes.push(trafficSign('ts1', 90, -40, { affectedLaneIds: ['lane0'], attributes: {} }))
+    const xml = exportToLanelet2(snapshot(shapes), { mapOrigin: { lat: 35, lon: 139 } })
+    const data = parseOsmXml(xml)
+    const subtypes = [...data.ways.values()]
+      .filter(w => w.tags.type === 'traffic_sign')
+      .map(w => w.tags.subtype)
+      .sort()
+    expect(subtypes).toEqual(['unknown', 'usR1-1'])
+  })
+
+  it('skips traffic signs without affectedLaneIds', () => {
+    const shapes = laneWithSignShapes().filter(s => s.id !== 'ts0')
+    shapes.push(trafficSign('ts1', 80, -40))
+    const xml = exportToLanelet2(snapshot(shapes), { mapOrigin: { lat: 35, lon: 139 } })
+    const data = parseOsmXml(xml)
+    expect(data.relations.some(r => r.tags.type === 'regulatory_element')).toBe(false)
+  })
+
+  it('tolerates dangling affectedLaneIds / stopLineId (deleted shapes)', () => {
+    const shapes = laneWithSignShapes().filter(s => s.id !== 'ts0')
+    shapes.push(trafficSign('ts0', 80, -40, { affectedLaneIds: ['lane0', 'lane_deleted'], stopLineId: 'stop_deleted' }))
+    const xml = exportToLanelet2(snapshot(shapes), { mapOrigin: { lat: 35, lon: 139 } })
+    const data = parseOsmXml(xml)
+
+    const re = data.relations.find(r => r.tags.type === 'regulatory_element')!
+    expect(re.members.some(m => m.role === 'ref_line')).toBe(false)
+    expect(re.members.some(m => m.role === 'refers')).toBe(true)
+
+    // Every member reference in the output resolves (no dangling ids leak).
+    const relationIds = new Set(data.relations.map(r => r.id))
+    for (const r of data.relations) {
+      for (const m of r.members) {
+        if (m.type === 'relation') expect(relationIds.has(m.ref)).toBe(true)
+        if (m.type === 'way') expect(data.ways.has(m.ref)).toBe(true)
+        if (m.type === 'node') expect(data.nodes.has(m.ref)).toBe(true)
+      }
+    }
+  })
+})
+
+describe('osmToShapes traffic_sign regulatory elements', () => {
+  it('round-trips sign_code / affectedLaneIds / stopLineId / position through Lanelet2', () => {
+    const xml = exportToLanelet2(snapshot(laneWithSignShapes()), { mapOrigin: { lat: 35, lon: 139 } })
+    const result = osmToShapes(parseOsmXml(xml))
+
+    expect(result.lanes).toHaveLength(1)
+    expect(result.trafficSigns).toHaveLength(1)
+    const ts = result.trafficSigns[0]
+
+    // Shape position / width come back from the refers way (origin embedded).
+    expect(ts.x).toBeCloseTo(80, 3)
+    expect(ts.y).toBeCloseTo(-40, 3)
+    expect(ts.w).toBeCloseTo(20, 3)
+
+    expect(ts.attributes.sign_code).toBe('de274')
+    expect(ts.affectedLaneIds).toEqual([result.lanes[0].id])
+
+    // Stop line imported as a linestring tagged type=stop_line.
+    expect(ts.stopLineId).not.toBeNull()
+    const stopLs = result.linestrings.find(ls => ls.id === ts.stopLineId)!
+    expect(stopLs.attributes.type).toBe('stop_line')
+
+    // Round-trip bookkeeping: relation / refers way OSM ids are retained.
+    const re = parseOsmXml(xml).relations.find(r => r.tags.type === 'regulatory_element')!
+    expect(ts.osmId).toBe(re.id)
+    expect(ts.attributes.refers_osm_id).toBe(re.members.find(m => m.role === 'refers')!.ref)
+  })
+
+  it('promotes speed_limit regulatory elements and keeps subtype / sign_type', () => {
+    const shapes = laneWithSignShapes().filter(s => s.id !== 'ts0')
+    shapes.push(
+      trafficSign('ts0', 80, -40, {
+        affectedLaneIds: ['lane0'],
+        attributes: { sign_code: 'de274-60', sign_type: '60 km/h' },
+      })
+    )
+    const firstXml = exportToLanelet2(snapshot(shapes), { mapOrigin: { lat: 35, lon: 139 } })
+    const result = osmToShapes(parseOsmXml(firstXml))
+    expect(result.trafficSigns).toHaveLength(1)
+    const ts = result.trafficSigns[0]
+    expect(ts.attributes.subtype).toBe('speed_limit')
+    expect(ts.attributes.sign_type).toBe('60 km/h')
+    expect(ts.attributes.sign_code).toBe('de274-60')
+
+    // Re-export keeps the speed_limit subtype.
+    const secondXml = exportToLanelet2(snapshot(shapesFromImport(result)), {
+      sidecar: { rawXml: firstXml, originLat: 35, originLon: 139 },
+    })
+    const re = parseOsmXml(secondXml).relations.find(r => r.tags.type === 'regulatory_element')!
+    expect(re.tags.subtype).toBe('speed_limit')
+    expect(re.tags.sign_type).toBe('60 km/h')
+  })
+
+  it('restricts traffic sign elements to the selected lanelets', () => {
+    const xml = exportToLanelet2(snapshot(laneWithSignShapes()), { mapOrigin: { lat: 35, lon: 139 } })
+    const data = parseOsmXml(xml)
+    const laneletId = data.relations.find(r => r.tags.type === 'lanelet')!.id
+    const none = osmToShapes(data, { selectedLaneIds: ['does-not-exist'] })
+    expect(none.trafficSigns).toHaveLength(0)
+    const some = osmToShapes(data, { selectedLaneIds: [laneletId] })
+    expect(some.trafficSigns).toHaveLength(1)
+  })
+
+  it('keeps a sign_type-only speed_limit relation (no refers way) sidecar-only', () => {
+    const sidecar = `<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='drawtonomy' drawtonomy_origin_lat='35.0' drawtonomy_origin_lon='139.0'>
+  <relation id='900'>
+    <tag k='type' v='regulatory_element' />
+    <tag k='subtype' v='speed_limit' />
+    <tag k='sign_type' v='50 km/h' />
+  </relation>
+</osm>`
+    const imported = osmToShapes(parseOsmXml(sidecar))
+    expect(imported.trafficSigns).toHaveLength(0)
+    // The relation survives a round trip verbatim through the sidecar.
+    const xml = exportToLanelet2(snapshot([]), { sidecar: { rawXml: sidecar, originLat: 35, originLon: 139 } })
+    const re = parseOsmXml(xml).relations.find(r => r.id === '900')!
+    expect(re.tags.sign_type).toBe('50 km/h')
+  })
+
+  it('overrides the sidecar regulatory element on re-export instead of duplicating it', () => {
+    const firstXml = exportToLanelet2(snapshot(laneWithSignShapes()), { mapOrigin: { lat: 35, lon: 139 } })
+    const firstData = parseOsmXml(firstXml)
+    const imported = osmToShapes(firstData)
+    const ts = imported.trafficSigns[0]
+
+    const secondXml = exportToLanelet2(snapshot(shapesFromImport(imported)), {
+      sidecar: { rawXml: firstXml, originLat: 35, originLon: 139 },
+    })
+    const data = parseOsmXml(secondXml)
+    expect(data.relations.filter(r => r.tags.type === 'regulatory_element')).toHaveLength(1)
+    expect(data.relations.filter(r => r.id === ts.osmId)).toHaveLength(1)
+    const refersWays = [...data.ways.values()].filter(w => w.tags.type === 'traffic_sign')
+    expect(refersWays).toHaveLength(1)
+    expect(refersWays[0].id).toBe(ts.attributes.refers_osm_id)
+    // Entity counts are stable across the round trip (nothing duplicated).
+    expect(data.relations).toHaveLength(firstData.relations.length)
+    expect(data.ways.size).toBe(firstData.ways.size)
+    expect(data.nodes.size).toBe(firstData.nodes.size)
+  })
+})
+
+const ODR_SIGN_MAP = (signal: string) => `<?xml version="1.0"?>
+<OpenDRIVE>
+  <header revMajor="1" revMinor="6"/>
+  <road name="r" length="100" id="1" junction="-1">
+    <planView>
+      <geometry s="0" x="0" y="0" hdg="0" length="100"><line/></geometry>
+    </planView>
+    <lanes>
+      <laneSection s="0">
+        <right>
+          <lane id="-1" type="driving" level="false">
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+          <lane id="-2" type="driving" level="false">
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
+    <signals>
+      ${signal}
+    </signals>
+  </road>
+</OpenDRIVE>`
+
+describe('odrToShapes static signals', () => {
+  it('converts a dynamic="no" signal with validity into a traffic sign', () => {
+    const xml = ODR_SIGN_MAP(
+      `<signal id="9" s="50" t="-8" zOffset="2" name="speed60" dynamic="no" orientation="-" type="274" subtype="60" country="DE" width="0.6" height="0.6"><validity fromLane="-1" toLane="-1"/></signal>`
+    )
+    const result = odrToShapes(parseOpenDriveXml(xml))
+    expect(result.trafficLights).toHaveLength(0)
+    expect(result.trafficSigns).toHaveLength(1)
+    const ts = result.trafficSigns[0]
+    const lane1 = result.lanes.find(l => l.attributes.odr_lane_id === '-1')!
+    expect(ts.affectedLaneIds).toEqual([lane1.id])
+    // Position: (s=50, t=-8) on an east-heading road -> canvas (50 m, +8 m down).
+    expect(ts.x).toBeCloseTo(50 * PIXELS_PER_METER, 6)
+    expect(ts.y).toBeCloseTo(8 * PIXELS_PER_METER, 6)
+    expect(ts.w).toBeCloseTo(0.6 * PIXELS_PER_METER, 6)
+    expect(ts.attributes.odr_signal_id).toBe('9')
+    expect(ts.attributes.odr_signal_type).toBe('274')
+    expect(ts.attributes.odr_signal_subtype).toBe('60')
+    expect(ts.attributes.odr_country).toBe('DE')
+    // Third-party files carry no signAttributes stash: the name is the code.
+    expect(ts.attributes.sign_code).toBe('speed60')
+    // Converted signals no longer show up in the "not converted" warning.
+    expect(result.warnings.some(w => w.includes('signal'))).toBe(false)
+  })
+
+  it('leaves dynamic unknown-type signals unconverted (warning)', () => {
+    const xml = ODR_SIGN_MAP(
+      `<signal id="9" s="50" t="-8" zOffset="2" name="x" dynamic="yes" orientation="-" type="999" subtype="-1" width="0.6" height="0.6"/>`
+    )
+    const result = odrToShapes(parseOpenDriveXml(xml))
+    expect(result.trafficSigns).toHaveLength(0)
+    expect(result.trafficLights).toHaveLength(0)
+    expect(result.warnings.some(w => w.includes('signal'))).toBe(true)
+  })
+})
+
+describe('exportToOpenDrive traffic signs', () => {
+  it('emits a static signal with validity / name=sign_code / signAttributes userData', () => {
+    const xml = exportToOpenDrive(snapshot(laneWithSignShapes()))
+    expect(xml).toMatch(/<signal [^>]*name="de274"[^>]*dynamic="no"[^>]*type="-1"[^>]*country="OpenDRIVE"/)
+    expect(xml).toContain('<validity fromLane="-1" toLane="-1"/>')
+    expect(xml).toContain('<userData code="signAttributes"')
+    expect(xml).toContain('name="StopLine"')
+  })
+
+  it('reuses recorded odr_signal_type / odr_signal_subtype / odr_country attributes', () => {
+    const shapes = laneWithSignShapes().filter(s => s.id !== 'ts0')
+    shapes.push(
+      trafficSign('ts0', 80, -40, {
+        affectedLaneIds: ['lane0'],
+        attributes: { sign_code: 'speed60', odr_signal_type: '274', odr_signal_subtype: '60', odr_country: 'DE' },
+      })
+    )
+    const xml = exportToOpenDrive(snapshot(shapes))
+    expect(xml).toMatch(/<signal [^>]*dynamic="no"[^>]*type="274" subtype="60" country="DE"/)
+  })
+
+  it('round-trips sign_code / affectedLaneIds / stop line through export -> import', () => {
+    const xml = exportToOpenDrive(snapshot(laneWithSignShapes()))
+    const result = odrToShapes(parseOpenDriveXml(xml))
+    expect(result.lanes).toHaveLength(1)
+    expect(result.trafficSigns).toHaveLength(1)
+    const ts = result.trafficSigns[0]
+    expect(ts.attributes.sign_code).toBe('de274')
+    expect(ts.affectedLaneIds).toEqual([result.lanes[0].id])
+    expect(ts.stopLineId).not.toBeNull()
+    const stopLs = result.linestrings.find(ls => ls.id === ts.stopLineId)!
+    expect(stopLs.attributes.type).toBe('stop_line')
+    // The sign itself converted; only the StopLine helper object remains
+    // unconverted (same as the traffic light path).
+    expect(result.warnings.some(w => /[1-9]\d* signal/.test(w))).toBe(false)
+  })
+
+  it('round-trips a speed limit sign_type through OpenDRIVE userData', () => {
+    const shapes = laneWithSignShapes().filter(s => s.id !== 'ts0')
+    shapes.push(
+      trafficSign('ts0', 80, -40, {
+        affectedLaneIds: ['lane0'],
+        attributes: { sign_code: 'de274-60', sign_type: '60 km/h', subtype: 'speed_limit' },
+      })
+    )
+    const result = odrToShapes(parseOpenDriveXml(exportToOpenDrive(snapshot(shapes))))
+    expect(result.trafficSigns).toHaveLength(1)
+    const ts = result.trafficSigns[0]
+    expect(ts.attributes.sign_type).toBe('60 km/h')
+    expect(ts.attributes.subtype).toBe('speed_limit')
+    expect(ts.attributes.sign_code).toBe('de274-60')
+  })
+})
+
+describe('exportToOpenDrive traffic sign carry-through', () => {
+  const SIGN_XODR = `<?xml version="1.0"?>
+<OpenDRIVE>
+  <header revMajor="1" revMinor="6" name="sign">
+    <geoReference><![CDATA[+proj=tmerc +lat_0=35.0 +lon_0=139.0 +datum=WGS84]]></geoReference>
+  </header>
+  <road name="a" length="60" id="1" junction="-1">
+    <planView><geometry s="0" x="0" y="0" hdg="0" length="60"><line/></geometry></planView>
+    <lanes>
+      <laneSection s="0">
+        <right>
+          <lane id="-1" type="driving" level="false">
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
+    <signals>
+      <signal id="7" s="55" t="-2" zOffset="2" name="stop" dynamic="no" orientation="+" type="206" subtype="-1" country="DE" value="0" height="0.8" width="0.8">
+        <validity fromLane="-1" toLane="-1"/>
+      </signal>
+    </signals>
+  </road>
+</OpenDRIVE>`
+
+  function snapshotFrom(imported: ReturnType<typeof odrToShapes>): DrawtonomySnapshot {
+    const shapes = shapesFromImport(imported)
+    const snap = snapshot(shapes)
+    if (imported.originLatLon) snap.origin = imported.originLatLon
+    return snap
+  }
+
+  it('re-emits the road (including the static signal) verbatim when unedited', () => {
+    const imported = odrToShapes(parseOpenDriveXml(SIGN_XODR))
+    expect(imported.trafficSigns).toHaveLength(1)
+    expect(imported.sidecar.roadRecords).toBeDefined()
+    const out = exportToOpenDrive(snapshotFrom(imported), { sidecar: imported.sidecar })
+    const roadText = SIGN_XODR.match(/<road[\s\S]*<\/road>/)![0]
+    expect(out).toContain(roadText)
+  })
+
+  it('regenerates the signal when the sign was moved', () => {
+    const imported = odrToShapes(parseOpenDriveXml(SIGN_XODR))
+    const snap = snapshotFrom(imported)
+    const ts = snap.shapes.find(s => s.type === 'traffic_sign')! as any
+    ts.x += 100 // ~6 m sideways
+    const out = exportToOpenDrive(snap, { sidecar: imported.sidecar })
+    const roadText = SIGN_XODR.match(/<road[\s\S]*<\/road>/)![0]
+    expect(out).not.toContain(roadText)
+    expect(out).toMatch(/<signal [^>]*dynamic="no"[^>]*type="206"[^>]*country="DE"/)
+    expect(out).toContain('<validity fromLane="-1" toLane="-1"/>')
+  })
+})

--- a/packages/drawtonomy-sdk/src/exporter/index.ts
+++ b/packages/drawtonomy-sdk/src/exporter/index.ts
@@ -40,6 +40,8 @@ export { sanitizeFileBaseName } from './sanitize'
 export { PIXELS_PER_METER } from './units'
 export {
   exportToLanelet2,
+  trafficSignCode,
+  trafficSignRelationSubtype,
   DEFAULT_ORIGIN_LAT,
   DEFAULT_ORIGIN_LON,
   type Lanelet2ExportOptions,
@@ -64,6 +66,7 @@ export {
   type ImportedLinestring,
   type ImportedLane,
   type ImportedTrafficLight,
+  type ImportedTrafficSign,
   type ImportedCrosswalk,
   type ImportBounds,
   type OsmToShapesOptions,

--- a/packages/drawtonomy-sdk/src/exporter/lanelet2.ts
+++ b/packages/drawtonomy-sdk/src/exporter/lanelet2.ts
@@ -11,6 +11,11 @@
 //   member is a synthesized 2-node way at the signal position and whose
 //   "ref_line" member is the stop line way; affected lanelet relations gain a
 //   `role=regulatory_element` member pointing back at it
+// - Each TrafficSignShape carrying `affectedLaneIds` becomes a
+//   `<relation type=regulatory_element subtype=traffic_sign>` (or
+//   `subtype=speed_limit` for speed limit signs, carrying the standard
+//   `sign_type` tag) with the same refers / ref_line structure; the refers
+//   way is tagged `type=traffic_sign subtype=<sign code>`
 // - Each LaneShape carrying `yieldLaneIds` additionally emits a
 //   `<relation type=regulatory_element subtype=right_of_way>` whose
 //   "right_of_way" member is the lane's lanelet and whose "yield" members are
@@ -36,6 +41,7 @@ import type {
   LinestringProps,
   PointProps,
   TrafficLightProps,
+  TrafficSignProps,
 } from '../types'
 import { canvasToLatLon, parseOsmXml, type OsmData } from './osmParser'
 
@@ -43,7 +49,32 @@ type LaneShape = BaseShape<'lane', LaneProps>
 type LinestringShape = BaseShape<'linestring', LinestringProps>
 type PointShape = BaseShape<'point', PointProps>
 type TrafficLightShape = BaseShape<'traffic_light', TrafficLightProps>
+type TrafficSignShape = BaseShape<'traffic_sign', TrafficSignProps>
 type CrosswalkShape = BaseShape<'crosswalk', CrosswalkProps>
+
+/**
+ * Sign code (Lanelet2 traffic sign subtype, e.g. "de274" / "usR1-1") of a
+ * traffic sign shape. `sign_code` wins; a `subtype` that is not one of the
+ * regulatory element subtypes (round-trip metadata) is accepted as a code.
+ */
+export function trafficSignCode(attrs: Record<string, string | undefined>): string {
+  if (attrs.sign_code) return attrs.sign_code
+  if (attrs.subtype && attrs.subtype !== 'traffic_sign' && attrs.subtype !== 'speed_limit') {
+    return attrs.subtype
+  }
+  return 'unknown'
+}
+
+/**
+ * Regulatory element subtype of a traffic sign shape: `speed_limit` when the
+ * shape came from / represents a speed limit (recorded RE subtype or a
+ * lanelet2 `sign_type` value such as "50 km/h"), otherwise `traffic_sign`.
+ */
+export function trafficSignRelationSubtype(
+  attrs: Record<string, string | undefined>
+): 'traffic_sign' | 'speed_limit' {
+  return attrs.subtype === 'speed_limit' || attrs.sign_type ? 'speed_limit' : 'traffic_sign'
+}
 
 /** Sidecar captured at OSM import time. Used to round-trip tags / `ele`. */
 export interface OsmSidecar {
@@ -134,12 +165,14 @@ function buildFromShapes(
   const linestrings: LinestringShape[] = []
   const lanes: LaneShape[] = []
   const trafficLights: TrafficLightShape[] = []
+  const trafficSigns: TrafficSignShape[] = []
   const crosswalks: CrosswalkShape[] = []
   for (const s of shapes) {
     if (s.type === 'point') points.push(s as unknown as PointShape)
     else if (s.type === 'linestring') linestrings.push(s as unknown as LinestringShape)
     else if (s.type === 'lane') lanes.push(s as unknown as LaneShape)
     else if (s.type === 'traffic_light') trafficLights.push(s as unknown as TrafficLightShape)
+    else if (s.type === 'traffic_sign') trafficSigns.push(s as unknown as TrafficSignShape)
     else if (s.type === 'crosswalk') crosswalks.push(s as unknown as CrosswalkShape)
   }
 
@@ -152,8 +185,26 @@ function buildFromShapes(
   const shapeRelationOsmIds = new Set<string>()
 
   // Resolve a shape -> OSM ID. Empty `osmId` (newly drawn shape) gets a fresh
-  // negative ID, matching the OSM convention for unsubmitted edits.
+  // negative ID, matching the OSM convention for unsubmitted edits. Fresh IDs
+  // must never collide with negative IDs already taken by imported shapes or
+  // sidecar elements (maps previously exported from here use negative IDs),
+  // so allocation starts below every reserved ID.
   let nextNewId = -1
+  const reserveId = (id: string | undefined): void => {
+    if (!id) return
+    const n = Number(id)
+    if (Number.isInteger(n) && n <= nextNewId) nextNewId = n - 1
+  }
+  for (const s of shapes) {
+    const props = s.props as { osmId?: string; attributes?: Record<string, string | undefined> }
+    reserveId(props.osmId)
+    reserveId(props.attributes?.refers_osm_id)
+  }
+  if (sidecarData) {
+    for (const id of sidecarData.nodes.keys()) reserveId(id)
+    for (const id of sidecarData.ways.keys()) reserveId(id)
+    for (const r of sidecarData.relations) reserveId(r.id)
+  }
   const newIdFor = new Map<string, string>()
   const resolveOsmId = (shapeId: string, propsOsmId: string | undefined): string => {
     if (propsOsmId && propsOsmId.length > 0) return propsOsmId
@@ -246,8 +297,9 @@ function buildFromShapes(
     laneRelationByShapeId.set(lane.id, relationOut)
   }
 
-  // Traffic lights with affected lanes -> relations (type=regulatory_element,
-  // subtype=traffic_light). The signal itself is represented as a 2-node
+  // Traffic lights / signs with affected lanes -> relations
+  // (type=regulatory_element, subtype=traffic_light / traffic_sign /
+  // speed_limit). The signal or sign itself is represented as a 2-node
   // "refers" way spanning the shape's width; the stop line (when present)
   // joins as the "ref_line" way, and each affected lanelet references the
   // regulatory element back.
@@ -266,11 +318,19 @@ function buildFromShapes(
     }
   }
 
-  for (const tl of trafficLights) {
-    const affected = tl.props.affectedLaneIds ?? []
-    if (affected.length === 0) continue
+  // Shared emission for refers-way-based regulatory elements (traffic lights
+  // and traffic signs). The two callbacks finalize the format-specific tags
+  // of the synthesized refers way and of the regulatory element relation.
+  const emitRefersRegulatoryElement = (
+    shape: TrafficLightShape | TrafficSignShape,
+    finishRefersTags: (tags: Record<string, string>, attrs: Record<string, string | undefined>) => void,
+    finishRelationTags: (tags: Record<string, string>, attrs: Record<string, string | undefined>) => void
+  ): void => {
+    const affected = shape.props.affectedLaneIds ?? []
+    if (affected.length === 0) return
 
-    const reOsmId = resolveOsmId(tl.id, tl.props.osmId)
+    const attrs = (shape.props.attributes ?? {}) as Record<string, string | undefined>
+    const reOsmId = resolveOsmId(shape.id, shape.props.osmId)
     shapeRelationOsmIds.add(reOsmId)
 
     // Round-trip fidelity: a signal imported from this sidecar and left
@@ -278,12 +338,12 @@ function buildFromShapes(
     // The 2-node synthesis below would otherwise lose the original way's
     // orientation, elevation and any extra members (light_bulbs etc.).
     const originalRelation = sidecarData?.relations.find(r => r.id === reOsmId)
-    const recordedRefersId = tl.props.attributes?.refers_osm_id
+    const recordedRefersId = attrs.refers_osm_id
     const originalRefers = recordedRefersId ? sidecarData?.ways.get(recordedRefersId) : undefined
     if (originalRelation && originalRefers && originalRefers.nodeRefs.length >= 2) {
       const nodeA = sidecarData?.nodes.get(originalRefers.nodeRefs[0])
       const nodeB = sidecarData?.nodes.get(originalRefers.nodeRefs[originalRefers.nodeRefs.length - 1])
-      const current = canvasToLatLon(tl.x, tl.y, originLat, originLon)
+      const current = canvasToLatLon(shape.x, shape.y, originLat, originLon)
       // Unmoved = the shape still sits at the refers way midpoint (import
       // placed it there; ~1e-9 deg covers projection round-trip fp error).
       const unmoved =
@@ -294,8 +354,8 @@ function buildFromShapes(
       const originalRefLine = originalRelation.members.find(
         m => m.type === 'way' && m.role === 'ref_line'
       )?.ref
-      const stopLs = tl.props.stopLineId
-        ? (shapeMap.get(tl.props.stopLineId) as unknown as LinestringShape | undefined)
+      const stopLs = shape.props.stopLineId
+        ? (shapeMap.get(shape.props.stopLineId) as unknown as LinestringShape | undefined)
         : undefined
       const currentRefLine = stopLs ? resolveOsmId(stopLs.id, stopLs.props.osmId) : undefined
       if (unmoved && originalRefLine === currentRefLine) {
@@ -317,26 +377,25 @@ function buildFromShapes(
           tags: { ...originalRelation.tags },
         })
         linkAffectedLanelets(reOsmId, affected)
-        continue
+        return
       }
     }
 
     // "refers" way: reuse the way / node IDs recorded at import time (the
     // `refers_osm_id` attribute) so the sidecar copies are overridden rather
     // than duplicated; otherwise allocate fresh negative IDs.
-    const refersWayId =
-      tl.props.attributes?.refers_osm_id || resolveOsmId(`${tl.id}#refers`, undefined)
+    const refersWayId = attrs.refers_osm_id || resolveOsmId(`${shape.id}#refers`, undefined)
     const sidecarRefers = sidecarData?.ways.get(refersWayId)
     const reuseNodes = !!sidecarRefers && sidecarRefers.nodeRefs.length >= 2
     const nodeIdA = reuseNodes
       ? sidecarRefers.nodeRefs[0]
-      : resolveOsmId(`${tl.id}#refers_a`, undefined)
+      : resolveOsmId(`${shape.id}#refers_a`, undefined)
     const nodeIdB = reuseNodes
       ? sidecarRefers.nodeRefs[sidecarRefers.nodeRefs.length - 1]
-      : resolveOsmId(`${tl.id}#refers_b`, undefined)
-    const halfW = (tl.props.w ?? 0) / 2
-    const a = canvasToLatLon(tl.x - halfW, tl.y, originLat, originLon)
-    const b = canvasToLatLon(tl.x + halfW, tl.y, originLat, originLon)
+      : resolveOsmId(`${shape.id}#refers_b`, undefined)
+    const halfW = (shape.props.w ?? 0) / 2
+    const a = canvasToLatLon(shape.x - halfW, shape.y, originLat, originLon)
+    const b = canvasToLatLon(shape.x + halfW, shape.y, originLat, originLon)
     for (const [nid, ll] of [[nodeIdA, a], [nodeIdB, b]] as const) {
       shapeNodeOsmIds.add(nid)
       const originalNode = sidecarData?.nodes.get(nid)
@@ -350,13 +409,7 @@ function buildFromShapes(
     }
     shapeWayOsmIds.add(refersWayId)
     const refersTags: Record<string, string> = sidecarRefers ? { ...sidecarRefers.tags } : {}
-    refersTags.type = 'traffic_light'
-    // Autoware requires subtype and height on the traffic light way; keep
-    // sidecar values when present, allow shape attributes to override, and
-    // fall back to the common defaults.
-    const tlAttrs = (tl.props.attributes ?? {}) as Record<string, string | undefined>
-    if (!refersTags.subtype) refersTags.subtype = tlAttrs.subtype || 'red_yellow_green'
-    if (!refersTags.height) refersTags.height = tlAttrs.height || '0.5'
+    finishRefersTags(refersTags, attrs)
     waysOut.set(refersWayId, { id: refersWayId, nodeRefs: [nodeIdA, nodeIdB], tags: refersTags })
 
     const members: { type: string; ref: string; role: string }[] = [
@@ -365,8 +418,8 @@ function buildFromShapes(
 
     // "ref_line": the stop line linestring, already exported as a way above.
     // Ensure the way carries type=stop_line so consumers recognize it.
-    if (tl.props.stopLineId) {
-      const stopLs = shapeMap.get(tl.props.stopLineId) as unknown as LinestringShape | undefined
+    if (shape.props.stopLineId) {
+      const stopLs = shapeMap.get(shape.props.stopLineId) as unknown as LinestringShape | undefined
       if (stopLs) {
         const stopWayId = resolveOsmId(stopLs.id, stopLs.props.osmId)
         const stopWay = waysOut.get(stopWayId)
@@ -376,11 +429,49 @@ function buildFromShapes(
     }
 
     const tags: Record<string, string> = originalRelation ? { ...originalRelation.tags } : {}
-    tags.type = 'regulatory_element'
-    tags.subtype = 'traffic_light'
+    finishRelationTags(tags, attrs)
     relationsOut.push({ id: reOsmId, members, tags })
 
     linkAffectedLanelets(reOsmId, affected)
+  }
+
+  for (const tl of trafficLights) {
+    emitRefersRegulatoryElement(
+      tl,
+      (refersTags, attrs) => {
+        refersTags.type = 'traffic_light'
+        // Autoware requires subtype and height on the traffic light way; keep
+        // sidecar values when present, allow shape attributes to override, and
+        // fall back to the common defaults.
+        if (!refersTags.subtype) refersTags.subtype = attrs.subtype || 'red_yellow_green'
+        if (!refersTags.height) refersTags.height = attrs.height || '0.5'
+      },
+      tags => {
+        tags.type = 'regulatory_element'
+        tags.subtype = 'traffic_light'
+      }
+    )
+  }
+
+  for (const ts of trafficSigns) {
+    emitRefersRegulatoryElement(
+      ts,
+      (refersTags, attrs) => {
+        refersTags.type = 'traffic_sign'
+        // The refers way carries the sign code as its subtype (ISO 3166
+        // region code + sign number). A sidecar subtype only survives when
+        // the shape has no code of its own.
+        const code = trafficSignCode(attrs)
+        if (!refersTags.subtype || code !== 'unknown') refersTags.subtype = code
+      },
+      (tags, attrs) => {
+        tags.type = 'regulatory_element'
+        tags.subtype = trafficSignRelationSubtype(attrs)
+        // Lanelet2 speed_limit convention: the value with unit (e.g.
+        // "50 km/h") rides on the relation as `sign_type`.
+        if (attrs.sign_type) tags.sign_type = attrs.sign_type
+      }
+    )
   }
 
   // Lanes with yieldLaneIds -> relations (type=regulatory_element,

--- a/packages/drawtonomy-sdk/src/exporter/odrCarryThrough.ts
+++ b/packages/drawtonomy-sdk/src/exporter/odrCarryThrough.ts
@@ -13,7 +13,7 @@
 //    road, the shape ids it materialized plus a hash over their editable
 //    state: boundary point sequences (in travel order), lane attributes,
 //    next/prev connectivity, right-of-way links, and every regulatory shape
-//    (traffic light / crosswalk) touching the road. At export time the same
+//    (traffic light / sign / crosswalk) touching the road. At export time the same
 //    hash is recomputed from the live shapes; equality means "unedited".
 //
 // 2. Raw document access. <header> / <road> / <junction> / <controller>
@@ -45,9 +45,9 @@ export interface CarryLaneState {
   yieldLaneIds: readonly string[]
 }
 
-/** Editable state of a regulatory shape (traffic light / crosswalk). */
+/** Editable state of a regulatory shape (traffic light / sign / crosswalk). */
 export interface CarryRegulatoryState {
-  kind: 'traffic_light' | 'crosswalk'
+  kind: 'traffic_light' | 'traffic_sign' | 'crosswalk'
   shapeId: string
   /** Positional numeric fields (position, size, rotation). */
   numbers: readonly number[]

--- a/packages/drawtonomy-sdk/src/exporter/odrToShapes.ts
+++ b/packages/drawtonomy-sdk/src/exporter/odrToShapes.ts
@@ -1,5 +1,6 @@
 // Convert a parsed OpenDRIVE model (`OdrMap`) into the shape primitives that
-// the drawtonomy editor consumes (points, linestrings, lanes, traffic lights).
+// the drawtonomy editor consumes (points, linestrings, lanes, traffic lights,
+// traffic signs, crosswalks).
 //
 // Mirrors the Lanelet2 OSM import path (`osmToShapes`): the output is the
 // same intermediate `ImportedShapes` structure, extended with a sidecar (the
@@ -45,6 +46,7 @@ import {
   type ImportedPoint,
   type ImportedShapes,
   type ImportedTrafficLight,
+  type ImportedTrafficSign,
   type ShapeIdAllocator,
 } from './osmToShapes'
 import { PIXELS_PER_METER } from './units'
@@ -295,6 +297,7 @@ export function odrToShapes(map: OdrMap, options: OdrToShapesOptions = {}): OdrI
     linestrings: [],
     lanes: [],
     trafficLights: [],
+    trafficSigns: [],
     crosswalks: [],
     bounds: emptyBounds(),
     sidecar: {
@@ -588,17 +591,22 @@ export function odrToShapes(map: OdrMap, options: OdrToShapesOptions = {}): OdrI
   }
 
   /**
-   * Convert traffic light signals (type 1000001/1000002) into traffic light
-   * shapes. The position is the (s, t) station evaluated on the reference
-   * line; `affectedLaneIds` resolves the <validity> lane range against the
-   * lane section containing s (falling back to every driving lane of the
-   * road), merged with the lanes of any road that re-applies the signal via
+   * Convert signals into shapes: type 1000001/1000002 become traffic lights,
+   * any other type with dynamic != "yes" becomes a static traffic sign. The
+   * position is the (s, t) station evaluated on the reference line;
+   * `affectedLaneIds` resolves the <validity> lane range against the lane
+   * section containing s (falling back to every driving lane of the road),
+   * merged with the lanes of any road that re-applies the signal via
    * <signalReference>. A <userData code="stopLine"> record is rebuilt into a
-   * stop-line linestring and linked through `stopLineId`.
+   * stop-line linestring and linked through `stopLineId`; sign attributes
+   * stashed in <userData code="signAttributes"> (sign_code etc.) are restored.
    */
   function materializeSignals(road: OdrRoad, samples: ReferenceSample[]): void {
     for (const sig of road.signals) {
-      if (!TRAFFIC_LIGHT_SIGNAL_TYPES.has(sig.type)) continue
+      const isTrafficLight = TRAFFIC_LIGHT_SIGNAL_TYPES.has(sig.type)
+      // Dynamic signals of unknown type cannot be represented as static
+      // signs; they stay sidecar-only (counted in the warnings).
+      if (!isTrafficLight && sig.dynamic === 'yes') continue
       const pose = poseAt(samples, sig.s)
       // Unit normal toward +t (left of the reference direction in ENU).
       const ex = pose.x - Math.sin(pose.hdg) * sig.t
@@ -611,25 +619,68 @@ export function odrToShapes(map: OdrMap, options: OdrToShapesOptions = {}): OdrI
         resolveAffectedLanes(ref.road, ref.s, ref.validity, affected)
       }
 
-      const data: ImportedTrafficLight = {
-        id: idAllocator.next('traffic_light'),
+      if (isTrafficLight) {
+        const data: ImportedTrafficLight = {
+          id: idAllocator.next('traffic_light'),
+          x: enuToCanvasX(ex),
+          y: enuToCanvasY(ey),
+          // Default editor proportions (30x60 px) when the signal carries no size.
+          w: sig.width > 0 ? sig.width * PIXELS_PER_METER : 30,
+          h: sig.height > 0 ? sig.height * PIXELS_PER_METER : 60,
+          osmId: '',
+          affectedLaneIds: affected,
+          stopLineId: materializeStopLine(sig.userData['stopLine']),
+          attributes: {
+            type: 'traffic_light',
+            odr_signal_id: sig.id,
+            odr_road_id: road.id,
+            odr_signal_type: sig.type,
+            odr_signal_subtype: sig.subtype,
+          },
+        }
+        result.trafficLights.push(data)
+        convertedSignalCount++
+        continue
+      }
+
+      // Static traffic sign. Attributes stashed by the exporter in
+      // <userData code="signAttributes"> (sign_code, sign_type, regulatory
+      // element subtype, custom tags) are restored verbatim; third-party
+      // signs fall back to the signal name as the sign code.
+      const attributes: Record<string, string> = { type: 'traffic_sign' }
+      const rawSignAttrs = sig.userData['signAttributes']
+      if (rawSignAttrs) {
+        try {
+          const obj = JSON.parse(rawSignAttrs) as unknown
+          if (obj && typeof obj === 'object' && !Array.isArray(obj)) {
+            for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+              if (typeof v !== 'string' || k === 'type' || k.startsWith('odr_')) continue
+              attributes[k] = v
+            }
+          }
+        } catch {
+          // Malformed userData JSON is ignored (third-party files).
+        }
+      }
+      if (!attributes.sign_code && sig.name) attributes.sign_code = sig.name
+      attributes.odr_signal_id = sig.id
+      attributes.odr_road_id = road.id
+      attributes.odr_signal_type = sig.type
+      attributes.odr_signal_subtype = sig.subtype
+      if (sig.country) attributes.odr_country = sig.country
+      const data: ImportedTrafficSign = {
+        id: idAllocator.next('traffic_sign'),
         x: enuToCanvasX(ex),
         y: enuToCanvasY(ey),
-        // Default editor proportions (30x60 px) when the signal carries no size.
+        // Default editor proportions (30x30 px) when the signal carries no size.
         w: sig.width > 0 ? sig.width * PIXELS_PER_METER : 30,
-        h: sig.height > 0 ? sig.height * PIXELS_PER_METER : 60,
+        h: sig.height > 0 ? sig.height * PIXELS_PER_METER : 30,
         osmId: '',
         affectedLaneIds: affected,
         stopLineId: materializeStopLine(sig.userData['stopLine']),
-        attributes: {
-          type: 'traffic_light',
-          odr_signal_id: sig.id,
-          odr_road_id: road.id,
-          odr_signal_type: sig.type,
-          odr_signal_subtype: sig.subtype,
-        },
+        attributes,
       }
-      result.trafficLights.push(data)
+      result.trafficSigns.push(data)
       convertedSignalCount++
     }
   }
@@ -1314,6 +1365,21 @@ export function odrToShapes(map: OdrMap, options: OdrToShapesOptions = {}): OdrI
         },
         tl.affectedLaneIds,
         tl.attributes['odr_road_id']
+      )
+    }
+    for (const ts of result.trafficSigns) {
+      addRegState(
+        {
+          kind: 'traffic_sign',
+          shapeId: ts.id as string,
+          numbers: [ts.x, ts.y, ts.w, ts.h, 0],
+          attributes: ts.attributes,
+          affectedLaneIds: ts.affectedLaneIds,
+          stopLinePts: boundaryPts(ts.stopLineId, false),
+          controllerId: '',
+        },
+        ts.affectedLaneIds,
+        ts.attributes['odr_road_id']
       )
     }
     for (const cw of result.crosswalks) {

--- a/packages/drawtonomy-sdk/src/exporter/opendrive.ts
+++ b/packages/drawtonomy-sdk/src/exporter/opendrive.ts
@@ -31,6 +31,7 @@ import type {
   PointProps,
   PolygonProps,
   TrafficLightProps,
+  TrafficSignProps,
 } from '../types'
 import { sampleAtParam, type Point2D } from './laneCenterline'
 import { evalGeometry } from './odrGeometry'
@@ -49,11 +50,13 @@ import {
   type OdrRoadRecord,
 } from './odrCarryThrough'
 import type { OdrSidecar } from './odrToShapes'
+import { trafficSignCode } from './lanelet2'
 
 type LaneShape = BaseShape<'lane', LaneProps>
 type LinestringShape = BaseShape<'linestring', LinestringProps>
 type PointShape = BaseShape<'point', PointProps>
 type TrafficLightShape = BaseShape<'traffic_light', TrafficLightProps>
+type TrafficSignShape = BaseShape<'traffic_sign', TrafficSignProps>
 type CrosswalkShape = BaseShape<'crosswalk', CrosswalkProps>
 type PolygonShape = BaseShape<'polygon', PolygonProps>
 
@@ -1281,6 +1284,8 @@ interface SignalEntry {
   name: string
   type: string
   subtype: string
+  /** Signal type catalog country; "OpenDRIVE" when omitted. */
+  country?: string
   dynamic: 'yes' | 'no'
   orientation: '+' | '-'
   /** Lane ranges the signal applies to (regulatory layer); omitted = whole road. */
@@ -1290,6 +1295,8 @@ interface SignalEntry {
    * so the importer can rebuild the stop-line linestring and re-link it.
    */
   stopLinePoints?: { x: number; y: number }[]
+  /** Additional <userData code value> records carried on the signal. */
+  userData?: { code: string; value: string }[]
 }
 
 /**
@@ -1324,6 +1331,7 @@ interface ObjectEntry {
 function attachShapesToRoads(
   shapeMap: Map<string, BaseShape>,
   trafficLights: TrafficLightShape[],
+  trafficSigns: TrafficSignShape[],
   crosswalks: CrosswalkShape[],
   polygons: { shape: PolygonShape; vertices: { x: number; y: number }[] }[],
   roads: { roadId: number; geom: BundleGeometry }[],
@@ -1363,7 +1371,17 @@ function attachShapesToRoads(
     return byRoad
   }
 
-  for (const tl of trafficLights) {
+  // Traffic lights (dynamic signals) and traffic signs (static signals)
+  // attach to roads through the same projection / validity machinery; only
+  // the emitted <signal> attributes differ per kind.
+  const signalShapes: (
+    | { kind: 'traffic_light'; shape: TrafficLightShape }
+    | { kind: 'traffic_sign'; shape: TrafficSignShape }
+  )[] = [
+    ...trafficLights.map(shape => ({ kind: 'traffic_light' as const, shape })),
+    ...trafficSigns.map(shape => ({ kind: 'traffic_sign' as const, shape })),
+  ]
+  for (const { kind, shape: tl } of signalShapes) {
     const xG = pxToEnuX(tl.x)
     const yG = pxToEnuY(tl.y)
 
@@ -1388,25 +1406,57 @@ function attachShapesToRoads(
       if (best && best.proj.distance > maxAttachDistanceMeter) best = null
     }
     if (!best) continue
-    const style = tl.props.style ?? ''
-    const isPed = style.startsWith('pedestrian') || style.includes('ped')
-    // Conventional signal type codes: 1000001 = vehicle, 1000002 = pedestrian.
-    const sigType = isPed ? '1000002' : '1000001'
     const heightM = pxToMeter(tl.props.h)
     const widthM = pxToMeter(tl.props.w)
     const list = roadSignals.get(best.roadId) ?? []
-    const entry: SignalEntry = {
-      id: signalIdCounter++,
-      s: best.proj.s,
-      t: best.proj.t,
-      zOffset: isPed ? 1.5 : 4.5,
-      height: heightM,
-      width: widthM,
-      name: style,
-      type: sigType,
-      subtype: '-1',
-      dynamic: 'yes',
-      orientation: best.proj.t >= 0 ? '+' : '-',
+    let entry: SignalEntry
+    if (kind === 'traffic_light') {
+      const style = (tl.props as TrafficLightProps).style ?? ''
+      const isPed = style.startsWith('pedestrian') || style.includes('ped')
+      // Conventional signal type codes: 1000001 = vehicle, 1000002 = pedestrian.
+      const sigType = isPed ? '1000002' : '1000001'
+      entry = {
+        id: signalIdCounter++,
+        s: best.proj.s,
+        t: best.proj.t,
+        zOffset: isPed ? 1.5 : 4.5,
+        height: heightM,
+        width: widthM,
+        name: style,
+        type: sigType,
+        subtype: '-1',
+        dynamic: 'yes',
+        orientation: best.proj.t >= 0 ? '+' : '-',
+      }
+    } else {
+      // Static traffic sign: reuse the exact OpenDRIVE type / subtype /
+      // country recorded at import time; fresh signs fall back to type "-1"
+      // with the sign code as the name. Full attribute round-trip rides on
+      // <userData code="signAttributes">.
+      const attrs = (tl.props.attributes ?? {}) as Record<string, string | undefined>
+      entry = {
+        id: signalIdCounter++,
+        s: best.proj.s,
+        t: best.proj.t,
+        zOffset: 2,
+        height: heightM,
+        width: widthM,
+        name: trafficSignCode(attrs),
+        type: attrs.odr_signal_type || '-1',
+        subtype: attrs.odr_signal_subtype || '-1',
+        country: attrs.odr_country || undefined,
+        dynamic: 'no',
+        orientation: best.proj.t >= 0 ? '+' : '-',
+      }
+      const stash: Record<string, string> = {}
+      for (const [k, v] of Object.entries(attrs)) {
+        if (k === 'type' || k === 'refers_osm_id' || k.startsWith('odr_')) continue
+        if (v === undefined || v === null || v === '') continue
+        stash[k] = String(v)
+      }
+      if (Object.keys(stash).length > 0) {
+        entry.userData = [{ code: 'signAttributes', value: JSON.stringify(stash) }]
+      }
     }
     if (affectedByRoad.size > 0) {
       entry.validity = laneIdRanges(affectedByRoad.get(best.roadId)!)
@@ -1638,8 +1688,8 @@ function emitSignals(signals: SignalEntry[], references: SignalReferenceEntry[])
   const lines: string[] = []
   lines.push(`    <signals>`)
   for (const s of signals) {
-    const attrs = `id="${s.id}" s="${fmt(s.s)}" t="${fmt(s.t)}" zOffset="${fmt(s.zOffset)}" name="${escapeXml(s.name)}" dynamic="${s.dynamic}" orientation="${s.orientation}" type="${s.type}" subtype="${s.subtype}" country="OpenDRIVE" value="0" height="${fmt(s.height)}" width="${fmt(s.width)}"`
-    if (s.validity?.length || s.stopLinePoints) {
+    const attrs = `id="${s.id}" s="${fmt(s.s)}" t="${fmt(s.t)}" zOffset="${fmt(s.zOffset)}" name="${escapeXml(s.name)}" dynamic="${s.dynamic}" orientation="${s.orientation}" type="${s.type}" subtype="${s.subtype}" country="${escapeXml(s.country ?? 'OpenDRIVE')}" value="0" height="${fmt(s.height)}" width="${fmt(s.width)}"`
+    if (s.validity?.length || s.stopLinePoints || s.userData?.length) {
       lines.push(`      <signal ${attrs}>`)
       for (const v of s.validity ?? []) {
         lines.push(`        <validity fromLane="${v.fromLane}" toLane="${v.toLane}"/>`)
@@ -1649,6 +1699,9 @@ function emitSignals(signals: SignalEntry[], references: SignalReferenceEntry[])
           s.stopLinePoints.map((p) => [roundMm(p.x), roundMm(p.y)])
         )
         lines.push(`        <userData code="stopLine" value="${escapeXml(json)}"/>`)
+      }
+      for (const ud of s.userData ?? []) {
+        lines.push(`        <userData code="${escapeXml(ud.code)}" value="${escapeXml(ud.value)}"/>`)
       }
       lines.push(`      </signal>`)
     } else {
@@ -1928,6 +1981,7 @@ function planCarryThrough(
   sidecar: OdrSidecar | null | undefined,
   shapeMap: Map<string, BaseShape>,
   trafficLights: TrafficLightShape[],
+  trafficSigns: TrafficSignShape[],
   crosswalks: CrosswalkShape[]
 ): CarryPlan | null {
   const records = sidecar?.roadRecords
@@ -1986,6 +2040,21 @@ function planCarryThrough(
       },
       tl.props.affectedLaneIds ?? [],
       tl.props.attributes?.odr_road_id
+    )
+  }
+  for (const ts of trafficSigns) {
+    addRegState(
+      {
+        kind: 'traffic_sign',
+        shapeId: ts.id,
+        numbers: [ts.x, ts.y, ts.props.w, ts.props.h, ts.rotation || 0],
+        attributes: ts.props.attributes ?? {},
+        affectedLaneIds: ts.props.affectedLaneIds ?? [],
+        stopLinePts: stopLinePts(ts.props.stopLineId),
+        controllerId: '',
+      },
+      ts.props.affectedLaneIds ?? [],
+      ts.props.attributes?.odr_road_id
     )
   }
   for (const cw of crosswalks) {
@@ -2201,11 +2270,13 @@ export function exportToOpenDrive(snapshot: DrawtonomySnapshot, options: OpenDri
   const shapeMap = buildShapeMap(shapes)
   const lanes: LaneShape[] = []
   const trafficLights: TrafficLightShape[] = []
+  const trafficSigns: TrafficSignShape[] = []
   const crosswalks: CrosswalkShape[] = []
   const polygons: { shape: PolygonShape; vertices: { x: number; y: number }[] }[] = []
   for (const s of shapes) {
     if (s.type === 'lane') lanes.push(s as unknown as LaneShape)
     else if (s.type === 'traffic_light') trafficLights.push(s as unknown as TrafficLightShape)
+    else if (s.type === 'traffic_sign') trafficSigns.push(s as unknown as TrafficSignShape)
     else if (s.type === 'crosswalk') crosswalks.push(s as unknown as CrosswalkShape)
     else if (s.type === 'polygon') {
       const poly = s as unknown as PolygonShape
@@ -2220,11 +2291,14 @@ export function exportToOpenDrive(snapshot: DrawtonomySnapshot, options: OpenDri
 
   // Carry-through: with an importer sidecar, unedited original roads are
   // re-emitted verbatim and excluded from regeneration.
-  const carry = planCarryThrough(options.sidecar, shapeMap, trafficLights, crosswalks)
+  const carry = planCarryThrough(options.sidecar, shapeMap, trafficLights, trafficSigns, crosswalks)
   const regenLanes = carry ? lanes.filter(l => !carry.verbatimLaneIds.has(l.id)) : lanes
   const regenTrafficLights = carry
     ? trafficLights.filter(t => !carry.consumedShapeIds.has(t.id))
     : trafficLights
+  const regenTrafficSigns = carry
+    ? trafficSigns.filter(t => !carry.consumedShapeIds.has(t.id))
+    : trafficSigns
   const regenCrosswalks = carry
     ? crosswalks.filter(c => !carry.consumedShapeIds.has(c.id))
     : crosswalks
@@ -2445,6 +2519,7 @@ export function exportToOpenDrive(snapshot: DrawtonomySnapshot, options: OpenDri
   const { roadSignals, roadObjects, roadSignalRefs, signalIdByShape } = attachShapesToRoads(
     shapeMap,
     regenTrafficLights,
+    regenTrafficSigns,
     regenCrosswalks,
     polygons,
     roads,

--- a/packages/drawtonomy-sdk/src/exporter/opendriveParser.ts
+++ b/packages/drawtonomy-sdk/src/exporter/opendriveParser.ts
@@ -125,6 +125,10 @@ export interface OdrSignal {
   type: string
   subtype: string
   name: string
+  /** "yes" for dynamic signals (traffic lights); "" when absent (= static). */
+  dynamic: string
+  /** Country code of the signal type catalog ("" when absent). */
+  country: string
   /** Physical size (m); 0 when absent. */
   width: number
   height: number
@@ -582,6 +586,8 @@ function parseRoad(el: XmlNode): OdrRoad {
         type: sig.attrs.type ?? '',
         subtype: sig.attrs.subtype ?? '',
         name: sig.attrs.name ?? '',
+        dynamic: sig.attrs.dynamic ?? '',
+        country: sig.attrs.country ?? '',
         width: numAttr(sig, 'width', 0),
         height: numAttr(sig, 'height', 0),
         validity: parseValidity(sig),

--- a/packages/drawtonomy-sdk/src/exporter/osmToShapes.ts
+++ b/packages/drawtonomy-sdk/src/exporter/osmToShapes.ts
@@ -1,7 +1,7 @@
 // Convert parsed Lanelet2 OSM data into the shape primitives that the
 // drawtonomy editor consumes (points, linestrings, lanes, traffic lights,
-// crosswalks). right_of_way regulatory elements are restored as lane-level
-// `yieldLaneIds` props rather than standalone shapes.
+// traffic signs, crosswalks). right_of_way regulatory elements are restored
+// as lane-level `yieldLaneIds` props rather than standalone shapes.
 //
 // The output is the intermediate `ImportedShapes` structure used by the
 // editor's import flow — not a full DrawtonomySnapshot — because the editor
@@ -18,12 +18,12 @@ import { latLonToCanvas, type OsmData } from './osmParser'
  * a custom allocator to coordinate IDs with their own counters.
  */
 export interface ShapeIdAllocator {
-  next(kind: 'point' | 'linestring' | 'lane' | 'traffic_light' | 'crosswalk'): ShapeId
+  next(kind: 'point' | 'linestring' | 'lane' | 'traffic_light' | 'traffic_sign' | 'crosswalk'): ShapeId
 }
 
 /** Default allocator: monotonic counter per shape kind. */
 export function createShapeIdAllocator(): ShapeIdAllocator {
-  const counters: Record<string, number> = { point: 0, linestring: 0, lane: 0, traffic_light: 0, crosswalk: 0 }
+  const counters: Record<string, number> = { point: 0, linestring: 0, lane: 0, traffic_light: 0, traffic_sign: 0, crosswalk: 0 }
   return {
     next(kind) {
       const id = `shape:${kind}_${counters[kind]}` as ShapeId
@@ -93,6 +93,30 @@ export interface ImportedTrafficLight {
   attributes: Record<string, string>
 }
 
+export interface ImportedTrafficSign {
+  id: ShapeId
+  /** Canvas position (midpoint of the "refers" way). */
+  x: number
+  y: number
+  /** Sign width in canvas pixels (span of the "refers" way). */
+  w: number
+  /** Sign height in canvas pixels (not encoded in the source; square default). */
+  h: number
+  /** OSM id of the regulatory_element relation ('' for non-OSM sources). */
+  osmId: string
+  /** Imported lane shape ids whose lanelet relations reference this regulatory element. */
+  affectedLaneIds: string[]
+  /** Imported linestring shape id of the "ref_line" stop line, or null. */
+  stopLineId: string | null
+  /**
+   * Relation tags plus round-trip bookkeeping: `sign_code` restores the
+   * refers way's subtype (the actual sign code), `subtype` keeps the
+   * regulatory element subtype (traffic_sign / speed_limit) and `sign_type`
+   * keeps a speed limit value (e.g. "50 km/h") when present.
+   */
+  attributes: Record<string, string>
+}
+
 export interface ImportedCrosswalk {
   id: ShapeId
   /** Canvas position (midpoint of the crosswalk axis). */
@@ -131,6 +155,8 @@ export interface ImportedShapes {
   lanes: ImportedLane[]
   /** Traffic lights promoted from regulatory elements / signals. */
   trafficLights: ImportedTrafficLight[]
+  /** Traffic signs promoted from `traffic_sign` / `speed_limit` regulatory elements / static signals. */
+  trafficSigns: ImportedTrafficSign[]
   /** Crosswalks promoted from `crosswalk` regulatory elements / objects. */
   crosswalks: ImportedCrosswalk[]
   bounds: ImportBounds
@@ -357,6 +383,7 @@ export function osmToShapes(osmData: OsmData, options: OsmToShapesOptions = {}):
     linestrings: [],
     lanes: [],
     trafficLights: [],
+    trafficSigns: [],
     crosswalks: [],
     bounds: emptyBounds(),
   }
@@ -392,11 +419,16 @@ export function osmToShapes(osmData: OsmData, options: OsmToShapesOptions = {}):
     laneletRelations = laneletRelations.filter(r => selected.has(r.id))
   }
 
-  // Traffic light / crosswalk / right_of_way regulatory elements to promote.
-  // When a lanelet selection is active, only the elements referenced by the
-  // selected lanelets come along.
+  // Traffic light / sign / crosswalk / right_of_way regulatory elements to
+  // promote. When a lanelet selection is active, only the elements referenced
+  // by the selected lanelets come along.
   let trafficLightRelations = osmData.relations.filter(
     r => r.tags.type === 'regulatory_element' && r.tags.subtype === 'traffic_light'
+  )
+  let trafficSignRelations = osmData.relations.filter(
+    r =>
+      r.tags.type === 'regulatory_element' &&
+      (r.tags.subtype === 'traffic_sign' || r.tags.subtype === 'speed_limit')
   )
   let crosswalkRelations = osmData.relations.filter(
     r => r.tags.type === 'regulatory_element' && r.tags.subtype === 'crosswalk'
@@ -414,6 +446,7 @@ export function osmToShapes(osmData: OsmData, options: OsmToShapesOptions = {}):
       }
     }
     trafficLightRelations = trafficLightRelations.filter(r => referencedReIds.has(r.id))
+    trafficSignRelations = trafficSignRelations.filter(r => referencedReIds.has(r.id))
     crosswalkRelations = crosswalkRelations.filter(r => referencedReIds.has(r.id))
     rightOfWayRelations = rightOfWayRelations.filter(r => referencedReIds.has(r.id))
   }
@@ -441,10 +474,10 @@ export function osmToShapes(osmData: OsmData, options: OsmToShapesOptions = {}):
     }
   }
   // Stop line ("ref_line") ways become linestrings too even though they are
-  // not lane boundaries; "refers" ways are consumed into the traffic light
-  // shape itself and stay sidecar-only.
+  // not lane boundaries; "refers" ways are consumed into the traffic light /
+  // sign shape itself and stay sidecar-only.
   const refLineWayIds = new Set<string>()
-  for (const re of [...trafficLightRelations, ...crosswalkRelations]) {
+  for (const re of [...trafficLightRelations, ...trafficSignRelations, ...crosswalkRelations]) {
     for (const member of re.members) {
       if (member.type === 'way' && member.role === 'ref_line' && osmData.ways.has(member.ref)) {
         refLineWayIds.add(member.ref)
@@ -636,6 +669,44 @@ export function osmToShapes(osmData: OsmData, options: OsmToShapesOptions = {}):
       affectedLaneIds: laneShapeIdsByRegElem.get(re.id) ?? [],
       stopLineId,
       attributes: { ...re.tags, refers_osm_id: refersWay.id },
+    })
+  }
+
+  // Materialize traffic signs from `traffic_sign` / `speed_limit` regulatory
+  // elements, mirroring the traffic light promotion above. The refers way's
+  // subtype (the actual sign code) is restored into `sign_code`; relations
+  // without a refers way (e.g. a sign_type-only speed limit) carry no
+  // geometry and stay sidecar-only.
+  for (const re of trafficSignRelations) {
+    const refersMember = re.members.find(m => m.type === 'way' && m.role === 'refers')
+    const refersWay = refersMember ? osmData.ways.get(refersMember.ref) : undefined
+    if (!refersWay || refersWay.nodeRefs.length === 0) continue
+    const coords: Point2d[] = []
+    for (const ref of refersWay.nodeRefs) {
+      const node = osmData.nodes.get(ref)
+      if (node) coords.push(latLonToCanvas(node.lat, node.lon, centerLat, centerLon))
+    }
+    if (coords.length === 0) continue
+    const first = coords[0]
+    const last = coords[coords.length - 1]
+    const span = Math.hypot(last.x - first.x, last.y - first.y)
+    // The OSM encoding carries only the sign width; height keeps a square
+    // default. Degenerate ways fall back to 30 px.
+    const w = span > 1e-6 ? span : 30
+    const refLineMember = re.members.find(m => m.type === 'way' && m.role === 'ref_line')
+    const stopLineId = refLineMember ? osmWayToLinestringId.get(refLineMember.ref) ?? null : null
+    const attributes: Record<string, string> = { ...re.tags, refers_osm_id: refersWay.id }
+    if (refersWay.tags.subtype) attributes.sign_code = refersWay.tags.subtype
+    result.trafficSigns.push({
+      id: idAllocator.next('traffic_sign'),
+      x: (first.x + last.x) / 2,
+      y: (first.y + last.y) / 2,
+      w,
+      h: w,
+      osmId: re.id,
+      affectedLaneIds: laneShapeIdsByRegElem.get(re.id) ?? [],
+      stopLineId,
+      attributes,
     })
   }
 

--- a/packages/drawtonomy-sdk/src/types.ts
+++ b/packages/drawtonomy-sdk/src/types.ts
@@ -162,6 +162,33 @@ export interface TrafficLightProps {
   controllerId?: string
 }
 
+export interface TrafficSignProps {
+  w: number
+  h: number
+  color: string
+  size?: string
+  /**
+   * Sign metadata. `sign_code` carries the Lanelet2 traffic sign subtype
+   * (ISO 3166 region code + sign number, e.g. "de274" / "usR1-1");
+   * `sign_type` carries a speed limit value with unit (e.g. "50 km/h") for
+   * speed limit regulatory elements that do not originate from a sign code.
+   */
+  attributes: { type?: string; subtype?: string; sign_code?: string; sign_type?: string } & Record<
+    string,
+    string
+  >
+  osmId: string
+  /**
+   * Lane shape ids whose traffic this sign regulates (regulatory layer).
+   * Exported as a Lanelet2 `traffic_sign` / `speed_limit` regulatory element
+   * referenced by the affected lanelets, and as an OpenDRIVE static signal
+   * (`dynamic="no"`) with per-lane validity.
+   */
+  affectedLaneIds?: string[]
+  /** Linestring shape id of the associated stop line, or null when absent. */
+  stopLineId?: string | null
+}
+
 export interface CrosswalkProps {
   /** Crosswalk axis start in shape-local coordinates. */
   startX: number


### PR DESCRIPTION
## Summary

Adds traffic sign support to the regulatory layer, mirroring the existing traffic light path: signs can reference the lanes they regulate and round-trip through both Lanelet2 and OpenDRIVE.

### Lanelet2
- `traffic_sign` regulatory elements: a synthesized `refers` way (`type=traffic_sign`, sign code as `subtype`), optional `ref_line` stop line, and back-references from the affected lanelets
- Speed-limit signs follow the documented `speed_limit` relation subtype with a unit-suffixed `sign_type` tag
- Both lift into editable records on import; unedited imported signs re-export their original ways verbatim via the sidecar (verified byte-stable across consecutive exports, and node/way/relation counts are fully preserved on a published sample map with 28 signs)

### OpenDRIVE
- Signs export as `<signal dynamic="no">` with lane `<validity>`; original `type`/`subtype`/`country` are reused when round-tripping, and the full attribute set is carried in signal `<userData>` so third-party codes survive
- Static signals on import become editable sign records (dynamic traffic lights keep their existing path); the carry-through state hash now covers sign edits

### Internals
- The regulatory-element emitter is shared between traffic lights and signs
- Id allocation reserves synthesized ids, fixing a potential collision between generated ways and later allocations

## Testing

18 new tests (structure, speed-limit conformance against the lanelet2 tagging documentation, fallbacks, dangling references, both round-trips, sidecar stability); 278 total passing, build clean.