### PR TITLE
fix(opendrive): tolerate malformed junction connections instead of failing the whole parse

### DIFF
--- a/packages/drawtonomy-sdk/__tests__/exporter/odrToShapes.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/odrToShapes.test.ts
@@ -391,3 +391,18 @@ describe('esmini sample map (fixture)', () => {
     }
   })
 })
+
+describe('junction connection tolerance (end to end)', () => {
+  it('still converts all roads when a connection lacks connectingRoad', () => {
+    // Same topology as JUNCTION_MAP, but the junction's connection record is
+    // broken (no connectingRoad/linkedRoad). The roads themselves must still
+    // import — a malformed junction record may cost connectivity, never geometry.
+    const brokenConn = JUNCTION_MAP.replace(
+      'incomingRoad="1" connectingRoad="5"',
+      'incomingRoad="1"'
+    )
+    const result = odrToShapes(parseOpenDriveXml(brokenConn))
+    expect(result.lanes).toHaveLength(3) // in / conn / out all materialize
+    expect(result.warnings.some(w => /connection/.test(w))).toBe(true)
+  })
+})

--- a/packages/drawtonomy-sdk/__tests__/exporter/opendriveParser.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/opendriveParser.test.ts
@@ -178,3 +178,87 @@ describe('parseOpenDriveXml', () => {
     expect(() => parseOpenDriveXml('<notOpenDrive/>')).toThrow(/OpenDRIVE/)
   })
 })
+
+// Junction records are topology metadata: a malformed <connection> must not
+// fail the whole document (which would prevent every road from rendering).
+const junctionXml = (connections: string) => `<?xml version="1.0"?>
+<OpenDRIVE>
+  <header revMajor="1" revMinor="7"/>
+  <road name="a" length="50" id="1" junction="-1">
+    <link><successor elementType="junction" elementId="8"/></link>
+    <planView><geometry s="0" x="0" y="0" hdg="0" length="50"><line/></geometry></planView>
+    <lanes><laneSection s="0"><right>
+      <lane id="-1" type="driving" level="false"><width sOffset="0" a="3.5" b="0" c="0" d="0"/></lane>
+    </right></laneSection></lanes>
+  </road>
+  <road name="b" length="50" id="2" junction="-1">
+    <link><predecessor elementType="junction" elementId="8"/></link>
+    <planView><geometry s="0" x="50" y="0" hdg="0" length="50"><line/></geometry></planView>
+    <lanes><laneSection s="0"><right>
+      <lane id="-1" type="driving" level="false"><width sOffset="0" a="3.5" b="0" c="0" d="0"/></lane>
+    </right></laneSection></lanes>
+  </road>
+  <junction id="8" name="j">${connections}</junction>
+</OpenDRIVE>`
+
+describe('junction connection tolerance', () => {
+  it('parses a direct connection that uses linkedRoad instead of connectingRoad', () => {
+    const map = parseOpenDriveXml(
+      junctionXml(`<connection id="0" type="direct" incomingRoad="1" linkedRoad="2" contactPoint="start">
+        <laneLink from="-1" to="-1"/>
+      </connection>`)
+    )
+    expect(map.warnings).toEqual([])
+    const conn = map.junctions[0].connections[0]
+    expect(conn.connectingRoad).toBe('2')
+    expect(conn.linkedRoad).toBe('2')
+    expect(conn.type).toBe('direct')
+    expect(conn.laneLinks).toEqual([{ from: -1, to: -1 }])
+  })
+
+  it('skips a connection missing both connectingRoad and linkedRoad, with a warning', () => {
+    const map = parseOpenDriveXml(
+      junctionXml(`<connection id="0" incomingRoad="1" contactPoint="start">
+        <laneLink from="-1" to="-1"/>
+      </connection>
+      <connection id="1" incomingRoad="1" connectingRoad="2" contactPoint="start">
+        <laneLink from="-1" to="-1"/>
+      </connection>`)
+    )
+    // The broken connection is dropped; the healthy sibling survives.
+    expect(map.junctions[0].connections).toHaveLength(1)
+    expect(map.junctions[0].connections[0].connectingRoad).toBe('2')
+    expect(map.warnings).toHaveLength(1)
+    expect(map.warnings[0]).toMatch(/Junction 8, connection 0/)
+    expect(map.warnings[0]).toMatch(/connectingRoad\/linkedRoad/)
+  })
+
+  it('skips a connection missing incomingRoad, with a warning', () => {
+    const map = parseOpenDriveXml(
+      junctionXml(`<connection id="0" connectingRoad="2" contactPoint="start"/>`)
+    )
+    expect(map.junctions[0].connections).toHaveLength(0)
+    expect(map.warnings).toHaveLength(1)
+    expect(map.warnings[0]).toMatch(/missing "incomingRoad"/)
+  })
+
+  it('skips malformed laneLink records without dropping the connection', () => {
+    const map = parseOpenDriveXml(
+      junctionXml(`<connection id="0" incomingRoad="1" connectingRoad="2" contactPoint="start">
+        <laneLink from="-1"/>
+        <laneLink from="-1" to="-1"/>
+      </connection>`)
+    )
+    const conn = map.junctions[0].connections[0]
+    expect(conn.laneLinks).toEqual([{ from: -1, to: -1 }])
+    expect(map.warnings).toHaveLength(1)
+    expect(map.warnings[0]).toMatch(/laneLink/)
+  })
+
+  it('keeps classic connectingRoad connections warning-free (regression)', () => {
+    const map = parseOpenDriveXml(SAMPLE)
+    expect(map.warnings).toEqual([])
+    expect(map.junctions[0].connections[0].connectingRoad).toBe('2')
+    expect(map.junctions[0].connections[0].linkedRoad).toBeUndefined()
+  })
+})

