### PR TITLE
Write real last-modified timestamps into zip entries

### DIFF
--- a/packages/drawtonomy-sdk/__tests__/exporter/zip.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/zip.test.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 import { execFileSync } from 'child_process'
-import { buildZip, _crc32ForTest } from '../../src/exporter/zip'
+import { buildZip, toDosDateTime, _crc32ForTest } from '../../src/exporter/zip'
 
 describe('crc32', () => {
   it('matches standard CRC-32 value for "123456789"', () => {
@@ -81,5 +81,81 @@ describe('buildZip', () => {
     execFileSync('unzip', ['-q', zipPath, '-d', tmp])
     expect(fs.readFileSync(path.join(tmp, 'note.txt'), 'utf-8')).toBe('こんにちは')
     fs.rmSync(tmp, { recursive: true, force: true })
+  })
+
+  it('writes zero last-mod time/date when modifiedAt is omitted (legacy behavior)', async () => {
+    const blob = buildZip([{ path: 'a.txt', data: 'hello' }])
+    const ab = await blob.arrayBuffer()
+    const u8 = new Uint8Array(ab)
+    // Local File Header: time at offset 10-11, date at offset 12-13.
+    expect(u8[10]).toBe(0)
+    expect(u8[11]).toBe(0)
+    expect(u8[12]).toBe(0)
+    expect(u8[13]).toBe(0)
+  })
+
+  it('writes the given modifiedAt into local header and central directory as DOS date/time', async () => {
+    // 2026-07-20 15:42:30 local time.
+    const modifiedAt = new Date(2026, 6, 20, 15, 42, 30)
+    const { time: expectedTime, date: expectedDate } = toDosDateTime(modifiedAt)
+
+    const blob = buildZip([{ path: 'a.txt', data: 'hello' }], modifiedAt)
+    const ab = await blob.arrayBuffer()
+    const u8 = new Uint8Array(ab)
+
+    // Local File Header: time at offset 10-11, date at offset 12-13 (LE).
+    expect(u8[10] | (u8[11] << 8)).toBe(expectedTime)
+    expect(u8[12] | (u8[13] << 8)).toBe(expectedDate)
+
+    // Central Directory File Header signature 0x02014b50 follows local
+    // header (30 + pathBytes.length) + data.length bytes for a single entry.
+    const localHeaderSize = 30 + 'a.txt'.length
+    const cdOffset = localHeaderSize + 'hello'.length
+    expect(u8[cdOffset]).toBe(0x50)
+    expect(u8[cdOffset + 1]).toBe(0x4b)
+    expect(u8[cdOffset + 2]).toBe(0x01)
+    expect(u8[cdOffset + 3]).toBe(0x02)
+    // CD header: time at offset 12-13, date at offset 14-15 relative to cdOffset.
+    expect(u8[cdOffset + 12] | (u8[cdOffset + 13] << 8)).toBe(expectedTime)
+    expect(u8[cdOffset + 14] | (u8[cdOffset + 15] << 8)).toBe(expectedDate)
+  })
+
+  it('produces an archive whose extracted mtime year matches modifiedAt (not 1979/1980)', async () => {
+    const modifiedAt = new Date(2026, 6, 20, 15, 42, 30)
+    const blob = buildZip([{ path: 'a.txt', data: 'hello' }], modifiedAt)
+    const ab = await blob.arrayBuffer()
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'drawtonomy-zip-mtime-'))
+    const zipPath = path.join(tmp, 'out.zip')
+    fs.writeFileSync(zipPath, Buffer.from(ab))
+
+    const listing = execFileSync('unzip', ['-l', zipPath], { encoding: 'utf-8' })
+    // `unzip -l` renders MM-DD-YYYY.
+    expect(listing).toContain('07-20-2026')
+
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+})
+
+describe('toDosDateTime', () => {
+  it('converts a known Date to the expected DOS date/time bit-packed values', () => {
+    // 2026-07-20 15:42:30.
+    // date: ((2026-1980) << 9) | (7 << 5) | 20 = (46 << 9) | 224 | 20 = 23552 + 244 = 23796
+    // time: (15 << 11) | (42 << 5) | (30 >>> 1) = 30720 + 1344 + 15 = 32079
+    const { time, date } = toDosDateTime(new Date(2026, 6, 20, 15, 42, 30))
+    expect(date).toBe(23796)
+    expect(time).toBe(32079)
+  })
+
+  it('clamps dates before 1980 to 1980-01-01 00:00:00', () => {
+    const { time, date } = toDosDateTime(new Date(1979, 10, 30, 12, 0, 0))
+    // date: ((1980-1980) << 9) | (1 << 5) | 1 = 33
+    expect(date).toBe(33)
+    expect(time).toBe(0)
+  })
+
+  it('round-trips a mid-range date through bit-packing without overflow', () => {
+    const { time, date } = toDosDateTime(new Date(2000, 0, 1, 0, 0, 0))
+    expect(date).toBe(((2000 - 1980) << 9) | (1 << 5) | 1)
+    expect(time).toBe(0)
   })
 })

--- a/packages/drawtonomy-sdk/__tests__/exporter/zip.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/zip.test.ts
@@ -129,8 +129,10 @@ describe('buildZip', () => {
     fs.writeFileSync(zipPath, Buffer.from(ab))
 
     const listing = execFileSync('unzip', ['-l', zipPath], { encoding: 'utf-8' })
-    // `unzip -l` renders MM-DD-YYYY.
-    expect(listing).toContain('07-20-2026')
+    // Info-ZIP renders the date as MM-DD-YYYY on macOS and YYYY-MM-DD on Linux,
+    // so assert the parts rather than one locale/platform-specific layout.
+    expect(listing).toMatch(/07-20-2026|2026-07-20/)
+    expect(listing).not.toMatch(/19(79|80)/)
 
     fs.rmSync(tmp, { recursive: true, force: true })
   })

--- a/packages/drawtonomy-sdk/src/exporter/zip.ts
+++ b/packages/drawtonomy-sdk/src/exporter/zip.ts
@@ -48,6 +48,43 @@ function writeU32(buf: Uint8Array, offset: number, value: number): void {
   buf[offset + 3] = (value >>> 24) & 0xff
 }
 
+export interface DosDateTime {
+  time: number
+  date: number
+}
+
+/**
+ * Convert a JS Date into the DOS date/time pair used by ZIP local file
+ * headers and central directory records.
+ *
+ * DOS date: bits 15-9 = year-1980, bits 8-5 = month (1-12), bits 4-0 = day (1-31).
+ * DOS time: bits 15-11 = hour (0-23), bits 10-5 = minute (0-59), bits 4-0 = second/2.
+ *
+ * The DOS format cannot represent years before 1980; such dates are
+ * clamped to 1980-01-01 00:00:00.
+ */
+export function toDosDateTime(d: Date): DosDateTime {
+  let year = d.getFullYear()
+  let month = d.getMonth() + 1
+  let day = d.getDate()
+  let hour = d.getHours()
+  let minute = d.getMinutes()
+  let second = d.getSeconds()
+
+  if (year < 1980) {
+    year = 1980
+    month = 1
+    day = 1
+    hour = 0
+    minute = 0
+    second = 0
+  }
+
+  const date = ((year - 1980) << 9) | (month << 5) | day
+  const time = (hour << 11) | (minute << 5) | (second >>> 1)
+  return { time, date }
+}
+
 interface PreparedEntry {
   path: string
   pathBytes: Uint8Array
@@ -63,8 +100,16 @@ function toBytes(d: string | Uint8Array): Uint8Array {
 
 /**
  * Bundle ZipEntry[] into a single application/zip Blob.
+ *
+ * @param modifiedAt - Timestamp written into each entry's local header and
+ *   central directory record (DOS date/time format). When omitted, entries
+ *   are written with a zero timestamp (DOS epoch, 1980-01-01).
  */
-export function buildZip(entries: ZipEntry[]): Blob {
+export function buildZip(entries: ZipEntry[], modifiedAt?: Date): Blob {
+  const { time: dosTime, date: dosDate } = modifiedAt
+    ? toDosDateTime(modifiedAt)
+    : { time: 0, date: 0 }
+
   // 1. Emit Local File Header + data for each entry, tracking offsets.
   const prepared: PreparedEntry[] = []
   let cursor = 0
@@ -80,8 +125,8 @@ export function buildZip(entries: ZipEntry[]): Blob {
     writeU16(localHeader, 4, 20)        // version needed to extract (2.0)
     writeU16(localHeader, 6, 0x0800)     // general purpose bit flag (UTF-8 filename)
     writeU16(localHeader, 8, 0)          // compression = store
-    writeU16(localHeader, 10, 0)         // last mod time
-    writeU16(localHeader, 12, 0)         // last mod date
+    writeU16(localHeader, 10, dosTime)   // last mod time
+    writeU16(localHeader, 12, dosDate)   // last mod date
     writeU32(localHeader, 14, crc)       // CRC-32
     writeU32(localHeader, 18, data.length) // compressed size
     writeU32(localHeader, 22, data.length) // uncompressed size
@@ -116,8 +161,8 @@ export function buildZip(entries: ZipEntry[]): Blob {
     writeU16(cdHeader, 6, 20)         // version needed to extract
     writeU16(cdHeader, 8, 0x0800)      // general purpose bit flag
     writeU16(cdHeader, 10, 0)          // compression = store
-    writeU16(cdHeader, 12, 0)          // last mod time
-    writeU16(cdHeader, 14, 0)          // last mod date
+    writeU16(cdHeader, 12, dosTime)    // last mod time
+    writeU16(cdHeader, 14, dosDate)    // last mod date
     writeU32(cdHeader, 16, e.crc)
     writeU32(cdHeader, 20, e.data.length) // compressed size
     writeU32(cdHeader, 24, e.data.length) // uncompressed size


### PR DESCRIPTION
Zip entries were previously stamped with the DOS epoch (1980-01-01). `buildZip` now accepts an optional `modifiedAt` and encodes it as DOS date/time, so extracted files carry their actual creation date.