### PR TITLE
Carry through <roadMark> attributes on OpenDRIVE round trips

### DIFF
--- a/packages/drawtonomy-sdk/__tests__/exporter/odrToShapes.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/odrToShapes.test.ts
@@ -241,6 +241,104 @@ describe('round-trip smoke (import -> export)', () => {
   })
 })
 
+describe('roadMark carry-through', () => {
+  const TWO_LANE_WITH_MARKS = `<?xml version="1.0"?>
+<OpenDRIVE>
+  <header revMajor="1" revMinor="6"/>
+  <road name="r" length="100" id="1" junction="-1">
+    <planView><geometry s="0" x="0" y="0" hdg="0" length="100"><line/></geometry></planView>
+    <lanes>
+      <laneSection s="0">
+        <center>
+          <lane id="0" type="none" level="false">
+            <roadMark sOffset="0" type="solid solid" weight="bold" color="yellow" width="0.25"/>
+          </lane>
+        </center>
+        <right>
+          <lane id="-1" type="driving" level="false">
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+            <roadMark sOffset="0" type="broken" weight="standard" color="white" width="0.13" laneChange="both"/>
+          </lane>
+          <lane id="-2" type="driving" level="false">
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+            <roadMark sOffset="0" type="solid" weight="standard" color="white" width="0.13"/>
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
+  </road>
+</OpenDRIVE>`
+
+  it('imports roadMark type/color/weight/width into linestring attributes', () => {
+    const result = odrToShapes(parseOpenDriveXml(TWO_LANE_WITH_MARKS))
+    // 3 boundaries: center (lane id 0), shared between -1/-2, outer of -2
+    expect(result.linestrings).toHaveLength(3)
+
+    const lsById = new Map(result.linestrings.map(ls => [ls.id, ls]))
+    const [lane1, lane2] = result.lanes
+    const centerLs = lsById.get(lane1.leftBoundaryId)!
+    const sharedLs = lsById.get(lane1.rightBoundaryId)!
+    const outerLs = lsById.get(lane2.rightBoundaryId)!
+
+    expect(centerLs.attributes.odr_road_mark_type).toBe('solid solid')
+    expect(centerLs.attributes.odr_road_mark_color).toBe('yellow')
+    expect(centerLs.attributes.odr_road_mark_weight).toBe('bold')
+    expect(centerLs.attributes.odr_road_mark_width).toBe('0.25')
+
+    expect(sharedLs.attributes.odr_road_mark_type).toBe('broken')
+    expect(sharedLs.attributes.odr_road_mark_color).toBe('white')
+    expect(sharedLs.attributes.odr_road_mark_lane_change).toBe('both')
+    // subtype は描画用に潰されているはず (broken -> dashed)
+    expect(sharedLs.attributes.subtype).toBe('dashed')
+
+    expect(outerLs.attributes.odr_road_mark_type).toBe('solid')
+    expect(outerLs.attributes.subtype).toBe('solid')
+  })
+
+  it('re-exports preserved roadMark attributes for edited roads', () => {
+    const imported = odrToShapes(parseOpenDriveXml(TWO_LANE_WITH_MARKS))
+    const shapes: unknown[] = []
+    for (const p of imported.points) {
+      shapes.push({
+        id: p.id, type: 'point', x: p.x, y: p.y, rotation: 0, zIndex: 0,
+        props: { color: 'black', visible: true, osmId: p.osmId },
+      })
+    }
+    for (const ls of imported.linestrings) {
+      shapes.push({
+        id: ls.id, type: 'linestring', x: ls.x, y: ls.y, rotation: 0, zIndex: 0,
+        props: { pointIds: ls.pointIds, color: 'black', strokeWidth: 2, attributes: ls.attributes, osmId: ls.osmId },
+      })
+    }
+    for (const lane of imported.lanes) {
+      shapes.push({
+        id: lane.id, type: 'lane', x: lane.x, y: lane.y, rotation: 0, zIndex: 0,
+        props: {
+          leftBoundaryId: lane.leftBoundaryId, rightBoundaryId: lane.rightBoundaryId,
+          invertLeft: lane.invertLeft, invertRight: lane.invertRight,
+          color: 'default', size: 'm', attributes: lane.attributes,
+          next: lane.next, prev: lane.prev, osmId: lane.osmId,
+        },
+      })
+    }
+    // sidecar を渡さずに export することで未編集 carry-through ではなく
+    // fitting exporter 経路を強制する (= roadMarkElementFor を通る)。
+    const snapshot: DrawtonomySnapshot = {
+      version: '1.1',
+      timestamp: new Date().toISOString(),
+      shapes: shapes as DrawtonomySnapshot['shapes'],
+    }
+    const xml = exportToOpenDrive(snapshot)
+    // ↓ 中央線 (solid solid + yellow + bold + 0.25) が出力されているか
+    expect(xml).toContain('type="solid solid"')
+    expect(xml).toContain('color="yellow"')
+    expect(xml).toContain('weight="bold"')
+    expect(xml).toContain('width="0.25"')
+    // ↓ -1 と -2 の間 (broken + white)
+    expect(xml).toMatch(/type="broken"[^>]*color="white"/)
+  })
+})
+
 describe('round-trip smoke (import -> Lanelet2)', () => {
   it('re-imports an OpenDRIVE map exported as Lanelet2 with the same lane count', async () => {
     const { exportToLanelet2 } = await import('../../src/exporter/lanelet2')

--- a/packages/drawtonomy-sdk/__tests__/exporter/opendriveParser.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/opendriveParser.test.ts
@@ -119,6 +119,33 @@ describe('parseOpenDriveXml', () => {
     expect(sec1.right[1].widths[0].b).toBeCloseTo(-0.07, 12)
   })
 
+  it('parses roadMark weight/width/material/laneChange when present', () => {
+    const xml = `<?xml version="1.0"?>
+<OpenDRIVE>
+  <header revMajor="1" revMinor="6"/>
+  <road name="r" length="10" id="1" junction="-1">
+    <planView><geometry s="0" x="0" y="0" hdg="0" length="10"><line/></geometry></planView>
+    <lanes>
+      <laneSection s="0">
+        <right>
+          <lane id="-1" type="driving" level="false">
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+            <roadMark sOffset="0" type="solid solid" weight="bold" color="yellow" width="0.25" material="custom" laneChange="none"/>
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
+  </road>
+</OpenDRIVE>`
+    const rm = parseOpenDriveXml(xml).roads[0].laneSections[0].right[0].roadMarks[0]
+    expect(rm.type).toBe('solid solid')
+    expect(rm.weight).toBe('bold')
+    expect(rm.color).toBe('yellow')
+    expect(rm.width).toBeCloseTo(0.25, 6)
+    expect(rm.material).toBe('custom')
+    expect(rm.laneChange).toBe('none')
+  })
+
   it('flags elevation and keeps minimal signal/object records', () => {
     const road = parseOpenDriveXml(SAMPLE).roads[0]
     expect(road.hasElevation).toBe(true)

--- a/packages/drawtonomy-sdk/src/exporter/odrToShapes.ts
+++ b/packages/drawtonomy-sdk/src/exporter/odrToShapes.ts
@@ -914,17 +914,29 @@ export function odrToShapes(map: OdrMap, options: OdrToShapesOptions = {}): OdrI
         result.points.push(data)
         pointIds.push(pointId)
       })
+      const attributes: Record<string, string> = {
+        type: 'line_thin',
+        subtype: roadMarkToSubtype(rm),
+        width: '0.2',
+      }
+      // OpenDRIVE roadMark carry-through. These are read back at export time
+      // when a road has been edited (and therefore cannot be emitted verbatim),
+      // and by the app's display-mode-aware boundary color resolver.
+      if (rm) {
+        attributes.odr_road_mark_type = rm.type
+        if (rm.color !== undefined) attributes.odr_road_mark_color = rm.color
+        if (rm.weight !== undefined) attributes.odr_road_mark_weight = rm.weight
+        if (rm.width !== undefined) attributes.odr_road_mark_width = String(rm.width)
+        if (rm.material !== undefined) attributes.odr_road_mark_material = rm.material
+        if (rm.laneChange !== undefined) attributes.odr_road_mark_lane_change = rm.laneChange
+      }
       const data: ImportedLinestring = {
         id: idAllocator.next('linestring'),
         x: firstX,
         y: firstY,
         pointIds,
         osmId: '',
-        attributes: {
-          type: 'line_thin',
-          subtype: roadMarkToSubtype(rm),
-          width: '0.2',
-        },
+        attributes,
       }
       result.linestrings.push(data)
       lsCache.set(key, data)

--- a/packages/drawtonomy-sdk/src/exporter/opendrive.ts
+++ b/packages/drawtonomy-sdk/src/exporter/opendrive.ts
@@ -584,7 +584,38 @@ function odrLaneTypeFor(lane: LaneShape): string {
 function roadMarkTypeFor(shapeMap: Map<string, BaseShape>, boundaryId: string | null): string {
   if (!boundaryId) return 'solid'
   const ls = shapeMap.get(boundaryId) as unknown as LinestringShape | undefined
+  // OpenDRIVE round-trip: prefer the carry-through value captured at import.
+  const carried = ls?.props?.attributes?.odr_road_mark_type
+  if (carried) return carried
   return ls?.props?.attributes?.subtype === 'dashed' ? 'broken' : 'solid'
+}
+
+/**
+ * Emit a `<roadMark>` element for a boundary linestring. Honors carry-through
+ * attributes (`odr_road_mark_*`) so an imported road that has been edited
+ * (and therefore cannot be re-emitted verbatim) still retains its original
+ * color / weight / width information.
+ */
+function roadMarkElementFor(
+  shapeMap: Map<string, BaseShape>,
+  boundaryId: string | null
+): string {
+  const ls = boundaryId ? (shapeMap.get(boundaryId) as unknown as LinestringShape | undefined) : undefined
+  const attrs: Record<string, string | undefined> = ls?.props?.attributes ?? {}
+  const type = roadMarkTypeFor(shapeMap, boundaryId)
+  const color = attrs.odr_road_mark_color ?? 'white'
+  const weight = attrs.odr_road_mark_weight ?? 'standard'
+  const width = attrs.odr_road_mark_width ?? '0.13'
+  const parts = [
+    'sOffset="0"',
+    `type="${type}"`,
+    `weight="${weight}"`,
+    `color="${color}"`,
+    `width="${width}"`,
+  ]
+  if (attrs.odr_road_mark_material !== undefined) parts.push(`material="${attrs.odr_road_mark_material}"`)
+  if (attrs.odr_road_mark_lane_change !== undefined) parts.push(`laneChange="${attrs.odr_road_mark_lane_change}"`)
+  return `<roadMark ${parts.join(' ')}/>`
 }
 
 function emitLanes(
@@ -603,8 +634,7 @@ function emitLanes(
   lines.push(`        <center>`)
   lines.push(`          <lane id="0" type="none" level="false">`)
   lines.push(`            <link/>`)
-  const centerMark = roadMarkTypeFor(shapeMap, bundle.lanes[0].props.leftBoundaryId)
-  lines.push(`            <roadMark sOffset="0" type="${centerMark}" weight="standard" color="white" width="0.13"/>`)
+  lines.push(`            ${roadMarkElementFor(shapeMap, bundle.lanes[0].props.leftBoundaryId)}`)
   lines.push(`          </lane>`)
   lines.push(`        </center>`)
   lines.push(`        <right>`)
@@ -613,8 +643,7 @@ function emitLanes(
     lines.push(`          <lane id="${odrId}" type="${odrLaneTypeFor(lane)}" level="false">`)
     emitLaneLink(lines, plan.lanePredecessor.get(lane.id), plan.laneSuccessor.get(lane.id))
     emitWidthEntries(geom, i, lines)
-    const outerMark = roadMarkTypeFor(shapeMap, lane.props.rightBoundaryId)
-    lines.push(`            <roadMark sOffset="0" type="${outerMark}" weight="standard" color="white" width="0.13"/>`)
+    lines.push(`            ${roadMarkElementFor(shapeMap, lane.props.rightBoundaryId)}`)
     lines.push(`          </lane>`)
   })
   lines.push(`        </right>`)

--- a/packages/drawtonomy-sdk/src/exporter/opendriveParser.ts
+++ b/packages/drawtonomy-sdk/src/exporter/opendriveParser.ts
@@ -81,6 +81,10 @@ export interface OdrRoadMark {
   sOffset: number
   type: string
   color?: string
+  weight?: string
+  width?: number
+  material?: string
+  laneChange?: string
 }
 
 export interface OdrLane {
@@ -505,11 +509,18 @@ function parseLane(el: XmlNode, roadId: string): OdrLane {
     d: numAttr(w, 'd', 0),
   }))
   widths.sort((a, b) => a.sOffset - b.sOffset)
-  const roadMarks: OdrRoadMark[] = children(el, 'roadMark').map(rm => ({
-    sOffset: numAttr(rm, 'sOffset', 0),
-    type: rm.attrs.type ?? 'none',
-    color: rm.attrs.color,
-  }))
+  const roadMarks: OdrRoadMark[] = children(el, 'roadMark').map(rm => {
+    const widthAttr = rm.attrs.width
+    return {
+      sOffset: numAttr(rm, 'sOffset', 0),
+      type: rm.attrs.type ?? 'none',
+      color: rm.attrs.color,
+      weight: rm.attrs.weight,
+      width: widthAttr !== undefined ? Number(widthAttr) : undefined,
+      material: rm.attrs.material,
+      laneChange: rm.attrs.laneChange,
+    }
+  })
   roadMarks.sort((a, b) => a.sOffset - b.sOffset)
   return {
     id,

--- a/packages/drawtonomy-sdk/src/types.ts
+++ b/packages/drawtonomy-sdk/src/types.ts
@@ -25,7 +25,7 @@ export interface LinestringProps {
   color: string
   strokeWidth: number
   opacity?: number | null
-  attributes: { type: string; subtype: string }
+  attributes: { type: string; subtype: string } & Record<string, string | undefined>
   osmId: string
   isPath?: boolean
   arrowHead?: string | null


### PR DESCRIPTION
## Summary

<img width="2940" height="1846" alt="Screenshot 2026-07-01 at 01-50-45" src="https://github.com/user-attachments/assets/c1c5fda4-84d0-4920-92df-7ec5dbd4d538" />

<img width="2940" height="1846" alt="Screenshot 2026-07-01 at 01-47-23" src="https://github.com/user-attachments/assets/157098b4-c4f8-4e25-9619-85619a1b4cdb" />


OpenDRIVE imports now preserve the full `<roadMark>` attribute set (`type`, `color`, `weight`, `width`, `material`, `laneChange`) on the resulting linestring. The exporter reads those attributes back, so an edited road keeps its original yellow center lines, bold widths, and custom materials instead of being replaced by hardcoded defaults.

Unedited roads still go through the verbatim carry-through path; this PR closes the gap for **edited** roads where the fitting exporter previously emitted `color="white" weight="standard" width="0.13"` unconditionally.

## Changes

- `opendriveParser`: parse `weight` / `width` / `material` / `laneChange`
- `odrToShapes`: inject `odr_road_mark_*` keys into the linestring attributes
- `opendrive` exporter: `roadMarkElementFor()` reads the carried values
- `types`: widen `LinestringProps.attributes` to `Record<string, string | undefined>`

## Test plan

- [x] Parser coverage for the four new attributes
- [x] `odrToShapes` carries `odr_road_mark_*` for center / shared / outer boundaries
- [x] Edited-road export emits the carried color / type / weight / width
- [x] Full SDK suite: 284 tests pass