### PR TITLE
docs(readme): consolidate Lanelet2 & OpenDRIVE into Import/Export sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,25 +157,19 @@ Place typeset LaTeX equations anywhere on the canvas with the `fx` tool. The sou
 
 <video src="https://github.com/user-attachments/assets/66365b83-4d74-4502-a204-cd9e09ae292b" width="80%" controls></video>
 
-#### [Lanelet2](https://github.com/fzi-forschungszentrum-informatik/Lanelet2) Import
+#### [Lanelet2](https://github.com/fzi-forschungszentrum-informatik/Lanelet2) Import / Export
 
-Import Lanelet2 OSM format maps for editing. Sample maps: [Autoware Documentation](https://autowarefoundation.github.io/autoware-documentation/main/demos/planning-sim/#download-the-sample-map)
+Import Lanelet2 OSM format maps for editing, and export the lanes you draw back out as a Lanelet2 OSM map. Round-trips preserve original IDs and tags. Sample maps: [Autoware Documentation](https://autowarefoundation.github.io/autoware-documentation/main/demos/planning-sim/#download-the-sample-map). You can also import only specific lanes (keep it under 500 for best performance).
 
 <video src="https://github.com/user-attachments/assets/92cf1c66-b7d4-4142-b637-7dd9eb0a156f" width="80%" controls></video>
-
-You can also select and import only specific lanes. For optimal performance, we recommend keeping the number of lanes under 500.
 
 <video src="https://github.com/user-attachments/assets/652af370-8bb6-4da4-8a5b-a798b59cf7f5" width="80%" controls></video>
 
 #### OpenDRIVE (.xodr) Import / Export
 
-Import ASAM OpenDRIVE (.xodr) maps for editing and export them back out, with lane/junction connectivity and high-fidelity round-trips (verified in esmini 3.3.0). The converter is implemented in `@drawtonomy/sdk` — see the [Exporter Developer Guide](docs/exporter.md).
+Import ASAM OpenDRIVE (.xodr) maps for editing and export them back out, with lane types, road marks, and junction connectivity preserved for high-fidelity round-trips (verified in esmini 3.3.0). The converter is implemented in `@drawtonomy/sdk` — see the [Exporter Developer Guide](docs/exporter.md).
 
 <video src="https://github.com/user-attachments/assets/84e16e91-e267-433b-9bd8-94eecf3124a8" width="80%" controls></video>
-
-#### [Lanelet2](https://github.com/fzi-forschungszentrum-informatik/Lanelet2) Export
-
-Export the lanes you draw back out as a Lanelet2 OSM map via the **`.osm (Lanelet2)`** menu item. Lane boundaries become `way` linestrings and each lane becomes a `relation type=lanelet` referencing its left/right boundary ways, so the result round-trips back into drawtonomy (or any Lanelet2-aware tool). Maps imported from OSM preserve their original IDs and tags on re-export. The exporter is implemented in `@drawtonomy/sdk` — see the [Exporter Developer Guide](docs/exporter.md).
 
 #### ROS OccupancyGrid Map Import
 


### PR DESCRIPTION
## Summary
- Merge each format's import and export docs into a single **Import / Export** section (Lanelet2, OpenDRIVE).
- Use the borderless OpenDRIVE demo video and keep both Lanelet2 demo clips.

Follow-up to the merged OpenDRIVE import docs; supersedes #78.