--- a/packages/drawtonomy-sdk/src/exporter/odrToShapes.ts
+++ b/packages/drawtonomy-sdk/src/exporter/odrToShapes.ts
@@ -283,7 +283,8 @@ function poseAt(samples: ReferenceSample[], s: number): { x: number; y: number; 
  */
 export function odrToShapes(map: OdrMap, options: OdrToShapesOptions = {}): OdrImportResult {
   const idAllocator = options.idAllocator ?? createShapeIdAllocator()
-  const warnings: string[] = []
+  // Seed with non-fatal parser notes (skipped malformed junction records).
+  const warnings: string[] = [...(map.warnings ?? [])]
 
   const origin = parseGeoReferenceOrigin(map.header.geoReference)
   if (origin?.approximate) {

--- a/packages/drawtonomy-sdk/src/exporter/opendriveParser.ts
+++ b/packages/drawtonomy-sdk/src/exporter/opendriveParser.ts
@@ -201,7 +201,15 @@ export interface OdrJunctionLaneLink {
 export interface OdrJunctionConnection {
   id: string
   incomingRoad: string
+  /**
+   * Target road id: the `connectingRoad` attribute or, for OpenDRIVE 1.7+
+   * direct/virtual connections that omit it, the `linkedRoad` attribute.
+   */
   connectingRoad: string
+  /** Raw `type` attribute ("default" / "virtual" / "direct"); undefined when absent. */
+  type?: string
+  /** Set when the target road id came from the `linkedRoad` attribute. */
+  linkedRoad?: string
   contactPoint: 'start' | 'end'
   laneLinks: OdrJunctionLaneLink[]
 }
@@ -227,6 +235,11 @@ export interface OdrMap {
   junctions: OdrJunction[]
   /** Original XML, captured for sidecar/round-trip workflows. */
   rawXml: string
+  /**
+   * Non-fatal parse notes: malformed junction records that were skipped
+   * instead of failing the whole document (surfaced by `odrToShapes`).
+   */
+  warnings: string[]
 }
 
 // ---------------------------------------------------------------------------
@@ -649,21 +662,57 @@ function parseRoad(el: XmlNode): OdrRoad {
   }
 }
 
-function parseJunction(el: XmlNode): OdrJunction {
-  const id = requireStrAttr(el, 'id', '<junction>')
-  const connections: OdrJunctionConnection[] = children(el, 'connection').map(conn => {
-    const ctx = `junction ${id}, <connection>`
-    return {
-      id: conn.attrs.id ?? '',
-      incomingRoad: requireStrAttr(conn, 'incomingRoad', ctx),
-      connectingRoad: requireStrAttr(conn, 'connectingRoad', ctx),
-      contactPoint: parseContactPoint(conn.attrs.contactPoint) ?? 'start',
-      laneLinks: children(conn, 'laneLink').map(ll => ({
-        from: requireNumAttr(ll, 'from', ctx),
-        to: requireNumAttr(ll, 'to', ctx),
-      })),
+/**
+ * Parse a <junction>. Junction records are topology metadata — the roads
+ * themselves render fine without them — so malformed connections degrade
+ * gracefully: each bad record is skipped with a warning instead of failing
+ * the whole document (plan-view geometry, by contrast, stays strict because
+ * a road without valid geometry attributes cannot be drawn at all).
+ * Returns null (with a warning) when the junction has no usable id.
+ */
+function parseJunction(el: XmlNode, warnings: string[]): OdrJunction | null {
+  const id = el.attrs.id
+  if (id === undefined || id === '') {
+    warnings.push('Junction with missing id was skipped.')
+    return null
+  }
+  const connections: OdrJunctionConnection[] = []
+  for (const conn of children(el, 'connection')) {
+    const ctx = `Junction ${id}, connection ${conn.attrs.id ?? '?'}`
+    const incomingRoad = conn.attrs.incomingRoad
+    const connecting = conn.attrs.connectingRoad
+    const linked = conn.attrs.linkedRoad
+    // OpenDRIVE 1.7+ direct/virtual connections carry linkedRoad instead of
+    // connectingRoad; either attribute identifies the road to link lanes to.
+    const target = connecting !== undefined && connecting !== '' ? connecting : linked
+    if (incomingRoad === undefined || incomingRoad === '' || target === undefined || target === '') {
+      const missing =
+        incomingRoad === undefined || incomingRoad === ''
+          ? 'incomingRoad'
+          : 'connectingRoad/linkedRoad'
+      warnings.push(`${ctx}: missing "${missing}"; connection skipped.`)
+      continue
     }
-  })
+    const laneLinks: OdrJunctionLaneLink[] = []
+    for (const ll of children(conn, 'laneLink')) {
+      const from = parseFloat(ll.attrs.from ?? '')
+      const to = parseFloat(ll.attrs.to ?? '')
+      if (!Number.isFinite(from) || !Number.isFinite(to)) {
+        warnings.push(`${ctx}: malformed <laneLink>; laneLink skipped.`)
+        continue
+      }
+      laneLinks.push({ from, to })
+    }
+    connections.push({
+      id: conn.attrs.id ?? '',
+      incomingRoad,
+      connectingRoad: target,
+      ...(conn.attrs.type !== undefined ? { type: conn.attrs.type } : {}),
+      ...(connecting === undefined || connecting === '' ? { linkedRoad: target } : {}),
+      contactPoint: parseContactPoint(conn.attrs.contactPoint) ?? 'start',
+      laneLinks,
+    })
+  }
   const priorities = children(el, 'priority')
     .map(pr => ({ high: pr.attrs.high ?? '', low: pr.attrs.low ?? '' }))
     .filter(pr => pr.high !== '' && pr.low !== '')
@@ -687,7 +736,12 @@ export function parseOpenDriveXml(xmlString: string): OdrMap {
   }
 
   const roads = children(root, 'road').map(parseRoad)
-  const junctions = children(root, 'junction').map(parseJunction)
+  const warnings: string[] = []
+  const junctions: OdrJunction[] = []
+  for (const j of children(root, 'junction')) {
+    const parsed = parseJunction(j, warnings)
+    if (parsed) junctions.push(parsed)
+  }
 
-  return { header, roads, junctions, rawXml: xmlString }
+  return { header, roads, junctions, rawXml: xmlString, warnings }
 }


### PR DESCRIPTION
A single malformed <connection> record inside a junction previously aborted the entire OpenDRIVE parse, so no roads were imported at all.

- Resolve OpenDRIVE 1.7+ direct/virtual connections via linkedRoad when connectingRoad is absent
- Skip only the malformed connection record (with a warning on OdrMap.warnings) when neither attribute is present; adjacent connections survive
- Keep strict errors for genuinely unrenderable input (missing road/geometry attributes)

Testing: 290 passed (parser: linkedRoad direct, skip+warning, missing incomingRoad, broken laneLink, legacy regression; end-to-end: all roads still convert to lanes with a warning present). Build green.