### PR TITLE
fix(odr): prune degenerate sliver lanes on import to keep round-trips lossless

### DIFF
--- a/packages/drawtonomy-sdk/__tests__/exporter/degenerateSliverPrune.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/degenerateSliverPrune.test.ts
@@ -1,4 +1,4 @@
-// Regression for issue #494: degenerate sliver-lane pruning on import.
+// Regression for degenerate sliver-lane pruning on import.
 //
 // CARLA Town04 junction connecting roads (e.g. road 107 in junction 106) pack
 // lane-count transitions into chains of centimetre-scale lane sections. After
@@ -123,7 +123,7 @@ function snapshotFrom(imported: ImportedShapes): DrawtonomySnapshot {
   return snapshot
 }
 
-describe('degenerate sliver-lane pruning (issue #494)', () => {
+describe('degenerate sliver-lane pruning', () => {
   const present = existsSync(FIXTURE)
   const itIf = present ? it : it.skip
   if (!present) {

--- a/packages/drawtonomy-sdk/__tests__/exporter/degenerateSliverPrune.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/degenerateSliverPrune.test.ts
@@ -1,0 +1,171 @@
+// Regression for issue #494: degenerate sliver-lane pruning on import.
+//
+// CARLA Town04 junction connecting roads (e.g. road 107 in junction 106) pack
+// lane-count transitions into chains of centimetre-scale lane sections. After
+// the importer welds connected boundary endpoints, a sub-half-metre section's
+// inner boundary collapses onto a single point: a wedge-shaped sliver lane
+// with a zero-length boundary that no exporter can represent (its apex is
+// displaced longitudinally, so OpenDRIVE's offset-along-normal width model
+// drops it, losing the lane round-trip).
+//
+// `odrToShapes` now runs `pruneDegenerateSliverLanes()`, which removes such
+// slivers and stitches their prev/next directly so connectivity survives.
+//
+// Fixture: `town04-junction106.xodr` is a self-contained slice of CARLA Town04
+// (junction 106 + its 12 connecting roads + 4 mainlines, elevation/userData
+// stripped). On import it produces 7 degenerate slivers — including road 107's
+// 0.42 m section, the exact case in the issue — which the prune removes.
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { parseOpenDriveXml } from '../../src/exporter/opendriveParser'
+import { odrToShapes } from '../../src/exporter/odrToShapes'
+import { exportToOpenDrive } from '../../src/exporter/opendrive'
+import { PIXELS_PER_METER } from '../../src/exporter/units'
+import type { DrawtonomySnapshot } from '../../src/types'
+import type { ImportedShapes } from '../../src/exporter/osmToShapes'
+
+const FIXTURE = join(__dirname, '..', 'fixtures', 'town04-junction106.xodr')
+
+/** Below this (m) a boundary has collapsed to a point — the prune threshold. */
+const SLIVER_EPS_M = 0.05
+
+function importXodr(xml: string): ImportedShapes {
+  return odrToShapes(parseOpenDriveXml(xml))
+}
+
+/** Arc length (m) of a linestring boundary. */
+function boundaryLengthM(shapes: ImportedShapes, lsId: string): number {
+  const ptById = new Map(shapes.points.map(p => [p.id, p]))
+  const ls = shapes.linestrings.find(l => l.id === lsId)
+  if (!ls) return 0
+  let total = 0
+  for (let i = 1; i < ls.pointIds.length; i++) {
+    const a = ptById.get(ls.pointIds[i - 1])
+    const b = ptById.get(ls.pointIds[i])
+    if (a && b) total += Math.hypot(a.x - b.x, a.y - b.y)
+  }
+  return total / PIXELS_PER_METER
+}
+
+/** Shortest lane boundary (m) in the import. */
+function minBoundaryM(shapes: ImportedShapes): number {
+  let min = Infinity
+  for (const lane of shapes.lanes) {
+    min = Math.min(
+      min,
+      boundaryLengthM(shapes, lane.leftBoundaryId),
+      boundaryLengthM(shapes, lane.rightBoundaryId)
+    )
+  }
+  return min
+}
+
+/** Wrap an import into a snapshot for re-export (mirrors the editor). */
+function snapshotFrom(imported: ImportedShapes): DrawtonomySnapshot {
+  const shapes: unknown[] = []
+  for (const p of imported.points) {
+    shapes.push({
+      id: p.id,
+      type: 'point',
+      x: p.x,
+      y: p.y,
+      rotation: 0,
+      zIndex: 0,
+      props: { color: 'black', visible: true, osmId: p.osmId },
+    })
+  }
+  for (const ls of imported.linestrings) {
+    shapes.push({
+      id: ls.id,
+      type: 'linestring',
+      x: ls.x,
+      y: ls.y,
+      rotation: 0,
+      zIndex: 0,
+      props: {
+        pointIds: ls.pointIds,
+        color: 'black',
+        strokeWidth: 2,
+        attributes: ls.attributes,
+        osmId: ls.osmId,
+      },
+    })
+  }
+  for (const lane of imported.lanes) {
+    shapes.push({
+      id: lane.id,
+      type: 'lane',
+      x: lane.x,
+      y: lane.y,
+      rotation: 0,
+      zIndex: 0,
+      props: {
+        leftBoundaryId: lane.leftBoundaryId,
+        rightBoundaryId: lane.rightBoundaryId,
+        invertLeft: lane.invertLeft,
+        invertRight: lane.invertRight,
+        color: 'default',
+        size: 'm',
+        attributes: lane.attributes,
+        next: lane.next,
+        prev: lane.prev,
+        osmId: lane.osmId,
+      },
+    })
+  }
+  const snapshot: DrawtonomySnapshot = {
+    version: '1.1',
+    timestamp: new Date().toISOString(),
+    shapes: shapes as DrawtonomySnapshot['shapes'],
+  }
+  snapshot.origin = imported.originLatLon ?? { lat: 49.0, lon: 8.0 }
+  return snapshot
+}
+
+describe('degenerate sliver-lane pruning (issue #494)', () => {
+  const present = existsSync(FIXTURE)
+  const itIf = present ? it : it.skip
+  if (!present) {
+    it.skip('town04-junction106.xodr fixture missing', () => {})
+  }
+
+  itIf('leaves no zero-length lane boundary after import', () => {
+    const imported = importXodr(readFileSync(FIXTURE, 'utf-8'))
+    // Without the prune the import carries 7 slivers whose inner boundary is
+    // exactly 0 m; with it the shortest surviving boundary clears the
+    // threshold by an order of magnitude.
+    expect(minBoundaryM(imported)).toBeGreaterThan(SLIVER_EPS_M)
+    for (const lane of imported.lanes) {
+      expect(boundaryLengthM(imported, lane.leftBoundaryId)).toBeGreaterThanOrEqual(
+        SLIVER_EPS_M
+      )
+      expect(boundaryLengthM(imported, lane.rightBoundaryId)).toBeGreaterThanOrEqual(
+        SLIVER_EPS_M
+      )
+    }
+  })
+
+  itIf('round-trips losslessly through OpenDRIVE (no lanes dropped)', () => {
+    const before = importXodr(readFileSync(FIXTURE, 'utf-8'))
+    const after = importXodr(exportToOpenDrive(snapshotFrom(before)))
+    // Pre-fix this was lossy (the exporter silently dropped the zero-width
+    // slivers, e.g. 53 -> 46): pruning them on import makes it stable.
+    expect(after.lanes.length).toBe(before.lanes.length)
+  })
+
+  itIf('bridges connectivity across each pruned sliver', () => {
+    const imported = importXodr(readFileSync(FIXTURE, 'utf-8'))
+    const byId = new Map(imported.lanes.map(l => [l.id as string, l]))
+    // Every surviving lane edge must point at another surviving lane (a pruned
+    // sliver would leave a dangling next/prev id) — the stitch replaces each
+    // removed sliver with a direct prev->next link.
+    for (const lane of imported.lanes) {
+      for (const n of lane.next) expect(byId.has(n)).toBe(true)
+      for (const p of lane.prev) expect(byId.has(p)).toBe(true)
+    }
+    // The fixture's connectivity is preserved: at least one through-edge exists.
+    const edges = imported.lanes.reduce((s, l) => s + l.next.length, 0)
+    expect(edges).toBeGreaterThan(0)
+  })
+})

--- a/packages/drawtonomy-sdk/__tests__/fixtures/README.md
+++ b/packages/drawtonomy-sdk/__tests__/fixtures/README.md
@@ -6,3 +6,11 @@ parser/conversion fixtures:
 
 - `fabriksgatan.xodr`
 - `two_plus_one.xodr`
+
+A self-contained slice of CARLA's Town04 (licensed under MIT), used by the
+issue #494 regression for degenerate junction sliver-lane pruning:
+
+- `town04-junction106.xodr` — junction 106 with its 12 connecting roads and
+  4 linked mainlines (elevation / lateral profiles and RoadRunner `userData`
+  stripped). Regenerate with
+  `scripts/extract-junction-fixture.py <town04.xodr>` from a full Town04 source.

--- a/packages/drawtonomy-sdk/__tests__/fixtures/README.md
+++ b/packages/drawtonomy-sdk/__tests__/fixtures/README.md
@@ -7,10 +7,16 @@ parser/conversion fixtures:
 - `fabriksgatan.xodr`
 - `two_plus_one.xodr`
 
-A self-contained slice of CARLA's Town04 (licensed under MIT), used by the
-issue #494 regression for degenerate junction sliver-lane pruning:
+A regression fixture for degenerate junction sliver-lane pruning:
 
-- `town04-junction106.xodr` — junction 106 with its 12 connecting roads and
-  4 linked mainlines (elevation / lateral profiles and RoadRunner `userData`
-  stripped). Regenerate with
+- `town04-junction106.xodr` — a self-contained slice of the **Town04** map from
+  the [CARLA simulator](https://github.com/carla-simulator/carla): junction 106
+  with its 12 connecting roads and 4 linked mainlines, with elevation / lateral
+  profiles and RoadRunner `userData` stripped. Regenerate with
   `scripts/extract-junction-fixture.py <town04.xodr>` from a full Town04 source.
+
+  CARLA assets (maps, including OpenDRIVE `.xodr` files) are licensed under
+  [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/) by the CARLA team
+  (© Computer Vision Center, CARLA Simulator project). This file is a modified
+  excerpt of Town04 (a subset of roads, with elevation / lateral profiles and
+  `userData` removed); changes were made for this test fixture.

--- a/packages/drawtonomy-sdk/__tests__/fixtures/town04-junction106.xodr
+++ b/packages/drawtonomy-sdk/__tests__/fixtures/town04-junction106.xodr
@@ -1,0 +1,1763 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenDRIVE>
+    <header revMajor="1" revMinor="4" name="" version="1" date="2019-03-29T17:46:35" north="4.2138922470160423e+2" south="-4.6125581588448603e+2" east="4.3938671433206167e+2" west="-5.4051785962181134e+2" vendor="VectorZero">
+        <geoReference><![CDATA[+lat_0=4.9000000000000000e+1 +lon_0=8.0000000000000000e+0]]></geoReference>
+    </header>
+<road name="Road 0" length="3.9509958168569284e+1" id="0" junction="-1">
+        <link>
+            <predecessor elementType="junction" elementId="106"/>
+            <successor elementType="junction" elementId="281"/>
+        </link>
+        <type s="0.0000000000000000e+0" type="town">
+            <speed max="55" unit="mph"/>
+        </type>
+        <planView>
+            <geometry s="0.0000000000000000e+0" x="2.1132980814927132e+2" y="3.0962988714087493e+2" hdg="-1.0293673214774701e-2" length="3.9509958168569284e+1">
+                <line/>
+            </geometry>
+        </planView>
+        <lanes>
+            <laneOffset s="0.0000000000000000e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneSection s="0.0000000000000000e+0">
+                <left>
+                    <lane id="2" type="shoulder" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="5.0000000000000000e-1" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                    <lane id="1" type="driving" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                        <roadMark sOffset="6.1237677906498860e+0" type="solid" material="standard" color="white" width="1.2500000000000000e-1" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                        <roadMark sOffset="6.1237677906498860e+0" type="broken" material="standard" color="yellow" width="1.2500000000000000e-1" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                        <roadMark sOffset="5.6896891820256261e+0" type="solid" material="standard" color="white" width="1.2500000000000000e-1" laneChange="none"/>
+                        <roadMark sOffset="3.6982024045654825e+1" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                    <lane id="-2" type="shoulder" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="5.0000000000000000e-1" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                    <lane id="-3" type="shoulder" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="6.3499999999999979e-1" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="curb" material="standard" width="1.5239999999999998e-1" laneChange="none"/>
+                    </lane>
+                    <lane id="-4" type="sidewalk" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="2.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+    </road>
+<road name="Road 15" length="4.1466894049748447e+1" id="15" junction="-1">
+        <link>
+            <predecessor elementType="junction" elementId="252"/>
+            <successor elementType="junction" elementId="106"/>
+        </link>
+        <type s="0.0000000000000000e+0" type="town">
+            <speed max="55" unit="mph"/>
+        </type>
+        <planView>
+            <geometry s="0.0000000000000000e+0" x="2.0469027822751227e+2" y="3.5923306545177417e+2" hdg="-1.5937374428464919e+0" length="4.1466894049748447e+1">
+                <line/>
+            </geometry>
+        </planView>
+        <lanes>
+            <laneOffset s="0.0000000000000000e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneSection s="0.0000000000000000e+0">
+                <left>
+                    <lane id="2" type="shoulder" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="5.0000000000000000e-1" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                    <lane id="1" type="driving" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                        <roadMark sOffset="4.4877696720496925e+0" type="solid" material="standard" color="white" width="1.2500000000000000e-1" laneChange="none"/>
+                        <roadMark sOffset="3.9050502546448293e+1" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="solid" material="standard" color="yellow" width="1.2500000000000000e-1" laneChange="none"/>
+                        <roadMark sOffset="3.8365165575274894e+1" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                        <roadMark sOffset="2.3526603436556837e+0" type="none" material="standard" color="white" laneChange="none"/>
+                        <roadMark sOffset="4.9379224154918422e+0" type="solid" material="standard" color="white" width="1.2500000000000000e-1" laneChange="none"/>
+                        <roadMark sOffset="3.8365165575274894e+1" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                    <lane id="-2" type="shoulder" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="5.0000000000000000e-1" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                    <lane id="-3" type="shoulder" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="6.3499999999999979e-1" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="curb" material="standard" width="1.5239999999999998e-1" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+    </road>
+<road name="Road 16" length="4.2915550058316711e+1" id="16" junction="-1">
+        <link>
+            <predecessor elementType="junction" elementId="106"/>
+            <successor elementType="junction" elementId="741"/>
+        </link>
+        <type s="0.0000000000000000e+0" type="town">
+            <speed max="55" unit="mph"/>
+        </type>
+        <planView>
+            <geometry s="0.0000000000000000e+0" x="2.0330417730674941e+2" y="2.9882372254060658e+2" hdg="-1.5937374428464919e+0" length="4.2915550058316711e+1">
+                <line/>
+            </geometry>
+        </planView>
+        <lanes>
+            <laneOffset s="0.0000000000000000e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneSection s="0.0000000000000000e+0">
+                <left>
+                    <lane id="4" type="sidewalk" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="2.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                    <lane id="3" type="shoulder" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="6.3499999999999979e-1" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="curb" material="standard" width="1.5239999999999998e-1" laneChange="none"/>
+                    </lane>
+                    <lane id="2" type="shoulder" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="5.0000000000000000e-1" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                        <roadMark sOffset="1.4164118310560525e-2" type="none" material="standard" color="white" laneChange="none"/>
+                        <roadMark sOffset="4.2896729389617860e+1" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                    <lane id="1" type="driving" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                        <roadMark sOffset="1.3771393899020268e-3" type="solid" material="standard" color="white" width="1.2500000000000000e-1" laneChange="none"/>
+                        <roadMark sOffset="4.2915087915080818e+1" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="broken" material="standard" color="yellow" width="1.2500000000000000e-1" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="solid" material="standard" color="white" width="1.2500000000000000e-1" laneChange="none"/>
+                    </lane>
+                    <lane id="-2" type="shoulder" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="5.0000000000000000e-1" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                    <lane id="-3" type="shoulder" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="6.3499999999999979e-1" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="curb" material="standard" width="1.5239999999999998e-1" laneChange="none"/>
+                    </lane>
+                    <lane id="-4" type="sidewalk" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="2.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                    <lane id="-5" type="sidewalk" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="2.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+    </road>
+<road name="Road 51" length="2.1855432383309565e+2" id="51" junction="-1">
+        <link>
+            <predecessor elementType="junction" elementId="106"/>
+            <successor elementType="junction" elementId="773"/>
+        </link>
+        <type s="0.0000000000000000e+0" type="town">
+            <speed max="35" unit="mph"/>
+        </type>
+        <planView>
+            <geometry s="0.0000000000000000e+0" x="1.9469556960801174e+2" y="3.0942100909932282e+2" hdg="3.1390921650436159e+0" length="3.2045866387514998e+1">
+                <line/>
+            </geometry>
+            <geometry s="3.2045866387514998e+1" x="1.6264980340292053e+2" y="3.0950113933767545e+2" hdg="3.1390921650436159e+0" length="8.1890889460652602e+1">
+                <arc curvature="1.0246438953653772e-2"/>
+            </geometry>
+            <geometry s="1.1393675584816759e+2" x="8.9954996109008789e+1" y="2.7729499053955078e+2" hdg="3.9781821647626026e+0" length="8.3180077139926723e+1">
+                <arc curvature="8.7525260161350604e-3"/>
+            </geometry>
+            <geometry s="1.9711683298809433e+2" x="6.0521374368530651e+1" y="2.0145088019925041e+2" hdg="-1.5769673532256538e+0" length="2.1437490845001321e+1">
+                <line/>
+            </geometry>
+        </planView>
+        <lanes>
+            <laneOffset s="0.0000000000000000e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneSection s="0.0000000000000000e+0">
+                <left>
+                    <lane id="5" type="sidewalk" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="2.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                    <lane id="4" type="sidewalk" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="2.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                    <lane id="3" type="shoulder" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="6.3499999999999979e-1" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="curb" material="standard" width="1.5239999999999998e-1" laneChange="none"/>
+                    </lane>
+                    <lane id="2" type="shoulder" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="5.0000000000000000e-1" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                        <roadMark sOffset="2.9332782281112912e-3" type="none" material="standard" color="white" laneChange="none"/>
+                        <roadMark sOffset="2.1854551175645832e+2" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                    <lane id="1" type="driving" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                        <roadMark sOffset="9.2648956375462888e-4" type="none" material="standard" color="white" laneChange="none"/>
+                        <roadMark sOffset="2.1855258548834257e+2" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                    <lane id="-2" type="shoulder" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="5.0000000000000000e-1" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                    <lane id="-3" type="shoulder" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="6.3499999999999979e-1" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="curb" material="standard" width="1.5239999999999998e-1" laneChange="none"/>
+                    </lane>
+                    <lane id="-4" type="sidewalk" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="2.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                    <lane id="-5" type="sidewalk" level="false">
+                        <width sOffset="0.0000000000000000e+0" a="2.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+    </road>
+<road name="Road 107" length="1.6636940064684126e+1" id="107" junction="106">
+        <link>
+            <predecessor elementType="road" elementId="0" contactPoint="start"/>
+            <successor elementType="road" elementId="51" contactPoint="start"/>
+        </link>
+        <planView>
+            <geometry s="0.0000000000000000e+0" x="2.1132980814927132e+2" y="3.0962988714087493e+2" hdg="3.1312989803750186e+0" length="5.9894673724201652e-2">
+                <line/>
+            </geometry>
+            <geometry s="5.9894673724201652e-2" x="2.1126991664873015e+2" y="3.0963050366618563e+2" hdg="3.1312989803750186e+0" length="1.8570870733752365e-1">
+                <line/>
+            </geometry>
+            <geometry s="2.4560338106172530e-1" x="2.1108421778012601e+2" y="3.0963241525717308e+2" hdg="3.1312989803750186e+0" length="1.7030942421410256e-1">
+                <line/>
+            </geometry>
+            <geometry s="4.1591280527582786e-1" x="2.1091391737880065e+2" y="3.0963416833577168e+2" hdg="3.1312989803750186e+0" length="4.0661348070574288e-1">
+                <line/>
+            </geometry>
+            <geometry s="8.2252628598157074e-1" x="2.1050732544022759e+2" y="3.0963835380815061e+2" hdg="3.1312989803750186e+0" length="1.8110406373093646e-1">
+                <line/>
+            </geometry>
+            <geometry s="1.0036303497125072e+0" x="2.1032623097127882e+2" y="3.0964021800127858e+2" hdg="3.1312989803750244e+0" length="7.7364946066113065e+0">
+                <arc curvature="5.7382645177502817e-3"/>
+            </geometry>
+            <geometry s="8.7401249563238146e+0" x="2.0259091969420805e+2" y="3.0954813751134083e+2" hdg="-3.1074922743119844e+0" length="7.2382953480218309e-2">
+                <line/>
+            </geometry>
+            <geometry s="8.8125079098040331e+0" x="2.0251857882139709e+2" y="3.0954566970351470e+2" hdg="-3.1074922743119844e+0" length="7.2382953480218309e-2">
+                <line/>
+            </geometry>
+            <geometry s="8.8848908632842516e+0" x="2.0244623794858612e+2" y="3.0954320189568858e+2" hdg="-3.1074922743116673e+0" length="7.7368849665444914e+0">
+                <arc curvature="-4.7306880096120293e-3"/>
+            </geometry>
+            <geometry s="1.6621775829828742e+1" x="1.9471073379546038e+2" y="3.0942097118136678e+2" hdg="3.1390921650436159e+0" length="1.5164234855383540e-2">
+                <line/>
+            </geometry>
+        </planView>
+        <lanes>
+            <laneOffset s="0.0000000000000000e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="5.9894673724201652e-2" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="2.4560338106172530e-1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="4.1591280527582786e-1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="8.2252628598157074e-1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="1.0036303497125072e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="1.6621775829828742e+1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneSection s="0.0000000000000000e+0">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="5.9894673724201652e-2">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="2.4560338106172530e-1">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="4.1591280527582786e-1">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="8.2252628598157074e-1">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="1.0036303497125072e+0">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="1.6621775829828742e+1">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                        <roadMark sOffset="2.0460029935609469e-3" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+    </road>
+<road name="Road 114" length="1.6636710728697430e+1" id="114" junction="106">
+        <link>
+            <predecessor elementType="road" elementId="0" contactPoint="start"/>
+            <successor elementType="road" elementId="51" contactPoint="start"/>
+        </link>
+        <planView>
+            <geometry s="0.0000000000000000e+0" x="2.1132980814927132e+2" y="3.0962988714087493e+2" hdg="3.1312989803750186e+0" length="5.9894673724201652e-2">
+                <line/>
+            </geometry>
+            <geometry s="5.9894673724201652e-2" x="2.1126991664873015e+2" y="3.0963050366618563e+2" hdg="3.1312989803750186e+0" length="1.8570870733752365e-1">
+                <line/>
+            </geometry>
+            <geometry s="2.4560338106172530e-1" x="2.1108421778012601e+2" y="3.0963241525717308e+2" hdg="3.1312989803750186e+0" length="1.7030942421410256e-1">
+                <line/>
+            </geometry>
+            <geometry s="4.1591280527582786e-1" x="2.1091390312019371e+2" y="3.0963416848254974e+2" hdg="3.1312990563954832e+0" length="7.7457467197492456e+0">
+                <arc curvature="5.3312668408985776e-3"/>
+            </geometry>
+            <geometry s="8.1616595250250725e+0" x="2.0316912187663297e+2" y="3.0955397828864790e+2" hdg="3.1725936990405241e+0" length="3.6445695117927779e-1">
+                <line/>
+            </geometry>
+            <geometry s="8.5261164762043506e+0" x="2.0280484004480485e+2" y="3.0954268155182518e+2" hdg="3.1725936990405241e+0" length="3.6445695117927779e-1">
+                <line/>
+            </geometry>
+            <geometry s="8.8905734273836252e+0" x="2.0244055821297670e+2" y="3.0953138481500247e+2" hdg="3.1725936990404766e+0" length="7.7461373013138042e+0">
+                <arc curvature="-4.3249341825095135e-3"/>
+            </geometry>
+        </planView>
+        <lanes>
+            <laneOffset s="0.0000000000000000e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="5.9894673724201652e-2" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="2.4560338106172530e-1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="4.1591280527582786e-1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneSection s="0.0000000000000000e+0">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+            <laneSection s="5.9894673724201652e-2">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+            <laneSection s="2.4560338106172530e-1">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+            <laneSection s="4.1591280527582786e-1">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+        </lanes>
+    </road>
+<road name="Road 118" length="1.3385324988900463e+1" id="118" junction="106">
+        <link>
+            <predecessor elementType="road" elementId="0" contactPoint="start"/>
+            <successor elementType="road" elementId="15" contactPoint="end"/>
+        </link>
+        <planView>
+            <geometry s="0.0000000000000000e+0" x="2.1132980814927132e+2" y="3.0962988714087493e+2" hdg="3.1312989803750186e+0" length="5.9894673724201652e-2">
+                <line/>
+            </geometry>
+            <geometry s="5.9894673724201652e-2" x="2.1126991664873015e+2" y="3.0963050366618563e+2" hdg="3.1312989803750186e+0" length="1.8570870733752365e-1">
+                <line/>
+            </geometry>
+            <geometry s="2.4560338106172530e-1" x="2.1108396076522831e+2" y="3.0963241790289379e+2" hdg="3.1312989803750200e+0" length="2.4915753304518855e+0">
+                <line/>
+            </geometry>
+            <geometry s="2.7371787115136108e+0" x="2.0859251743690839e+2" y="3.0965806491220491e+2" hdg="3.1312989803750142e+0" length="4.5071462068422061e+0">
+                <arc curvature="-2.3135254753754025e-1"/>
+            </geometry>
+            <geometry s="7.2443249183558187e+0" x="2.0488114664286863e+2" y="3.1184092190339879e+2" hdg="2.0885592232979158e+0" length="4.8438597781660118e+0">
+                <arc curvature="-1.1162668560140271e-1"/>
+            </geometry>
+            <geometry s="1.2088184696521830e+1" x="2.0370930960456724e+2" y="3.1648028386068444e+2" hdg="1.5478552107432915e+0" length="4.9436156253601782e-1">
+                <line/>
+            </geometry>
+            <geometry s="1.2582546259057848e+1" x="2.0372064981576801e+2" y="3.1697451533896458e+2" hdg="1.5478552107433012e+0" length="1.4399646346848272e-1">
+                <line/>
+            </geometry>
+            <geometry s="1.2726542722526331e+1" x="2.0372395296559125e+2" y="3.1711847391179953e+2" hdg="1.5478552107433012e+0" length="9.5573213845810301e-2">
+                <line/>
+            </geometry>
+            <geometry s="1.2822115936372141e+1" x="2.0372614532946477e+2" y="3.1721402197690531e+2" hdg="1.5478552107433012e+0" length="1.3317472533891817e-1">
+                <line/>
+            </geometry>
+            <geometry s="1.2955290661711059e+1" x="2.0372920023831367e+2" y="3.1734716165919804e+2" hdg="1.5478552107433012e+0" length="4.3003432718940360e-1">
+                <line/>
+            </geometry>
+        </planView>
+        <lanes>
+            <laneOffset s="0.0000000000000000e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="5.9894673724201652e-2" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="2.4560338106172530e-1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="1.2582546259057848e+1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="1.2726542722526331e+1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="1.2822115936372141e+1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="1.2955290661711059e+1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneSection s="0.0000000000000000e+0">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+            <laneSection s="5.9894673724201652e-2">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+            <laneSection s="2.4560338106172530e-1">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+            <laneSection s="1.2582546259057848e+1">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+            <laneSection s="1.2726542722526331e+1">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+            <laneSection s="1.2822115936372141e+1">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+            <laneSection s="1.2955290661711059e+1">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+        </lanes>
+    </road>
+<road name="Road 125" length="1.3519641041379888e+1" id="125" junction="106">
+        <link>
+            <predecessor elementType="road" elementId="0" contactPoint="start"/>
+            <successor elementType="road" elementId="15" contactPoint="end"/>
+        </link>
+        <planView>
+            <geometry s="0.0000000000000000e+0" x="2.1132980814927132e+2" y="3.0962988714087487e+2" hdg="3.1312989803750129e+0" length="2.6467412083488071e+0">
+                <line/>
+            </geometry>
+            <geometry s="2.6467412083488071e+0" x="2.0868320716364747e+2" y="3.0965713134882037e+2" hdg="-3.1518863268045716e+0" length="4.1427599830358615e+0">
+                <arc curvature="-2.0806101412927064e-1"/>
+            </geometry>
+            <geometry s="6.7895011913846677e+0" x="2.0505216521335137e+2" y="3.1137217913697123e+2" hdg="-4.0138331701691738e+0" length="4.2264377544023590e+0">
+                <arc curvature="-1.7071041103481938e-1"/>
+            </geometry>
+            <geometry s="1.1015938945787028e+1" x="2.0368162723171756e+2" y="3.1527382484387056e+2" hdg="1.5478552107433072e+0" length="2.5037020955928604e+0">
+                <line/>
+            </geometry>
+        </planView>
+        <lanes>
+            <laneOffset s="0.0000000000000000e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneSection s="0.0000000000000000e+0">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+    </road>
+<road name="Road 126" length="1.5197012769667621e+1" id="126" junction="106">
+        <link>
+            <predecessor elementType="road" elementId="0" contactPoint="start"/>
+            <successor elementType="road" elementId="16" contactPoint="start"/>
+        </link>
+        <planView>
+            <geometry s="0.0000000000000000e+0" x="2.1132980814927132e+2" y="3.0962988714087493e+2" hdg="3.1312989803750186e+0" length="5.9894673724201652e-2">
+                <line/>
+            </geometry>
+            <geometry s="5.9894673724201652e-2" x="2.1126991664873015e+2" y="3.0963050366618563e+2" hdg="3.1312989803750186e+0" length="1.8570870733752365e-1">
+                <line/>
+            </geometry>
+            <geometry s="2.4560338106172530e-1" x="2.1108421778012601e+2" y="3.0963241525717308e+2" hdg="3.1312989803750186e+0" length="1.7030942421410256e-1">
+                <line/>
+            </geometry>
+            <geometry s="4.1591280527582786e-1" x="2.1091391737880065e+2" y="3.0963416833577168e+2" hdg="3.1312989803750186e+0" length="4.0661348070574288e-1">
+                <line/>
+            </geometry>
+            <geometry s="8.2252628598157074e-1" x="2.1050732544022759e+2" y="3.0963835380815067e+2" hdg="3.1312989803750098e+0" length="6.2367021210626987e+0">
+                <arc curvature="1.7601799182930900e-1"/>
+            </geometry>
+            <geometry s="7.0592284070442695e+0" x="2.0541834992676976e+2" y="3.0659760129483431e+2" hdg="-2.0541145438175183e+0" length="4.4073164013965310e-1">
+                <line/>
+            </geometry>
+            <geometry s="7.4999600471839223e+0" x="2.0521353317644878e+2" y="3.0620735204447226e+2" hdg="-2.0541145438176680e+0" length="8.7411751849831257e-2">
+                <line/>
+            </geometry>
+            <geometry s="7.5873717990337530e+0" x="2.0517291119853024e+2" y="3.0612995263057627e+2" hdg="4.2290707633620688e+0" length="7.5195602968584359e+0">
+                <arc curvature="6.1220921177824524e-2"/>
+            </geometry>
+            <geometry s="1.5106932095892189e+1" x="2.0330624367667608e+2" y="2.9891377951092630e+2" hdg="-1.5937374428464919e+0" length="9.0080673775432274e-2">
+                <line/>
+            </geometry>
+        </planView>
+        <lanes>
+            <laneOffset s="0.0000000000000000e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="5.9894673724201652e-2" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="2.4560338106172530e-1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="4.1591280527582786e-1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="8.2252628598157074e-1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="1.5106932095892189e+1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneSection s="0.0000000000000000e+0">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="5.9894673724201652e-2">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="2.4560338106172530e-1">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="4.1591280527582786e-1">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="8.2252628598157074e-1">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="1.5106932095892189e+1">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                        <roadMark sOffset="1.9259102097777259e-3" type="broken" material="standard" color="yellow" width="1.2500000000000000e-1" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="solid" material="standard" color="white" width="1.2500000000000000e-1" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+    </road>
+<road name="Road 132" length="1.5747978458763999e+1" id="132" junction="106">
+        <link>
+            <predecessor elementType="road" elementId="0" contactPoint="start"/>
+            <successor elementType="road" elementId="16" contactPoint="start"/>
+        </link>
+        <planView>
+            <geometry s="0.0000000000000000e+0" x="2.1132980814927132e+2" y="3.0962988714087493e+2" hdg="3.1312989803750186e+0" length="5.9894673724201652e-2">
+                <line/>
+            </geometry>
+            <geometry s="5.9894673724201652e-2" x="2.1126963572088172e+2" y="3.0963050655806717e+2" hdg="3.1312989803749951e+0" length="1.2769265723580041e+0">
+                <line/>
+            </geometry>
+            <geometry s="1.3368212460822058e+0" x="2.0999277679930989e+2" y="3.0964365059079648e+2" hdg="3.1312989803750142e+0" length="5.4456007128293322e+0">
+                <arc curvature="1.6832052732408945e-1"/>
+            </geometry>
+            <geometry s="6.7824219589115380e+0" x="2.0525462142691032e+2" y="3.0736648138790713e+2" hdg="4.0479053639548868e+0" length="5.6594343846125774e+0">
+                <arc curvature="1.1335805961855472e-1"/>
+            </geometry>
+            <geometry s="1.2441856343524115e+1" x="2.0338001678514672e+2" y="3.0212897469655394e+2" hdg="4.6894478643331006e+0" length="3.3061221152398832e+0">
+                <line/>
+            </geometry>
+        </planView>
+        <lanes>
+            <laneOffset s="0.0000000000000000e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="5.9894673724201652e-2" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneSection s="0.0000000000000000e+0">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+            <laneSection s="5.9894673724201652e-2">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+        </lanes>
+    </road>
+<road name="Road 134" length="1.4144219029923619e+1" id="134" junction="106">
+        <link>
+            <predecessor elementType="road" elementId="51" contactPoint="start"/>
+            <successor elementType="road" elementId="15" contactPoint="end"/>
+        </link>
+        <planView>
+            <geometry s="0.0000000000000000e+0" x="1.9469556960801174e+2" y="3.0942100909932282e+2" hdg="-2.5004885461707982e-3" length="5.8462779057832224e+0">
+                <arc curvature="8.4601159988341126e-2"/>
+            </geometry>
+            <geometry s="5.8462779057832224e+0" x="2.0030990718213744e+2" y="3.1082353050304192e+2" hdg="4.9210140389728174e-1" length="3.8589129415842227e-1">
+                <line/>
+            </geometry>
+            <geometry s="6.2321691999416444e+0" x="2.0065000936246173e+2" y="3.1100585603017930e+2" hdg="4.9210140389731949e-1" length="6.1022197084977039e+0">
+                <arc curvature="1.7301143801423380e-1"/>
+            </geometry>
+            <geometry s="1.2334388908439349e+1" x="2.0369754127591801e+2" y="3.1596739407739341e+2" hdg="1.5478552107432981e+0" length="1.2466210689559478e+0">
+                <line/>
+            </geometry>
+            <geometry s="1.3581009977395297e+1" x="2.0372614532946477e+2" y="3.1721402197690531e+2" hdg="1.5478552107433012e+0" length="1.3317472533891817e-1">
+                <line/>
+            </geometry>
+            <geometry s="1.3714184702734215e+1" x="2.0372920023831367e+2" y="3.1734716165919804e+2" hdg="1.5478552107433012e+0" length="4.3003432718940360e-1">
+                <line/>
+            </geometry>
+        </planView>
+        <lanes>
+            <laneOffset s="0.0000000000000000e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="1.3581009977395297e+1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="1.3714184702734215e+1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneSection s="0.0000000000000000e+0">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="1.3581009977395297e+1">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="1.3714184702734215e+1">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+    </road>
+<road name="Road 137" length="1.4056819308148711e+1" id="137" junction="106">
+        <link>
+            <predecessor elementType="road" elementId="51" contactPoint="start"/>
+            <successor elementType="road" elementId="15" contactPoint="end"/>
+        </link>
+        <planView>
+            <geometry s="0.0000000000000000e+0" x="1.9469556960801174e+2" y="3.0942100909932282e+2" hdg="6.2806848186334090e+0" length="1.5164234855383540e-2">
+                <line/>
+            </geometry>
+            <geometry s="1.5164234855383540e-2" x="1.9471102333399361e+2" y="3.0942097045737756e+2" hdg="6.2806848186334054e+0" length="1.4413838035110640e+0">
+                <line/>
+            </geometry>
+            <geometry s="1.4565480383664475e+0" x="1.9615240263142201e+2" y="3.0941736629744202e+2" hdg="6.2806848186334090e+0" length="6.0199371176699943e+0">
+                <arc curvature="1.3867956120344097e-1"/>
+            </geometry>
+            <geometry s="7.4764851560364427e+0" x="2.0150294034402208e+2" y="3.1177424578335751e+2" hdg="8.3234174940464545e-1" length="2.1776022206000800e-1">
+                <line/>
+            </geometry>
+            <geometry s="7.6942453780964506e+0" x="2.0164952473616259e+2" y="3.1193528158773785e+2" hdg="8.3234174940460726e-1" length="5.7037916636781283e+0">
+                <arc curvature="1.2544523073924640e-1"/>
+            </geometry>
+            <geometry s="1.3398037041774579e+1" x="2.0372395296559125e+2" y="3.1711847391179953e+2" hdg="1.5478552107433012e+0" length="9.5573213845810301e-2">
+                <line/>
+            </geometry>
+            <geometry s="1.3493610255620389e+1" x="2.0372614532946477e+2" y="3.1721402197690531e+2" hdg="1.5478552107433012e+0" length="1.3317472533891817e-1">
+                <line/>
+            </geometry>
+            <geometry s="1.3626784980959307e+1" x="2.0372920023831367e+2" y="3.1734716165919804e+2" hdg="1.5478552107433012e+0" length="4.3003432718940360e-1">
+                <line/>
+            </geometry>
+        </planView>
+        <lanes>
+            <laneOffset s="0.0000000000000000e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="1.5164234855383540e-2" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="1.3398037041774579e+1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="1.3493610255620389e+1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="1.3626784980959307e+1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneSection s="0.0000000000000000e+0">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                        <roadMark sOffset="1.3118231861822593e-2" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+            <laneSection s="1.5164234855383540e-2">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+            <laneSection s="1.3398037041774579e+1">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+            <laneSection s="1.3493610255620389e+1">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+            <laneSection s="1.3626784980959307e+1">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+        </lanes>
+    </road>
+<road name="Road 142" length="1.5343626921787644e+1" id="142" junction="106">
+        <link>
+            <predecessor elementType="road" elementId="51" contactPoint="start"/>
+            <successor elementType="road" elementId="16" contactPoint="start"/>
+        </link>
+        <planView>
+            <geometry s="0.0000000000000000e+0" x="1.9469556960801174e+2" y="3.0942100909932282e+2" hdg="-2.5004885462278637e-3" length="2.9748651164277212e-1">
+                <line/>
+            </geometry>
+            <geometry s="2.9748651164277212e-1" x="1.9499305518964627e+2" y="3.0942026523848295e+2" hdg="-2.5004885461803461e-3" length="7.2265983487919998e+0">
+                <arc curvature="-1.3260387906875634e-1"/>
+            </geometry>
+            <geometry s="7.5240848604347716e+0" x="2.0115528501838085e+2" y="3.0619930130385518e+2" hdg="-9.6077546206786957e-1" length="7.5722249901494481e+0">
+                <arc curvature="-8.3589959569614791e-2"/>
+            </geometry>
+            <geometry s="1.5096309850584220e+1" x="2.0330985956443217e+2" y="2.9907136789436595e+2" hdg="-1.5937374428464066e+0" length="1.5723639742799200e-1">
+                <line/>
+            </geometry>
+            <geometry s="1.5253546248012212e+1" x="2.0330624367667608e+2" y="2.9891377951092630e+2" hdg="-1.5937374428464919e+0" length="9.0080673775432274e-2">
+                <line/>
+            </geometry>
+        </planView>
+        <lanes>
+            <laneOffset s="0.0000000000000000e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="1.5253546248012212e+1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneSection s="0.0000000000000000e+0">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="1.5253546248012212e+1">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                        <roadMark sOffset="1.9259102097777259e-3" type="broken" material="standard" color="yellow" width="1.2500000000000000e-1" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="solid" material="standard" color="white" width="1.2500000000000000e-1" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+    </road>
+<road name="Road 144" length="1.5273403236304720e+1" id="144" junction="106">
+        <link>
+            <predecessor elementType="road" elementId="51" contactPoint="start"/>
+            <successor elementType="road" elementId="16" contactPoint="start"/>
+        </link>
+        <planView>
+            <geometry s="0.0000000000000000e+0" x="1.9469556960801174e+2" y="3.0942100909932282e+2" hdg="6.2806848186334090e+0" length="1.5164234855383540e-2">
+                <line/>
+            </geometry>
+            <geometry s="1.5164234855383540e-2" x="1.9471113250676282e+2" y="3.0942097018439171e+2" hdg="6.2806848186336035e+0" length="1.1487419415433742e-1">
+                <line/>
+            </geometry>
+            <geometry s="1.3003842900972096e-1" x="1.9482600634179516e+2" y="3.0942068294308427e+2" hdg="6.2806848186334143e+0" length="7.3446612777093288e+0">
+                <arc curvature="-1.2970674390168496e-1"/>
+            </geometry>
+            <geometry s="7.4746997067190497e+0" x="2.0110094129620538e+2" y="3.0616323718843250e+2" hdg="5.3280327192409462e+0" length="7.6834306228824643e+0">
+                <arc curvature="-8.3111943902512045e-2"/>
+            </geometry>
+            <geometry s="1.5158130329601514e+1" x="2.0330682156392231e+2" y="2.9893896511487412e+2" hdg="4.6894478643331059e+0" length="1.1527290670320600e-1">
+                <line/>
+            </geometry>
+        </planView>
+        <lanes>
+            <laneOffset s="0.0000000000000000e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="1.5164234855383540e-2" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneSection s="0.0000000000000000e+0">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                        <roadMark sOffset="1.3118231861822593e-2" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+            <laneSection s="1.5164234855383540e-2">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+        </lanes>
+    </road>
+<road name="Road 156" length="1.8958348909809182e+1" id="156" junction="106">
+        <link>
+            <predecessor elementType="road" elementId="15" contactPoint="end"/>
+            <successor elementType="road" elementId="16" contactPoint="start"/>
+        </link>
+        <planView>
+            <geometry s="0.0000000000000000e+0" x="2.0373906484038528e+2" y="3.1777708282893411e+2" hdg="-1.5937374428464919e+0" length="4.3003432718940360e-1">
+                <line/>
+            </geometry>
+            <geometry s="4.3003432718940360e-1" x="2.0372920023831367e+2" y="3.1734716165919809e+2" hdg="-1.5937374428464919e+0" length="1.3317472533891817e-1">
+                <line/>
+            </geometry>
+            <geometry s="5.6320905252832176e-1" x="2.0372614532946474e+2" y="3.1721402197690531e+2" hdg="-1.5937374428464919e+0" length="9.5573213845810301e-2">
+                <line/>
+            </geometry>
+            <geometry s="6.5878226637413206e-1" x="2.0372395296559125e+2" y="3.1711847391179953e+2" hdg="-1.5937374428464919e+0" length="1.4399646346848272e-1">
+                <line/>
+            </geometry>
+            <geometry s="8.0277872984261478e-1" x="2.0372064981576801e+2" y="3.1697451533896458e+2" hdg="-1.5937374428464919e+0" length="1.9792382180504120e-1">
+                <line/>
+            </geometry>
+            <geometry s="1.0007025516476560e+0" x="2.0371610962067393e+2" y="3.1677664359801497e+2" hdg="-1.5937374428464919e+0" length="5.8805999970386438e+0">
+                <line/>
+            </geometry>
+            <geometry s="6.8813025486862998e+0" x="2.0358121392689924e+2" y="3.1089759099772539e+2" hdg="-1.5937374428464919e+0" length="3.0002723192978920e-5">
+                <line/>
+            </geometry>
+            <geometry s="6.8813325514094927e+0" x="2.0358121323866365e+2" y="3.1089756100289696e+2" hdg="-1.5937374428464919e+0" length="1.0815920841511968e+0">
+                <line/>
+            </geometry>
+            <geometry s="7.9629246355606895e+0" x="2.0355640248556938e+2" y="3.0981625352441108e+2" hdg="-1.5937374428464919e+0" length="1.0905343600473060e+1">
+                <line/>
+            </geometry>
+            <geometry s="1.8868268236033749e+1" x="2.0330624367667608e+2" y="2.9891377951092630e+2" hdg="-1.5937374428464919e+0" length="9.0080673775432274e-2">
+                <line/>
+            </geometry>
+        </planView>
+        <lanes>
+            <laneOffset s="0.0000000000000000e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="4.3003432718940360e-1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="5.6320905252832176e-1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="6.5878226637413206e-1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="8.0277872984261478e-1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="1.0007025516476560e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="6.8813025486862998e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="6.8813325514094927e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="7.9629246355606895e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="1.8868268236033749e+1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneSection s="0.0000000000000000e+0">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+            <laneSection s="4.3003432718940360e-1">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+            <laneSection s="5.6320905252832176e-1">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+            <laneSection s="6.5878226637413206e-1">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+            <laneSection s="8.0277872984261478e-1">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+            <laneSection s="1.0007025516476560e+0">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                        <roadMark sOffset="3.5240079851866071e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+            <laneSection s="6.8813025486862998e+0">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+            <laneSection s="6.8813325514094927e+0">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+            <laneSection s="7.9629246355606895e+0">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                        <roadMark sOffset="3.5623519273001136e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+            <laneSection s="1.8868268236033749e+1">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                        <roadMark sOffset="1.9259102097777259e-3" type="broken" material="standard" color="yellow" width="1.2500000000000000e-1" laneChange="none"/>
+                    </lane>
+                </center>
+            </laneSection>
+        </lanes>
+    </road>
+<road name="Road 157" length="1.8958348909809182e+1" id="157" junction="106">
+        <link>
+            <predecessor elementType="road" elementId="15" contactPoint="end"/>
+            <successor elementType="road" elementId="16" contactPoint="start"/>
+        </link>
+        <planView>
+            <geometry s="0.0000000000000000e+0" x="2.0373906484038528e+2" y="3.1777708282893411e+2" hdg="-1.5937374428464919e+0" length="4.3003432718940360e-1">
+                <line/>
+            </geometry>
+            <geometry s="4.3003432718940360e-1" x="2.0372920023831367e+2" y="3.1734716165919809e+2" hdg="-1.5937374428464919e+0" length="1.3317472533891817e-1">
+                <line/>
+            </geometry>
+            <geometry s="5.6320905252832176e-1" x="2.0372614532946474e+2" y="3.1721402197690531e+2" hdg="-1.5937374428464919e+0" length="9.5573213845810301e-2">
+                <line/>
+            </geometry>
+            <geometry s="6.5878226637413206e-1" x="2.0372395296559125e+2" y="3.1711847391179953e+2" hdg="-1.5937374428464919e+0" length="1.4399646346848272e-1">
+                <line/>
+            </geometry>
+            <geometry s="8.0277872984261478e-1" x="2.0372064981576801e+2" y="3.1697451533896458e+2" hdg="-1.5937374428464919e+0" length="1.9792382180504120e-1">
+                <line/>
+            </geometry>
+            <geometry s="1.0007025516476560e+0" x="2.0371610962067393e+2" y="3.1677664359801497e+2" hdg="-1.5937374428464919e+0" length="5.8805999970386438e+0">
+                <line/>
+            </geometry>
+            <geometry s="6.8813025486862998e+0" x="2.0358121392689924e+2" y="3.1089759099772539e+2" hdg="-1.5937374428464919e+0" length="3.0002723192978920e-5">
+                <line/>
+            </geometry>
+            <geometry s="6.8813325514094927e+0" x="2.0358121323866365e+2" y="3.1089756100289696e+2" hdg="-1.5937374428464919e+0" length="1.0815920841511968e+0">
+                <line/>
+            </geometry>
+            <geometry s="7.9629246355606895e+0" x="2.0355640248556938e+2" y="3.0981625352441108e+2" hdg="-1.5937374428464919e+0" length="1.0905343600473060e+1">
+                <line/>
+            </geometry>
+            <geometry s="1.8868268236033749e+1" x="2.0330624367667608e+2" y="2.9891377951092630e+2" hdg="-1.5937374428464919e+0" length="9.0080673775432274e-2">
+                <line/>
+            </geometry>
+        </planView>
+        <lanes>
+            <laneOffset s="0.0000000000000000e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="4.3003432718940360e-1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="5.6320905252832176e-1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="6.5878226637413206e-1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="8.0277872984261478e-1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="1.0007025516476560e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="6.8813025486862998e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="6.8813325514094927e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="7.9629246355606895e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneOffset s="1.8868268236033749e+1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+            <laneSection s="0.0000000000000000e+0">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="4.3003432718940360e-1">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="5.6320905252832176e-1">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="6.5878226637413206e-1">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="8.0277872984261478e-1">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="1.0007025516476560e+0">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                        <roadMark sOffset="3.9505227601634871e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="6.8813025486862998e+0">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="6.8813325514094927e+0">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="7.9629246355606895e+0">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                        <roadMark sOffset="1.0817734249773508e+1" type="solid" material="standard" color="white" width="1.2500000000000000e-1" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="1.8868268236033749e+1">
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
+                        <roadMark sOffset="1.9259102097777259e-3" type="broken" material="standard" color="yellow" width="1.2500000000000000e-1" laneChange="none"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1"/>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
+                        <roadMark sOffset="0.0000000000000000e+0" type="solid" material="standard" color="white" width="1.2500000000000000e-1" laneChange="none"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+    </road>
+    <junction id="106" name="junction106">
+        <connection id="0" incomingRoad="0" connectingRoad="107" contactPoint="start">
+            <laneLink from="1" to="-1"/>
+        </connection>
+        <connection id="1" incomingRoad="51" connectingRoad="114" contactPoint="end">
+            <laneLink from="1" to="1"/>
+        </connection>
+        <connection id="2" incomingRoad="15" connectingRoad="118" contactPoint="end">
+            <laneLink from="-1" to="1"/>
+        </connection>
+        <connection id="3" incomingRoad="0" connectingRoad="125" contactPoint="start">
+            <laneLink from="1" to="-1"/>
+        </connection>
+        <connection id="4" incomingRoad="0" connectingRoad="126" contactPoint="start">
+            <laneLink from="1" to="-1"/>
+        </connection>
+        <connection id="5" incomingRoad="16" connectingRoad="132" contactPoint="end">
+            <laneLink from="1" to="1"/>
+        </connection>
+        <connection id="6" incomingRoad="51" connectingRoad="134" contactPoint="start">
+            <laneLink from="1" to="-1"/>
+        </connection>
+        <connection id="7" incomingRoad="15" connectingRoad="137" contactPoint="end">
+            <laneLink from="-1" to="1"/>
+        </connection>
+        <connection id="8" incomingRoad="51" connectingRoad="142" contactPoint="start">
+            <laneLink from="1" to="-1"/>
+        </connection>
+        <connection id="9" incomingRoad="16" connectingRoad="144" contactPoint="end">
+            <laneLink from="1" to="1"/>
+        </connection>
+        <connection id="10" incomingRoad="16" connectingRoad="156" contactPoint="end">
+            <laneLink from="1" to="1"/>
+        </connection>
+        <connection id="11" incomingRoad="15" connectingRoad="157" contactPoint="start">
+            <laneLink from="-1" to="-1"/>
+        </connection>
+    </junction>
+</OpenDRIVE>

--- a/packages/drawtonomy-sdk/scripts/extract-junction-fixture.py
+++ b/packages/drawtonomy-sdk/scripts/extract-junction-fixture.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Extract a self-contained xodr slice from Town04 for the sliver regression.
+
+Pulls junction 106 with its connecting roads (incl. road 107) and the linked
+mainlines, closing one hop of road-level links so the welded contact clusters
+that collapse the sliver are present. Output is a few-road, ~100 KB xodr that
+still reproduces the degenerate-sliver collapse on import.
+
+Usage: python3 extractJunction.py <town04.xodr> [out.xodr]
+  <town04.xodr> is a full CARLA Town04 source (MIT-licensed). Pass the source
+  path explicitly; it is not vendored in this repo.
+"""
+import re
+import sys
+
+if len(sys.argv) < 2:
+    sys.exit("usage: extractJunction.py <town04.xodr> [out.xodr]")
+SRC = sys.argv[1]
+
+xml = open(SRC, encoding="utf-8").read()
+
+# Index every <road ...> ... </road> block by id.
+road_blocks = {}
+for m in re.finditer(r'<road\b[^>]*\bid="([^"]+)"[^>]*>.*?</road>', xml, re.S):
+    road_blocks[m.group(1)] = m.group(0)
+
+def links_of(block):
+    ids = set()
+    for mm in re.finditer(r'element(?:Type)?="road"\s+elementId="([^"]+)"', block):
+        ids.add(mm.group(1))
+    for mm in re.finditer(r'<(?:predecessor|successor)\b[^>]*elementId="([^"]+)"[^>]*elementType="road"', block):
+        ids.add(mm.group(1))
+    return ids
+
+# Pull the whole junction 106: every connecting road + every incoming road,
+# then transitively close one hop of road-level links so all welded contacts
+# are present (this is what reshapes the clusters that collapse the sliver).
+jm = re.search(r'<junction\b[^>]*\bid="106"[^>]*>.*?</junction>', xml, re.S)
+jb = jm.group(0)
+junction_min = "    " + jb
+
+wanted = set()
+for mm in re.finditer(r'connectingRoad="([^"]+)"', jb):
+    wanted.add(mm.group(1))
+for mm in re.finditer(r'incomingRoad="([^"]+)"', jb):
+    wanted.add(mm.group(1))
+
+# One hop of road-link closure so predecessor/successor mainlines are present.
+frontier = set(wanted)
+for _ in range(1):
+    nxt = set()
+    for rid in list(frontier):
+        if rid in road_blocks:
+            for l in links_of(road_blocks[rid]):
+                if l not in wanted and l in road_blocks:
+                    nxt.add(l)
+    wanted |= nxt
+    frontier = nxt
+    if not nxt:
+        break
+wanted = {r for r in wanted if r in road_blocks}
+
+header_m = re.search(r'<header\b.*?</header>', xml, re.S)
+header = header_m.group(0)
+
+ordered = sorted(wanted, key=lambda r: int(r) if r.lstrip("-").isdigit() else 1 << 30)
+
+def slim(block):
+    # Strip sub-elements that do not affect 2D lane geometry / connectivity:
+    # elevation/lateral profiles (flattened on import anyway) and RoadRunner
+    # <userData>. Keeps planView + lanes + links intact.
+    for tag in ("elevationProfile", "lateralProfile", "userData"):
+        block = re.sub(rf"\s*<{tag}\b.*?</{tag}>", "", block, flags=re.S)
+        block = re.sub(rf"\s*<{tag}\b[^>]*/>", "", block, flags=re.S)
+    block = re.sub(r"\n\s*\n", "\n", block)
+    return block
+
+header = slim(header)
+out = ['<?xml version="1.0" encoding="UTF-8"?>', "<OpenDRIVE>", "    " + header]
+for rid in ordered:
+    out.append(slim(road_blocks[rid]))
+out.append(junction_min)
+out.append("</OpenDRIVE>")
+result = "\n".join(out)
+
+import os
+dst = (
+    sys.argv[2]
+    if len(sys.argv) > 2
+    else os.path.join(
+        os.path.dirname(__file__), "..", "__tests__", "fixtures", "town04-junction106.xodr"
+    )
+)
+open(dst, "w", encoding="utf-8").write(result)
+print(f"wrote {dst}  ({len(result)} bytes)  roads={ordered}")

--- a/packages/drawtonomy-sdk/src/exporter/odrToShapes.ts
+++ b/packages/drawtonomy-sdk/src/exporter/odrToShapes.ts
@@ -1933,6 +1933,7 @@ function removeOrphanLinestrings(result: ImportedShapes): void {
     used.add(lane.rightBoundaryId)
   }
   for (const tl of result.trafficLights) if (tl.stopLineId) used.add(tl.stopLineId)
+  for (const ts of result.trafficSigns) if (ts.stopLineId) used.add(ts.stopLineId)
   for (const cw of result.crosswalks) if (cw.stopLineId) used.add(cw.stopLineId)
   if (used.size === result.linestrings.length) return
   result.linestrings = result.linestrings.filter(l => used.has(l.id as string))

--- a/packages/drawtonomy-sdk/src/exporter/odrToShapes.ts
+++ b/packages/drawtonomy-sdk/src/exporter/odrToShapes.ts
@@ -1019,6 +1019,76 @@ export function odrToShapes(map: OdrMap, options: OdrToShapesOptions = {}): OdrI
   }
 
   /**
+   * Drop wedge-shaped sliver lanes whose inner boundary has collapsed to a
+   * point. Generated junction maps (e.g. CARLA towns) route turns through
+   * short lane sections whose inner edge converges on the corner; after weld,
+   * one boundary degenerates to a single coincident pair of endpoints. Such a
+   * triangle cannot be expressed by OpenDRIVE's offset-along-normal width
+   * model (its apex is displaced longitudinally, not laterally, so the width
+   * collapses to zero) and the exporter would silently drop it, losing the
+   * lane round-trip. The sliver carries no usable area and only chains
+   * connectivity (every one has a full-size sibling lane that already covers
+   * the maneuver), so it is removed and its `prev`/`next` are stitched
+   * directly, bridging the connection across it.
+   */
+  function pruneDegenerateSliverLanes(): void {
+    const lsById = new Map(result.linestrings.map(l => [l.id as string, l]))
+    const ptById = new Map(result.points.map(p => [p.id as string, p]))
+    const boundaryLengthM = (lsId: string): number => {
+      const ls = lsById.get(lsId)
+      if (!ls) return 0
+      let total = 0
+      for (let i = 1; i < ls.pointIds.length; i++) {
+        const a = ptById.get(ls.pointIds[i - 1])
+        const b = ptById.get(ls.pointIds[i])
+        if (a && b) total += Math.hypot(a.x - b.x, a.y - b.y)
+      }
+      return total / PIXELS_PER_METER
+    }
+    // A boundary shorter than this (m) counts as collapsed. The shortest
+    // legitimate boundary in practice clears the micro-section threshold by an
+    // order of magnitude, so this only ever catches true point-collapses.
+    const SLIVER_EPS_M = 0.05
+    const degenerate = result.lanes.filter(
+      lane =>
+        boundaryLengthM(lane.leftBoundaryId) < SLIVER_EPS_M ||
+        boundaryLengthM(lane.rightBoundaryId) < SLIVER_EPS_M
+    )
+    if (degenerate.length === 0) return
+
+    const removedIds = new Set(degenerate.map(l => l.id as string))
+    // Stitch connectivity across each removed sliver: every predecessor links
+    // directly to every successor.
+    for (const lane of degenerate) {
+      for (const fromId of lane.prev) {
+        if (removedIds.has(fromId)) continue
+        for (const toId of lane.next) {
+          if (removedIds.has(toId)) continue
+          connect(fromId, toId)
+        }
+      }
+    }
+    // Drop the slivers from the lane list, every lane's next/prev, and the
+    // registries the carry-through hash builder reads.
+    result.lanes = result.lanes.filter(l => !removedIds.has(l.id as string))
+    for (const lane of result.lanes) {
+      lane.next = lane.next.filter(id => !removedIds.has(id))
+      lane.prev = lane.prev.filter(id => !removedIds.has(id))
+    }
+    for (const lane of degenerate) laneShapeById.delete(lane.id as string)
+    // Purge the slivers from laneRegistry / lanesByRoad (keyed by road/section).
+    for (const [roadId, regs] of lanesByRoad) {
+      const kept = regs.filter(r => !removedIds.has(r.shapeId))
+      if (kept.length !== regs.length) lanesByRoad.set(roadId, kept)
+      for (const r of regs) {
+        if (removedIds.has(r.shapeId)) {
+          laneRegistry.delete(registryKey(r.roadId, r.sectionIdx, r.odrLaneId))
+        }
+      }
+    }
+  }
+
+  /**
    * Registered lanes at a road's start (first section) or end (last
    * section). When the outermost section is a skipped micro section, the
    * lane reference is resolved through it along the lane-level links to the
@@ -1309,6 +1379,8 @@ export function odrToShapes(map: OdrMap, options: OdrToShapesOptions = {}): OdrI
   //    shared-node connection detection both depend on this).
   dedupeSharedBoundaries(result)
   weldConnectedLaneContacts(result)
+  pruneDegenerateSliverLanes()
+  removeOrphanLinestrings(result)
   removeOrphanPoints(result)
 
   // ---- Carry-through records ----
@@ -1848,6 +1920,22 @@ function weldConnectedLaneContacts(result: ImportedShapes): void {
       lane.y = ls.y
     }
   }
+}
+
+/**
+ * Drop linestrings that no lane references (boundaries orphaned by sliver-lane
+ * pruning). Run before `removeOrphanPoints` so their points are freed too.
+ */
+function removeOrphanLinestrings(result: ImportedShapes): void {
+  const used = new Set<string>()
+  for (const lane of result.lanes) {
+    used.add(lane.leftBoundaryId)
+    used.add(lane.rightBoundaryId)
+  }
+  for (const tl of result.trafficLights) if (tl.stopLineId) used.add(tl.stopLineId)
+  for (const cw of result.crosswalks) if (cw.stopLineId) used.add(cw.stopLineId)
+  if (used.size === result.linestrings.length) return
+  result.linestrings = result.linestrings.filter(l => used.has(l.id as string))
 }
 
 /** Drop Point records no longer referenced by any linestring. */


### PR DESCRIPTION

<img width="1500" height="854" alt="issue494lanes" src="https://github.com/user-attachments/assets/39334dcd-2c37-4dcb-a35a-77117c623864" />

<img width="1178" height="664" alt="image" src="https://github.com/user-attachments/assets/0516f44d-86e4-42b9-b55a-f6fedef3009c" />



## Problem

Generated junction maps (e.g. CARLA towns) route turns through chains of
centimetre-scale lane sections. After the importer welds connected boundary
endpoints, a sub-half-metre section's inner boundary collapses onto a single
point — a wedge-shaped **sliver lane** with a zero-length boundary.

Such a triangle cannot be represented by OpenDRIVE's offset-along-normal width
model: its apex is displaced longitudinally, not laterally, so the lane width
collapses to zero and the exporter silently drops it. The lane is then lost on
an import → export round trip. On a CARLA Town04 round trip this lost **26 of
904 lanes**, and left contact-point gaps that an ASAM quality checker flags.

## Fix

Add `pruneDegenerateSliverLanes()` to the import post-processing
(`odrToShapes.ts`):

- Remove lanes whose left or right boundary arc length collapses below 5 cm.
- Stitch each removed sliver's `prev`/`next` directly so connectivity survives
  the bridge (every sliver has a full-size sibling lane already covering the
  maneuver, so nothing drivable is lost).
- Clean up the orphaned boundary linestrings and points.

The 5 cm threshold is well separated from legitimate geometry — the shortest
real boundary clears it by an order of magnitude — so non-degenerate maps are
untouched and the prune is a no-op for them.

## Result

- Town04 round trip: lanes **904 → 878 → 878** (no lanes dropped; the 26
  degenerate slivers are pruned on import and the round trip is lossless).
- Full suite green (263 passed), existing fixtures (fabriksgatan, two_plus_one,
  synthetic, diamond) unaffected — none carry zero-length boundaries.
- O(n) single pass, no measurable export slowdown.

## Tests

- `__tests__/exporter/degenerateSliverPrune.test.ts` — asserts no zero-length
  boundary survives import, the round trip drops no lanes, and connectivity is
  bridged across every pruned sliver.
- `__tests__/fixtures/town04-junction106.xodr` — a self-contained slice of CARLA
  Town04 (one junction with its connecting roads + mainlines) that reproduces
  the collapse. The sliver is an emergent property of the whole junction's weld
  topology, so it cannot be reproduced with a hand-written minimal map; the
  slice is extracted with `scripts/extract-junction-fixture.py`.