### PR TITLE
OpenDRIVE import: parkingSpace objects and direct junctions

### DIFF
--- a/packages/drawtonomy-sdk/__tests__/exporter/odrToShapes.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/odrToShapes.test.ts
@@ -391,3 +391,121 @@ describe('esmini sample map (fixture)', () => {
     }
   })
 })
+
+// A straight road carrying a single <object type="parkingSpace"> with a
+// four-corner <cornerLocal> outline (the esmini parking_demo pattern).
+const PARKING_LOCAL = `<?xml version="1.0"?>
+<OpenDRIVE>
+  <header revMajor="1" revMinor="6"/>
+  <road name="r" length="100" id="1" junction="-1">
+    <planView><geometry s="0" x="0" y="0" hdg="0" length="100"><line/></geometry></planView>
+    <lanes>
+      <laneSection s="0">
+        <right><lane id="-1" type="driving" level="false"><width sOffset="0" a="3.5" b="0" c="0" d="0"/></lane></right>
+      </laneSection>
+    </lanes>
+    <objects>
+      <object type="parkingSpace" name="parkingSpace" id="7" s="10" t="-5" hdg="0" length="0" width="0">
+        <outlines>
+          <outline id="0" closed="true">
+            <cornerLocal u="0" v="0" z="0" height="4" id="0"/>
+            <cornerLocal u="2.5" v="0" z="0" height="4" id="1"/>
+            <cornerLocal u="2.5" v="5" z="0" height="4" id="2"/>
+            <cornerLocal u="0" v="5" z="0" height="4" id="3"/>
+          </outline>
+        </outlines>
+      </object>
+    </objects>
+  </road>
+</OpenDRIVE>`
+
+// A parking space with no <outlines>; the footprint is an oriented rectangle
+// derived from s/t/hdg/length/width.
+const PARKING_RECT = `<?xml version="1.0"?>
+<OpenDRIVE>
+  <header revMajor="1" revMinor="6"/>
+  <road name="r" length="100" id="1" junction="-1">
+    <planView><geometry s="0" x="0" y="0" hdg="0" length="100"><line/></geometry></planView>
+    <lanes>
+      <laneSection s="0">
+        <right><lane id="-1" type="driving" level="false"><width sOffset="0" a="3.5" b="0" c="0" d="0"/></lane></right>
+      </laneSection>
+    </lanes>
+    <objects>
+      <object type="parkingSpace" name="parkingSpace" id="8" s="20" t="-5" hdg="0" length="2.5" width="5"/>
+    </objects>
+  </road>
+</OpenDRIVE>`
+
+describe('odrToShapes parkingSpace objects', () => {
+  it('converts a <cornerLocal> parking space into a polygon footprint with origin markers', () => {
+    const result = odrToShapes(parseOpenDriveXml(PARKING_LOCAL))
+    expect(result.parkingSpaces).toBeDefined()
+    expect(result.parkingSpaces).toHaveLength(1)
+    const ps = result.parkingSpaces![0]
+    expect(ps.points).toHaveLength(4)
+    // Origin markers: type + odr_object_id / odr_road_id / odr_type.
+    expect(ps.attributes.type).toBe('parking_space')
+    expect(ps.attributes.odr_object_id).toBe('7')
+    expect(ps.attributes.odr_road_id).toBe('1')
+    expect(ps.attributes.odr_type).toBe('parkingSpace')
+    // Geometry: object origin at s=10, t=-5 (ENU y=-5 -> canvas y=+5m). The
+    // first corner (u=0,v=0) coincides with the origin.
+    expect(ps.points[0].x).toBeCloseTo(10 * PIXELS_PER_METER, 3)
+    expect(ps.points[0].y).toBeCloseTo(5 * PIXELS_PER_METER, 3)
+    // Corner (u=2.5,v=0) advances along the road heading (+x).
+    expect(ps.points[1].x).toBeCloseTo(12.5 * PIXELS_PER_METER, 3)
+    expect(ps.points[1].y).toBeCloseTo(5 * PIXELS_PER_METER, 3)
+    // All vertices finite.
+    for (const p of ps.points) {
+      expect(Number.isFinite(p.x)).toBe(true)
+      expect(Number.isFinite(p.y)).toBe(true)
+    }
+  })
+
+  it('derives an oriented-rectangle footprint when no outline is present', () => {
+    const result = odrToShapes(parseOpenDriveXml(PARKING_RECT))
+    expect(result.parkingSpaces).toHaveLength(1)
+    expect(result.parkingSpaces![0].points).toHaveLength(4)
+    expect(result.parkingSpaces![0].attributes.odr_object_id).toBe('8')
+  })
+
+  it('does not disturb the road carry-through hash (source object stays verbatim)', () => {
+    // A parking space is materialized as a polygon only; the road that carries
+    // it must still hash as unedited so the exporter re-emits it verbatim.
+    const withPs = odrToShapes(parseOpenDriveXml(PARKING_LOCAL))
+    const withoutPs = odrToShapes(
+      parseOpenDriveXml(PARKING_LOCAL.replace(/<objects>[\s\S]*<\/objects>/, ''))
+    )
+    const hashWith = withPs.sidecar.roadRecords?.['1'].stateHash
+    const hashWithout = withoutPs.sidecar.roadRecords?.['1'].stateHash
+    expect(hashWith).toBeDefined()
+    expect(hashWith).toBe(hashWithout)
+  })
+})
+
+describe('esmini parking_demo (fixture)', () => {
+  const fixturePath = join(__dirname, '..', 'fixtures', 'parking_demo.xodr')
+  it.skipIf(!existsSync(fixturePath))(
+    'materializes 7 parkingSpace polygons and keeps the existing crosswalks',
+    () => {
+      const xml = readFileSync(fixturePath, 'utf-8')
+      const result = odrToShapes(parseOpenDriveXml(xml))
+      expect(result.parkingSpaces).toHaveLength(7)
+      // Crosswalk conversion is unchanged by parkingSpace support: the fixture
+      // carries 3 <object type="crosswalk"> but one lacks length/width, so 2 are
+      // materialized (the pre-existing materializeCrosswalks guard).
+      expect(result.crosswalks).toHaveLength(2)
+      for (const ps of result.parkingSpaces!) {
+        expect(ps.points.length).toBeGreaterThanOrEqual(3)
+        expect(ps.attributes.type).toBe('parking_space')
+        expect(ps.attributes.odr_object_id).not.toBe('')
+        expect(ps.attributes.odr_road_id).not.toBe('')
+        for (const p of ps.points) {
+          expect(Number.isFinite(p.x)).toBe(true)
+          expect(Number.isFinite(p.y)).toBe(true)
+        }
+      }
+    }
+  )
+})

--- a/packages/drawtonomy-sdk/__tests__/exporter/odrToShapes.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/odrToShapes.test.ts
@@ -390,6 +390,35 @@ describe('esmini sample map (fixture)', () => {
       expect(Number.isFinite(p.y)).toBe(true)
     }
   })
+
+  // soderleden.xodr uses a direct junction (linkedRoad). Before the parser
+  // tolerated it, the missing `connectingRoad` threw and the whole map failed
+  // to parse -> 0 lanes -> highway_merge had no road network / no actors.
+  const soderledenPath = join(__dirname, '..', 'fixtures', 'soderleden.xodr')
+  it.skipIf(!existsSync(soderledenPath))('parses soderleden.xodr (direct junction) and expands lanes', () => {
+    const xml = readFileSync(soderledenPath, 'utf-8')
+    const map = parseOpenDriveXml(xml)
+    expect(map.roads.length).toBeGreaterThan(0)
+    // The direct junction must be present and recognized.
+    const direct = map.junctions.find(j => j.type === 'direct')
+    expect(direct).toBeTruthy()
+    expect(direct!.connections.length).toBeGreaterThan(0)
+    // Direct-junction connections normalize linkedRoad into connectingRoad.
+    for (const conn of direct!.connections) {
+      expect(conn.connectingRoad).not.toBe('')
+    }
+
+    const result = odrToShapes(map)
+    // Road network must materialize (0 lanes -> N lanes).
+    expect(result.lanes.length).toBeGreaterThan(0)
+    // The direct junction must actually wire lanes across the linked roads.
+    const linked = result.lanes.filter(l => l.next.length + l.prev.length > 0)
+    expect(linked.length).toBeGreaterThan(0)
+    for (const p of result.points) {
+      expect(Number.isFinite(p.x)).toBe(true)
+      expect(Number.isFinite(p.y)).toBe(true)
+    }
+  })
 })
 
 // A straight road carrying a single <object type="parkingSpace"> with a

--- a/packages/drawtonomy-sdk/__tests__/exporter/opendriveParser.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/opendriveParser.test.ts
@@ -169,6 +169,61 @@ describe('parseOpenDriveXml', () => {
     ])
   })
 
+  it('parses a direct junction (linkedRoad) without failing the whole document', () => {
+    // Minimal reproduction of soderleden.xodr: two incoming roads join a third
+    // through a <junction type="direct">, whose connections carry `linkedRoad`
+    // (not `connectingRoad`). The whole map must still parse.
+    const xml = `<?xml version="1.0"?>
+<OpenDRIVE>
+  <header revMajor="1" revMinor="5"/>
+  <road name="" length="10" id="0" junction="-1">
+    <planView><geometry s="0" x="0" y="0" hdg="0" length="10"><line/></geometry></planView>
+    <lanes><laneSection s="0"><right><lane id="-1" type="driving" level="false"><width sOffset="0" a="3.5" b="0" c="0" d="0"/></lane></right></laneSection></lanes>
+  </road>
+  <road name="" length="10" id="2" junction="-1">
+    <link><successor elementType="junction" elementId="8"/></link>
+    <planView><geometry s="0" x="10" y="0" hdg="0" length="10"><line/></geometry></planView>
+    <lanes><laneSection s="0"><right><lane id="-1" type="driving" level="false"><width sOffset="0" a="3.5" b="0" c="0" d="0"/></lane></right></laneSection></lanes>
+  </road>
+  <junction name="" id="8" type="direct">
+    <connection id="0" incomingRoad="2" linkedRoad="0" contactPoint="start">
+      <laneLink from="-1" to="-1"/>
+    </connection>
+  </junction>
+</OpenDRIVE>`
+    const map = parseOpenDriveXml(xml)
+    expect(map.roads).toHaveLength(2)
+    const junction = map.junctions[0]
+    expect(junction.id).toBe('8')
+    expect(junction.type).toBe('direct')
+    expect(junction.connections).toHaveLength(1)
+    const conn = junction.connections[0]
+    expect(conn.incomingRoad).toBe('2')
+    // linkedRoad is normalized into connectingRoad so the converter wires it.
+    expect(conn.connectingRoad).toBe('0')
+    expect(conn.contactPoint).toBe('start')
+    expect(conn.laneLinks).toEqual([{ from: -1, to: -1 }])
+  })
+
+  it('records junction type as "default" when the attribute is absent', () => {
+    expect(parseOpenDriveXml(SAMPLE).junctions[0].type).toBe('default')
+  })
+
+  it('skips a connection with neither connectingRoad nor linkedRoad without throwing', () => {
+    const xml = `<?xml version="1.0"?>
+<OpenDRIVE>
+  <header revMajor="1" revMinor="6"/>
+  <road name="" length="10" id="0" junction="-1">
+    <planView><geometry s="0" x="0" y="0" hdg="0" length="10"><line/></geometry></planView>
+  </road>
+  <junction name="" id="9">
+    <connection id="0" incomingRoad="0"><laneLink from="-1" to="-1"/></connection>
+  </junction>
+</OpenDRIVE>`
+    const map = parseOpenDriveXml(xml)
+    expect(map.junctions[0].connections).toHaveLength(0)
+  })
+
   it('throws with road context on malformed required attributes', () => {
     const bad = `<OpenDRIVE><header revMajor="1" revMinor="6"/><road id="7" length="abc"/></OpenDRIVE>`
     expect(() => parseOpenDriveXml(bad)).toThrow(/road 7/)

--- a/packages/drawtonomy-sdk/__tests__/exporter/roundtripFidelity.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/roundtripFidelity.test.ts
@@ -1822,6 +1822,23 @@ describe('carry-through export (sidecar verbatim re-emission)', () => {
     expectVerbatimRoundTrip(readFileSync(TWO_PLUS_ONE, 'utf-8'))
   })
 
+  it('keeps <object type="parkingSpace"> verbatim for unedited roads', () => {
+    // W50: parking spaces are materialized as polygons only; the source
+    // <object> stays in the road's verbatim XML and re-emits unchanged when the
+    // road is not edited. The polygon does not participate in the road state
+    // hash, so importing it must not force regeneration of the carrying road.
+    const parkingFixture = join(FIXTURES, 'parking_demo.xodr')
+    if (!existsSync(parkingFixture)) return
+    const xml = readFileSync(parkingFixture, 'utf-8')
+    const imported = odrToShapesFull(parseOpenDriveXml(xml))
+    expect((imported.parkingSpaces ?? []).length).toBe(7)
+    const out = exportToOpenDrive(snapshotFrom(imported), { sidecar: imported.sidecar })
+    // Every original parkingSpace object survives the unedited round trip.
+    const before = (xml.match(/type="parkingSpace"/g) || []).length
+    const after = (out.match(/type="parkingSpace"/g) || []).length
+    expect(after).toBe(before)
+  })
+
   it('regenerates only the edited road and keeps its original id', () => {
     const imported = odrToShapesFull(parseOpenDriveXml(CHAIN_XODR))
     const records = imported.sidecar.roadRecords!

--- a/packages/drawtonomy-sdk/__tests__/fixtures/README.md
+++ b/packages/drawtonomy-sdk/__tests__/fixtures/README.md
@@ -6,6 +6,9 @@ parser/conversion fixtures:
 
 - `fabriksgatan.xodr`
 - `two_plus_one.xodr`
+- `soderleden.xodr` — uses a `<junction type="direct">` whose connections carry
+  `linkedRoad` (not `connectingRoad`); regression fixture for direct-junction
+  parse tolerance (highway_merge / highway_merge_advanced scenarios).
 
 A regression fixture for degenerate junction sliver-lane pruning:
 

--- a/packages/drawtonomy-sdk/__tests__/fixtures/parking_demo.xodr
+++ b/packages/drawtonomy-sdk/__tests__/fixtures/parking_demo.xodr
@@ -1,0 +1,855 @@
+<?xml version='1.0' encoding='utf-8'?>
+<OpenDRIVE>
+    <header name="myroad" revMajor="1" revMinor="7" date="2025-01-11 09:31:21.161369" north="0.0"
+        south="0.0" east="0.0" west="0.0" />
+    <road rule="RHT" id="1" junction="-1" length="200.0">
+        <link>
+            <successor elementType="road" elementId="2" contactPoint="start" />
+        </link>
+        <planView>
+            <geometry s="0" x="0" y="0" hdg="0" length="100">
+                <line />
+            </geometry>
+            <geometry s="100" x="100.0" y="0.0" hdg="0" length="100.0">
+                <arc curvature="-0.02" />
+            </geometry>
+        </planView>
+        <elevationProfile />
+        <lateralProfile />
+        <lanes>
+            <laneSection s="0">
+                <left>
+                    <lane id="3" type="border" level="false">
+                        <link>
+                            <successor id="3" />
+                        </link>
+                        <width a="6" b="0" c="0" d="0" sOffset="0" />
+                        <width a="6" b="-1" c="0" d="0" sOffset="13.35" />
+                        <width a="0.65" b="0" c="0" d="0" sOffset="18.7" />
+                        <width a="0.65" b="1" c="0" d="0" sOffset="64.65" />
+                        <width a="6.0" b="0" c="0" d="0" sOffset="70.0" />
+                        <width a="6.0" b="-1" c="0" d="0" sOffset="85.0" />
+                        <width a="1" b="0" c="0" d="0" sOffset="90.0" />
+                        <width a="1" b="1" c="0" d="0" sOffset="140.0" />
+                        <width a="6" b="0" c="0" d="0" sOffset="145.0" />
+                        <width a="6" b="-0.5" c="0" d="0" sOffset="165.0" />
+                        <width a="3.5" b="0" c="0" d="0" sOffset="170.0" />
+                        <width a="3.5" b="0.5" c="0" d="0" sOffset="190.0" />
+                        <width a="6.0" b="0.0" c="0" d="0" sOffset="195.0" />
+                    </lane>
+                    <lane id="2" type="driving" level="false">
+                        <link>
+                            <successor id="2" />
+                        </link>
+                        <width a="0" b="0" c="0" d="0" sOffset="0" />
+                        <width a="0.0" b="1" c="0" d="0" sOffset="13.35" />
+                        <width a="5.35" b="0" c="0" d="0" sOffset="18.7" />
+                        <width a="5.35" b="-1" c="0" d="0" sOffset="64.65" />
+                        <width a="0.0" b="0" c="0" d="0" sOffset="70.0" />
+                        <width a="0.0" b="1" c="0" d="0" sOffset="85.0" />
+                        <width a="5.0" b="0" c="0" d="0" sOffset="90.0" />
+                        <width a="5.0" b="-1" c="0" d="0" sOffset="140.0" />
+                        <width a="0.0" b="0" c="0" d="0" sOffset="145.0" />
+                        <width a="0.0" b="0.5" c="0" d="0" sOffset="165.0" />
+                        <width a="2.5" b="0" c="0" d="0" sOffset="170.0" />
+                        <width a="2.5" b="-0.5" c="0" d="0" sOffset="190.0" />
+                        <width a="0.0" b="0.0" c="0" d="0" sOffset="195.0" />
+                    </lane>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <successor id="1" />
+                        </link>
+                        <width a="3.25" b="0" c="0" d="0" sOffset="0" />
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0" type="broken" weight="standard" color="standard"
+                            height="0.02" width="0.2" />
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <successor id="-1" />
+                        </link>
+                        <width a="3.25" b="0" c="0" d="0" sOffset="0" />
+                    </lane>
+                    <lane id="-2" type="border" level="false">
+                        <link>
+                            <successor id="-2" />
+                        </link>
+                        <width a="0.3" b="0" c="0" d="0" sOffset="0" />
+                    </lane>
+                    <lane id="-3" type="shoulder" level="false">
+                        <link>
+                            <successor id="-3" />
+                        </link>
+                        <width a="2.05" b="0" c="0" d="0" sOffset="0" />
+                        <height inner="0.12" outer="0.12" sOffset="0" />
+                    </lane>
+                    <lane id="-4" type="border" level="false">
+                        <link>
+                            <successor id="-4" />
+                        </link>
+                        <width a="0.2" b="0" c="0" d="0" sOffset="0" />
+                        <height inner="0.12" outer="0.12" sOffset="0" />
+                    </lane>
+                    <lane id="-5" type="biking" level="false">
+                        <link>
+                            <successor id="-5" />
+                        </link>
+                        <width a="1.6" b="0" c="0" d="0" sOffset="0" />
+                        <height inner="0.12" outer="0.12" sOffset="0" />
+                    </lane>
+                    <lane id="-6" type="sidewalk" level="false">
+                        <link>
+                            <successor id="-6" />
+                        </link>
+                        <width a="3" b="0" c="0" d="0" sOffset="0" />
+                        <height inner="0.12" outer="0.12" sOffset="0" />
+                    </lane>
+                    <lane id="-7" type="border" level="false">
+                        <link>
+                            <successor id="-7" />
+                        </link>
+                        <width a="7" b="0" c="0" d="0" sOffset="0" />
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+            <object type="crosswalk" id="1" s="1" t="0.0" zOffset="0.0" orientation="none"
+                length="5.0"
+                width="2.0" hdg="0.0" pitch="0.0" roll="0.0">
+                <outlines>
+                    <outline id="0" closed="true">
+                        <cornerRoad s="7.0" t="3.2" dz="0.0" height="0.0" id="0" />
+                        <cornerRoad s="8.0" t="-3.2" dz="0.0" height="0.0" id="1" />
+                        <cornerRoad s="11.0" t="-3.2" dz="0.0" height="0.0" id="2" />
+                        <cornerRoad s="12.0" t="3.2" dz="0.0" height="0.0" id="3" />
+                    </outline>
+                </outlines>
+                <markings>
+                    <marking width="0.20" color="white" zOffset="0.005" spaceLength="0.20"
+                        lineLength="0.40"
+                        startOffset="0.0" stopOffset="0.0">
+                        <cornerReference id="0" />
+                        <cornerReference id="1" />
+                    </marking>
+                    <marking width="0.20" color="white" zOffset="0.005" spaceLength="0.20"
+                        lineLength="0.40"
+                        startOffset="0.0" stopOffset="0.0">
+                        <cornerReference id="2" />
+                        <cornerReference id="3" />
+                    </marking>
+                </markings>
+            </object>
+            <object type="crosswalk" id="2" s="10.0" t="0.0" zOffset="0.0" orientation="none"
+                length="10.0" width="7.0" hdg="0.0" pitch="0.0" roll="0.0">
+                <outlines>
+                    <outline id="0" closed="true">
+                        <cornerRoad s="79.0" t="-3.0" dz="0.0" height="0.0" id="0" />
+                        <cornerRoad s="79.0" t="3.0" dz="0.0" height="0.0" id="1" />
+                    </outline>
+                </outlines>
+                <markings>
+                    <marking width="5" color="white" zOffset="0.005" spaceLength="0.5"
+                        lineLength="0.5" startOffset="0.25" stopOffset="0.0">
+                        <cornerReference id="0" />
+                        <cornerReference id="1" />
+                    </marking>
+                </markings>
+            </object>
+            <object type="crosswalk" id="3" s="152.0" t="0.0" hdg="1.5707964" zOffset="0.0">
+                <outlines>
+                    <outline id="0" closed="true">
+                        <cornerLocal u="-3.2" v="-2.0" z="0.0" height="4.0" id="0" />
+                        <cornerLocal u="3.2" v="-2.0" z="0.0" height="4.0" id="1" />
+                        <cornerLocal u="3.2" v="2.0" z="0.0" height="4.0" id="2" />
+                        <cornerLocal u="-3.2" v="2.0" z="0.0" height="4.0" id="3" />
+                    </outline>
+                </outlines>
+                <markings>
+                    <marking width="0.20" color="white" zOffset="0.005" spaceLength="0.20"
+                        lineLength="0.40"
+                        startOffset="0.3" stopOffset="0.1">
+                        <cornerReference id="0" />
+                        <cornerReference id="1" />
+                    </marking>
+                    <marking width="0.20" color="white" zOffset="0.005" spaceLength="0.20"
+                        lineLength="0.40"
+                        startOffset="0.3" stopOffset="0.1">
+                        <cornerReference id="2" />
+                        <cornerReference id="3" />
+                    </marking>
+                </markings>
+            </object>
+            <object type="parkingSpace" name="parkingSpace" id="4" s="2.5" t="0.0" zOffset="0.0">
+                <repeat distance="3.53" tStart="3.25" tEnd="3.25" length="45" s="20.5"
+                    heightStart="4.0"
+                    heightEnd="4.0" zOffsetEnd="0.0" zOffsetStart="0.0" />
+                <outlines>
+                    <outline id="0" closed="true">
+                        <cornerLocal u="3.53" v="0.0" z="0.0" height="4.0" id="0" />
+                        <cornerLocal u="-1.77" v="5.3" z="0.0" height="4.0" id="1" />
+                        <cornerLocal u="-3.53" v="3.53" z="0.0" height="4.0" id="2" />
+                        <cornerLocal u="0.0" v="0.0" z="0.0" height="4.0" id="3" />
+                    </outline>
+                </outlines>
+                <markings>
+                    <marking width="0.1" color="white" zOffset="0.005" spaceLength="0.0"
+                        lineLength="10"
+                        startOffset="0.0" stopOffset="0.0">
+                        <cornerReference id="0" />
+                        <cornerReference id="1" />
+                        <cornerReference id="2" />
+                        <cornerReference
+                            id="3" />
+                    </marking>
+                </markings>
+            </object>
+            <object type="parkingSpace" name="parkingSpace" id="5" s="66.4" t="3.25" zOffset="0.0"
+                height="4.0">
+                <outlines>
+                    <outline id="0" closed="true">
+                        <cornerLocal u="3.53" v="0.0" z="0.0" height="4.0" id="0" />
+                        <cornerLocal u="-1.77" v="5.3" z="0.0" height="4.0" id="1" />
+                        <cornerLocal u="-3.53" v="3.53" z="0.0" height="4.0" id="2" />
+                        <cornerLocal u="0.0" v="0.0" z="0.0" height="4.0" id="3" />
+                    </outline>
+                </outlines>
+                <markings>
+                    <marking width="0.1" color="white" zOffset="0.005" spaceLength="0.0"
+                        lineLength="10.0"
+                        startOffset="0.0" stopOffset="0.0">
+                        <cornerReference id="0" />
+                        <cornerReference id="1" />
+                        <cornerReference id="2" />
+                    </marking>
+                </markings>
+            </object>
+            <object type="parkingSpace" name="parkingSpace" id="6" s="0" t="3.25" zOffset="0.0">
+                <repeat distance="2.5" heightStart="4.0" heightEnd="4.0" zOffsetEnd="0.0"
+                    lengthStart="2.5" lengthEnd="2.5" widthStart="5.0" widthEnd="5.0"
+                    zOffsetStart="0.0" tStart="3.25" tEnd="3.25" length="45" s="90" />
+                <outlines>
+                    <outline id="0" closed="true">
+                        <cornerRoad s="0" t="3.25" dz="0.0" height="4.0" id="0" />
+                        <cornerRoad s="2.5" t="3.25" dz="0.0" height="4.0" id="1" />
+                        <cornerRoad s="2.5" t="8.25" dz="0.0" height="4.0" id="2" />
+                        <cornerRoad s="0" t="8.25" dz="0.0" height="4.0" id="3" />
+                    </outline>
+                </outlines>
+                <markings>
+                    <marking width="0.1" color="white" zOffset="0.005" spaceLength="0.0"
+                        lineLength="0.1"
+                        startOffset="0.0" stopOffset="0.0">
+                        <cornerReference id="2" />
+                        <cornerReference id="3" />
+                        <cornerReference id="0" />
+                    </marking>
+                </markings>
+            </object>
+            <object type="parkingSpace" name="parkingSpace" id="7" s="135" t="3.25" zOffset="0.0">
+                <outlines>
+                    <outline id="0" closed="true">
+                        <cornerRoad s="137.5" t="3.25" dz="0.0" height="4.0" id="0" />
+                        <cornerRoad s="140" t="3.25" dz="0.0" height="4.0" id="1" />
+                        <cornerRoad s="140" t="8.25" dz="0.0" height="4.0" id="2" />
+                        <cornerRoad s="137.5" t="8.25" dz="0.0" height="4.0" id="3" />
+                    </outline>
+                </outlines>
+                <markings>
+                    <marking width="0.1" color="white" zOffset="0.005" spaceLength="0.0"
+                        lineLength="0.1"
+                        startOffset="0.0" stopOffset="0.0">
+                        <cornerReference id="1" />
+                        <cornerReference id="2" />
+                        <cornerReference id="3" />
+                        <cornerReference
+                            id="0" />
+                    </marking>
+                </markings>
+            </object>
+            <object type="parkingSpace" name="parkingSpace" id="8" s="2.5" t="0.0" zOffset="0.0">
+                <repeat distance="5" lengthStart="5.0" lengthEnd="5.0" heightStart="4.0"
+                    heightEnd="4.0"
+                    widthStart="2.0" widthEnd="2.0" zOffsetEnd="0.0" zOffsetStart="0.0" tStart="4.5"
+                    tEnd="4.5" length="18" s="172.5" />
+                <outlines>
+                    <outline id="0" closed="true">
+                        <cornerRoad s="0.0" t="-1.25" dz="0.0" height="4.0" id="0" />
+                        <cornerRoad s="5.0" t="-1.25" dz="0.0" height="4.0" id="1" />
+                        <cornerRoad s="5.0" t="1.25" dz="0.0" height="4.0" id="2" />
+                        <cornerRoad s="0.0" t="1.25" dz="0.0" height="4.0" id="3" />
+                    </outline>
+                </outlines>
+                <markings>
+                    <marking width="0.1" color="white" zOffset="0.005" spaceLength="0.0"
+                        lineLength="6.0"
+                        startOffset="0.0" stopOffset="0.0">
+                        <cornerReference id="1" />
+                        <cornerReference id="2" />
+                        <cornerReference id="3" />
+                        <cornerReference id="0" />
+                    </marking>
+                </markings>
+            </object>
+            <object id="100" type="tree" s="10" t="-14" zOffset="0" radius="0.3" height="3.0">
+                <repeat distance="40" heightStart="4" heightEnd="4" length="200" s="10" tEnd="-14"
+                    tStart="-14" zOffsetEnd="0" zOffsetStart="0" />
+            </object>
+            <object id="101" type="tree" s="10" t="-14" zOffset="0" length="4.0" width="2.5"
+                height="4.0">
+                <repeat distance="40" heightStart="4" heightEnd="4" length="200" s="10" tEnd="-14"
+                    tStart="-14" zOffsetEnd="0" zOffsetStart="0" />
+                <outlines>
+                    <outline id="0" closed="true">
+                        <cornerLocal u="1.1495920785002685" v="0.21673501899765402" z="3.0"
+                            height="0.3531622792856542" />
+                        <cornerLocal u="0.32865764939201" v="0.48137476968197423" z="3.0"
+                            height="0.3531622792856542" />
+                        <cornerLocal u="-0.18638789708884043" v="0.9886268080377618" z="3.0"
+                            height="0.3531622792856542" />
+                        <cornerLocal u="-0.45241930443792183" v="0.3088883641208907" z="3.0"
+                            height="0.3531622792856542" />
+                        <cornerLocal u="-1.0835252871711152" v="-0.20427930749647652" z="3.0"
+                            height="0.3531622792856542" />
+                        <cornerLocal u="-0.3475110065832529" v="-0.5089887031852884" z="3.0"
+                            height="0.3531622792856542" />
+                        <cornerLocal u="0.2048823408555767" v="-1.086723858292197" z="3.0"
+                            height="0.3531622792856542" />
+                        <cornerLocal u="0.4375359104720964" v="-0.2987267570241685" z="3.0"
+                            height="0.3531622792856542" />
+                    </outline>
+                    <outline id="1" closed="true">
+                        <cornerLocal u="2.412650755657238" v="-0.5096686812404231"
+                            z="3.3531622792856544" height="0.7647206929815523" />
+                        <cornerLocal u="1.1776637167768917" v="0.7668815785233364"
+                            z="3.3531622792856544" height="0.7647206929815523" />
+                        <cornerLocal u="0.5038157025720472" v="2.384944141680615"
+                            z="3.3531622792856544" height="0.7647206929815523" />
+                        <cornerLocal u="-0.8539704674752291" v="1.311401998573336"
+                            z="3.3531622792856544" height="0.7647206929815523" />
+                        <cornerLocal u="-2.2314878795837756" v="0.4713983083231748"
+                            z="3.3531622792856544" height="0.7647206929815523" />
+                        <cornerLocal u="-1.196349373069635" v="-0.7790494710968986"
+                            z="3.3531622792856544" height="0.7647206929815523" />
+                        <cornerLocal u="-0.5104397081918753" v="-2.416300614527362"
+                            z="3.3531622792856544" height="0.7647206929815523" />
+                        <cornerLocal u="0.7822698626075194" v="-1.201294775778588"
+                            z="3.3531622792856544" height="0.7647206929815523" />
+                    </outline>
+                    <outline id="2" closed="true">
+                        <cornerLocal u="3.212022493502211" v="-0.3815460335851026"
+                            z="4.117882972267207" height="1.0440519515915438" />
+                        <cornerLocal u="1.4195094801489612" v="0.794174730546252"
+                            z="4.117882972267207" height="1.0440519515915438" />
+                        <cornerLocal u="1.3489108258393299" v="2.922760600777907"
+                            z="4.117882972267207" height="1.0440519515915438" />
+                        <cornerLocal u="-0.41120049218192106" v="2.071825382473304"
+                            z="4.117882972267207" height="1.0440519515915438" />
+                        <cornerLocal u="-2.1401366328694653" v="1.9800018504180514"
+                            z="4.117882972267207" height="1.0440519515915438" />
+                        <cornerLocal u="-1.9641422948235718" v="0.2333142758192701"
+                            z="4.117882972267207" height="1.0440519515915438" />
+                        <cornerLocal u="-2.8851216988655715" v="-1.6141426174549154"
+                            z="4.117882972267207" height="1.0440519515915438" />
+                        <cornerLocal u="-0.7889034804036743" v="-1.7093613352133246"
+                            z="4.117882972267207" height="1.0440519515915438" />
+                        <cornerLocal u="0.6249611955038317" v="-3.148854372802784"
+                            z="4.117882972267207" height="1.0440519515915438" />
+                        <cornerLocal u="1.4131911649147597" v="-1.3074497574362742"
+                            z="4.117882972267207" height="1.0440519515915438" />
+                    </outline>
+                    <outline id="3" closed="true">
+                        <cornerLocal u="3.693847772212909" v="-0.41749276934911156"
+                            z="5.161934923858751" height="1.1428571428571428" />
+                        <cornerLocal u="1.9112582209193605" v="0.8330853265668936"
+                            z="5.161934923858751" height="1.1428571428571428" />
+                        <cornerLocal u="1.9670263687043468" v="2.663294322362287"
+                            z="5.161934923858751" height="1.1428571428571428" />
+                        <cornerLocal u="0.24010888609783218" v="2.1244096643488093"
+                            z="5.161934923858751" height="1.1428571428571428" />
+                        <cornerLocal u="-1.259927505786121" v="2.8905164049877095"
+                            z="5.161934923858751" height="1.1428571428571428" />
+                        <cornerLocal u="-1.6733264957855305" v="1.2358669160313858"
+                            z="5.161934923858751" height="1.1428571428571428" />
+                        <cornerLocal u="-3.7461979238546297" v="0.4234095832333109"
+                            z="5.161934923858751" height="1.1428571428571428" />
+                        <cornerLocal u="-1.8198418539140664" v="-0.7932384690744867"
+                            z="5.161934923858751" height="1.1428571428571428" />
+                        <cornerLocal u="-1.9704121938966064" v="-2.6678786274608477"
+                            z="5.161934923858751" height="1.1428571428571428" />
+                        <cornerLocal u="-0.21681277608392407" v="-1.9182928393550227"
+                            z="5.161934923858751" height="1.1428571428571428" />
+                        <cornerLocal u="1.2814882033710566" v="-2.9399807986024413"
+                            z="5.161934923858751" height="1.1428571428571428" />
+                        <cornerLocal u="1.565508577816619" v="-1.15623595452521"
+                            z="5.161934923858751" height="1.1428571428571428" />
+                    </outline>
+                    <outline id="4" closed="true">
+                        <cornerLocal u="3.0672082338062725" v="-0.6440955820014684"
+                            z="6.304792066715894" height="1.044051951591544" />
+                        <cornerLocal u="1.9166364185045794" v="0.858981126076523"
+                            z="6.304792066715894" height="1.044051951591544" />
+                        <cornerLocal u="1.670528351977734" v="2.9099010601887683"
+                            z="6.304792066715894" height="1.044051951591544" />
+                        <cornerLocal u="-0.18823985146827968" v="1.7496855597741585"
+                            z="6.304792066715894" height="1.044051951591544" />
+                        <cornerLocal u="-2.1796824419047263" v="2.408873325925016"
+                            z="6.304792066715894" height="1.044051951591544" />
+                        <cornerLocal u="-1.9530296939515057" v="0.4101246806548898"
+                            z="6.304792066715894" height="1.044051951591544" />
+                        <cornerLocal u="-2.651820719254594" v="-1.188469511267884"
+                            z="6.304792066715894" height="1.044051951591544" />
+                        <cornerLocal u="-0.7902119245626045" v="-1.3764738050307435"
+                            z="6.304792066715894" height="1.044051951591544" />
+                        <cornerLocal u="0.3294283601899909" v="-3.0620298534480974"
+                            z="6.304792066715894" height="1.044051951591544" />
+                        <cornerLocal u="1.3862494861162178" v="-1.5320118866785728"
+                            z="6.304792066715894" height="1.044051951591544" />
+                    </outline>
+                    <outline id="5" closed="true">
+                        <cornerLocal u="2.1651871225412593" v="-0.08043095235743618"
+                            z="7.348844018307438" height="0.7647206929815524" />
+                        <cornerLocal u="0.856334997659088" v="0.7949925635483094"
+                            z="7.348844018307438" height="0.7647206929815524" />
+                        <cornerLocal u="0.08541293600136957" v="2.2993012479418606"
+                            z="7.348844018307438" height="0.7647206929815524" />
+                        <cornerLocal u="-1.067617236843214" v="1.149995667798948"
+                            z="7.348844018307438" height="0.7647206929815524" />
+                        <cornerLocal u="-2.11822756294274" v="0.07868652941058173"
+                            z="7.348844018307438" height="0.7647206929815524" />
+                        <cornerLocal u="-0.8518719524076546" v="-0.7908492226882857"
+                            z="7.348844018307438" height="0.7647206929815524" />
+                        <cornerLocal u="-0.08390190343049536" v="-2.258624516306761"
+                            z="7.348844018307438" height="0.7647206929815524" />
+                        <cornerLocal u="0.7976963850497057" v="-0.8592474487752786"
+                            z="7.348844018307438" height="0.7647206929815524" />
+                    </outline>
+                    <outline id="6" closed="true">
+                        <cornerLocal u="1.1404858178776287" v="-0.05890978156598799"
+                            z="8.11356471128899" height="0.35316227928565386" />
+                        <cornerLocal u="0.527640803297077" v="0.4758093567218981"
+                            z="8.11356471128899" height="0.35316227928565386" />
+                        <cornerLocal u="0.05704562793135937" v="1.1043960425275423"
+                            z="8.11356471128899" height="0.35316227928565386" />
+                        <cornerLocal u="-0.4307322308323199" v="0.4776532808184004"
+                            z="8.11356471128899" height="0.35316227928565386" />
+                        <cornerLocal u="-1.0126692674265103" v="0.05230764329336513"
+                            z="8.11356471128899" height="0.35316227928565386" />
+                        <cornerLocal u="-0.38244427459713776" v="-0.3448758381477605"
+                            z="8.11356471128899" height="0.35316227928565386" />
+                        <cornerLocal u="-0.05046063424343702" v="-0.9769114090379909"
+                            z="8.11356471128899" height="0.35316227928565386" />
+                        <cornerLocal u="0.4427657397012358" v="-0.4909976385877005"
+                            z="8.11356471128899" height="0.35316227928565386" />
+                    </outline>
+                </outlines>
+            </object>
+        </objects>
+    </road>
+    <road rule="RHT" id="2" junction="-1" length="30">
+        <link>
+            <predecessor elementType="road" elementId="1" contactPoint="end" />
+            <successor elementType="junction" elementId="100" />
+        </link>
+        <planView>
+            <geometry s="0" x="145.46487134128407" y="-70.80734182735712" hdg="4.283185307179586"
+                length="30">
+                <line />
+            </geometry>
+        </planView>
+        <elevationProfile />
+        <lateralProfile />
+        <lanes>
+            <laneSection s="0">
+                <left>
+                    <lane id="3" type="border" level="false">
+                        <link>
+                            <predecessor id="3" />
+                        </link>
+                        <width a="6.0" b="-0.2" c="0" d="0" sOffset="0" />
+                    </lane>
+                    <lane id="2" type="border" level="false">
+                        <link>
+                            <predecessor id="2" />
+                        </link>
+                        <width a="0.0" b="0.0" c="0" d="0" sOffset="0" />
+                    </lane>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1" />
+                        </link>
+                        <width a="3.25" b="0" c="0" d="0" sOffset="0" />
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0" type="broken" weight="standard" color="standard"
+                            height="0.02" width="0.2" />
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1" />
+                        </link>
+                        <width a="3.25" b="0" c="0" d="0" sOffset="0" />
+                    </lane>
+                    <lane id="-2" type="border" level="false">
+                        <link>
+                            <predecessor id="-2" />
+                        </link>
+                        <width a="0.3" b="-0.01" c="0" d="0" sOffset="0" />
+                    </lane>
+                    <lane id="-3" type="shoulder" level="false">
+                        <link>
+                            <predecessor id="-3" />
+                        </link>
+                        <width a="2.05" b="-0.06833333333333333" c="0" d="0" sOffset="0" />
+                        <height inner="0.12" outer="0.12" sOffset="0" />
+                    </lane>
+                    <lane id="-4" type="border" level="false">
+                        <link>
+                            <predecessor id="-4" />
+                        </link>
+                        <width a="0.2" b="-0.006666666666666667" c="0" d="0" sOffset="0" />
+                        <height inner="0.12" outer="0.12" sOffset="0" />
+                    </lane>
+                    <lane id="-5" type="biking" level="false">
+                        <link>
+                            <predecessor id="-5" />
+                        </link>
+                        <width a="1.6" b="-0.05333333333333334" c="0" d="0" sOffset="0" />
+                        <height inner="0.12" outer="0.12" sOffset="0" />
+                    </lane>
+                    <lane id="-6" type="sidewalk" level="false">
+                        <link>
+                            <predecessor id="-6" />
+                        </link>
+                        <width a="3" b="-0.1" c="0" d="0" sOffset="0" />
+                        <height inner="0.12" outer="0.12" sOffset="0" />
+                    </lane>
+                    <lane id="-7" type="border" level="false">
+                        <link>
+                            <predecessor id="-7" />
+                        </link>
+                        <width a="7" b="-0.23333333333333334" c="0" d="0" sOffset="0" />
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+    </road>
+    <road rule="RHT" id="3" junction="-1" length="30.1">
+        <link>
+            <predecessor elementType="junction" elementId="100" />
+        </link>
+        <type s="0" type="lowSpeed">
+            <speed max="10" unit="m/s" />
+        </type>
+        <planView>
+            <geometry s="0" x="123.0396342695736" y="-101.7848940592166" hdg="2.7123889803846897"
+                length="30.1">
+                <line />
+            </geometry>
+        </planView>
+        <elevationProfile />
+        <lateralProfile />
+        <lanes>
+            <laneSection s="0">
+                <left>
+                    <lane id="2" type="driving" level="false">
+                        <link />
+                        <width a="12" b="0" c="0" d="0" sOffset="0" />
+                    </lane>
+                    <lane id="1" type="driving" level="false">
+                        <link />
+                        <width a="3.25" b="0" c="0" d="0" sOffset="0" />
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link />
+                        <width a="3.25" b="0" c="0" d="0" sOffset="0" />
+                    </lane>
+                    <lane id="-2" type="driving" level="false">
+                        <link />
+                        <width a="12" b="0" c="0" d="0" sOffset="0" />
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+            <object type="parkingSpace" name="parking1" id="11" s="0" t="0.0" zOffset="0.0"
+                hdg="0" length="2.4" width="4.9">
+                <repeat distance="2.5" heightStart="4.0" heightEnd="4.0" zOffsetEnd="0.0"
+                    zOffsetStart="0.0"
+                    tStart="-12.7" tEnd="-12.7" length="30.0" s="1.3" />
+                <markings>
+                    <marking width="0.1" color="white" zOffset="0.005" spaceLength="0.0"
+                        lineLength="5.5"
+                        startOffset="0.0" stopOffset="0.0" side="rear">
+                        <userData code="lateralOffset" value="-0.05" />
+                    </marking>
+                    <marking width="0.1" color="white" zOffset="0.005" spaceLength="0.0"
+                        lineLength="5.5"
+                        startOffset="0.0" stopOffset="0.0" side="right">
+                        <userData code="lateralOffset" value="-0.05" />
+                    </marking>
+                    <marking width="0.1" color="white" zOffset="0.005" spaceLength="0.0"
+                        lineLength="5.5"
+                        startOffset="0.0" stopOffset="0.0" side="front">
+                        <userData code="lateralOffset" value="-0.05" />
+                    </marking>
+                </markings>
+            </object>
+            <object type="parkingSpace" name="parking2" id="12" s="0" t="0.0" zOffset="0.0"
+                hdg="0" length="2.4" width="5.0">
+                <repeat distance="2.5" heightStart="4.0" heightEnd="4.0" zOffsetEnd="0.0"
+                    zOffsetStart="0.0"
+                    tStart="12.7" tEnd="12.7" length="30.0" s="1.3" />
+                <markings>
+                    <marking width="0.1" color="white" zOffset="0.005" spaceLength="0.0"
+                        lineLength="5.5"
+                        startOffset="0.0" stopOffset="0.0" side="front">
+                        <userData code="lateralOffset" value="-0.05" />
+                    </marking>
+                    <marking width="0.1" color="white" zOffset="0.005" spaceLength="0.0"
+                        lineLength="5.5"
+                        startOffset="0.0" stopOffset="0.0" side="left">
+                        <userData code="lateralOffset" value="-0.05" />
+                    </marking>
+                    <marking width="0.1" color="white" zOffset="0.005" spaceLength="0.0"
+                        lineLength="5.5"
+                        startOffset="0.0" stopOffset="0.0" side="rear">
+                        <userData code="lateralOffset" value="-0.05" />
+                    </marking>
+                </markings>
+            </object>
+        </objects>
+    </road>
+    <road rule="RHT" id="4" junction="-1" length="20">
+        <link>
+            <predecessor elementType="junction" elementId="100" />
+        </link>
+        <planView>
+            <geometry s="0" x="126.73826369666263" y="-111.72572603451279" hdg="4.283185307179586"
+                length="20">
+                <line />
+            </geometry>
+        </planView>
+        <elevationProfile />
+        <lateralProfile />
+        <lanes>
+            <laneSection s="0">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link />
+                        <width a="3.25" b="0.0" c="-0.0" d="0.0" sOffset="0" />
+                        <roadMark sOffset="0" type="solid" weight="standard" color="standard"
+                            height="0.02" width="0.2" />
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0" type="broken" weight="standard" color="standard"
+                            height="0.02" width="0.2">
+                            <type name="broken" width="0.2">
+                                <line length="3" space="9" tOffset="0" width="0.15" sOffset="0" />
+                            </type>
+                        </roadMark>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link />
+                        <width a="3.25" b="0.0" c="-0.0" d="0.0" sOffset="0" />
+                        <roadMark sOffset="0" type="solid" weight="standard" color="standard"
+                            height="0.02" width="0.2" />
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+    </road>
+    <road rule="RHT" id="100" junction="100" length="12.451987006358245">
+        <link>
+            <predecessor elementType="road" elementId="2" contactPoint="end" />
+            <successor elementType="road" elementId="3" contactPoint="start" />
+        </link>
+        <planView>
+            <geometry s="0" x="132.98046624486977" y="-98.08626463212757" hdg="4.283185307179586"
+                length="3.9267690476849655">
+                <spiral curvStart="1e-09" curvEnd="-0.1842529233077952" />
+            </geometry>
+            <geometry s="3.9267690476849655" x="130.94105221227775" y="-101.41520203541766"
+                hdg="3.92142597104771" length="4.5984489109883135">
+                <spiral curvStart="-0.18425292330779514" curvEnd="-0.18425292330779514" />
+            </geometry>
+            <geometry s="8.525217958673279" x="126.7590065963201" y="-102.97119222004693"
+                hdg="3.074148316516566" length="3.9267690476849655">
+                <spiral curvStart="-0.1842529233077952" curvEnd="9.999999994736442e-10" />
+            </geometry>
+        </planView>
+        <elevationProfile />
+        <lateralProfile />
+        <lanes>
+            <laneSection s="0">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1" />
+                            <successor id="1" />
+                        </link>
+                        <width a="3.25" b="0.0" c="-0.0" d="0.0" sOffset="0" />
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1" />
+                            <successor id="-1" />
+                        </link>
+                        <width a="3.25" b="0.0" c="-0.0" d="0.0" sOffset="0" />
+                        <roadMark sOffset="0" type="solid" weight="standard" color="standard"
+                            height="0.02" width="0.2" />
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+    </road>
+    <road rule="RHT" id="101" junction="100" length="12.451987006358245">
+        <link>
+            <predecessor elementType="road" elementId="3" contactPoint="start" />
+            <successor elementType="road" elementId="4" contactPoint="start" />
+        </link>
+        <planView>
+            <geometry s="0" x="123.0396342695736" y="-101.7848940592166" hdg="5.853981633974483"
+                length="3.9267690476849655">
+                <spiral curvStart="1e-09" curvEnd="-0.1842529233077952" />
+            </geometry>
+            <geometry s="3.9267690476849655" x="126.3685716728637" y="-103.82430809180863"
+                hdg="5.4922222978426065" length="4.5984489109883135">
+                <spiral curvStart="-0.18425292330779514" curvEnd="-0.18425292330779514" />
+            </geometry>
+            <geometry s="8.525217958673279" x="127.92456185749296" y="-108.00635370776628"
+                hdg="4.6449446433114625" length="3.9267690476849655">
+                <spiral curvStart="-0.1842529233077952" curvEnd="9.999999994736442e-10" />
+            </geometry>
+        </planView>
+        <elevationProfile />
+        <lateralProfile />
+        <lanes>
+            <laneSection s="0">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1" />
+                            <successor id="1" />
+                        </link>
+                        <width a="3.25" b="0.0" c="-0.0" d="0.0" sOffset="0" />
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1" />
+                            <successor id="-1" />
+                        </link>
+                        <width a="3.25" b="0.0" c="-0.0" d="0.0" sOffset="0" />
+                        <roadMark sOffset="0" type="solid" weight="standard" color="standard"
+                            height="0.02" width="0.2" />
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+    </road>
+    <road rule="RHT" id="102" junction="100" length="15.0">
+        <link>
+            <predecessor elementType="road" elementId="2" contactPoint="end" />
+            <successor elementType="road" elementId="4" contactPoint="start" />
+        </link>
+        <planView>
+            <geometry s="0" x="132.98046624486977" y="-98.08626463212757" hdg="4.283185307179586"
+                length="15.0">
+                <line />
+            </geometry>
+        </planView>
+        <elevationProfile />
+        <lateralProfile />
+        <lanes>
+            <laneSection s="0">
+                <left>
+                    <lane id="1" type="driving" level="false">
+                        <link>
+                            <predecessor id="1" />
+                            <successor id="1" />
+                        </link>
+                        <width a="3.25" b="0.0" c="-0.0" d="0.0" sOffset="0" />
+                        <roadMark sOffset="0" type="solid" weight="standard" color="standard"
+                            height="0.02" width="0.2" />
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level="false">
+                        <roadMark sOffset="0" type="broken" weight="standard" color="standard"
+                            height="0.02" width="0.2">
+                            <type name="broken" width="0.2">
+                                <line length="4" space="9" tOffset="0" width="0.2" sOffset="5" />
+                            </type>
+                        </roadMark>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level="false">
+                        <link>
+                            <predecessor id="-1" />
+                            <successor id="-1" />
+                        </link>
+                        <width a="3.25" b="0.0" c="-0.0" d="0.0" sOffset="0" />
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+    </road>
+    <junction name="my junction" id="100" type="default">
+        <connection incomingRoad="2" id="0" contactPoint="start" connectingRoad="100">
+            <laneLink from="1" to="1" />
+            <laneLink from="-1" to="-1" />
+        </connection>
+        <connection incomingRoad="3" id="1" contactPoint="end" connectingRoad="100">
+            <laneLink from="1" to="1" />
+            <laneLink from="-1" to="-1" />
+        </connection>
+        <connection incomingRoad="3" id="2" contactPoint="start" connectingRoad="101">
+            <laneLink from="1" to="-1" />
+            <laneLink from="-1" to="1" />
+        </connection>
+        <connection incomingRoad="4" id="3" contactPoint="end" connectingRoad="101">
+            <laneLink from="1" to="1" />
+            <laneLink from="-1" to="-1" />
+        </connection>
+        <connection incomingRoad="4" id="4" contactPoint="end" connectingRoad="102">
+            <laneLink from="1" to="1" />
+            <laneLink from="-1" to="-1" />
+        </connection>
+        <connection incomingRoad="2" id="5" contactPoint="start" connectingRoad="102">
+            <laneLink from="1" to="1" />
+            <laneLink from="-1" to="-1" />
+        </connection>
+    </junction>
+</OpenDRIVE>

--- a/packages/drawtonomy-sdk/__tests__/fixtures/soderleden.xodr
+++ b/packages/drawtonomy-sdk/__tests__/fixtures/soderleden.xodr
@@ -1,0 +1,655 @@
+<?xml version="1.0" standalone="yes"?>
+<OpenDRIVE>
+    <header revMajor="1" revMinor="7" name="" version="1.00" date="Wed Jul  1 07:46:42 2020" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00">
+        <geoReference> <![CDATA[+proj=utm +lat_0=37.35429341239328 +lon_0=-122.0859797650754 +k_0=1 +x_0=0 +y_0=0 +datum=WGS84 +geoidgrids=egm96_15.gtx +vunits=m +zone=32 +ellps=GRS80 +units=m +no_defs]]>
+        </geoReference>
+    </header>
+    <road name="" length="1.4736654010688267e+03" id="0" junction="-1">
+        <link>
+            <predecessor elementType="junction" elementId="8"/>
+        </link>
+        <type s="0.0000000000000000e+00" type="motorway"/>
+        <planView>
+            <geometry s="0.0000000000000000e+00" x="7.9113134075887501e+00" y="1.8445681725628674e+01" hdg="-1.5320868260295661e-02" length="3.5095845791110236e+02">
+                <paramPoly3 pRange="arcLength" aU="0.0000000000000000e+00" bU="1.0000000000000000e+00" cU="-1.5242630501756444e-08" dU="4.8168195177690708e-12" aV="0.0000000000000000e+00" bV="0.0000000000000000e+00" cV="2.4065405387521902e-05" dV="-6.8570524075010782e-08"/>
+            </geometry>
+            <geometry s="3.5095845791110236e+02" x="3.5882691301521845e+02" y="1.3068929353728890e+01" hdg="-2.3766700330396517e-02" length="2.2259866074459575e+02">
+                <paramPoly3 pRange="arcLength" aU="0.0000000000000000e+00" bU="1.0000000000000000e+00" cU="2.5148251175736379e-07" dU="-2.5097418854626902e-09" aV="0.0000000000000000e+00" bV="0.0000000000000000e+00" cV="7.0988036336312992e-06" dV="-2.0233312644530308e-07"/>
+            </geometry>
+            <geometry s="5.7355711865569810e+02" x="5.8130281603441108e+02" y="5.8999373195692897e+00" hdg="-5.0683778150055758e-02" length="3.8811310025233661e+02">
+                <paramPoly3 pRange="arcLength" aU="0.0000000000000000e+00" bU="1.0000000000000000e+00" cU="9.7158519585766672e-08" dU="-1.8201575958334395e-09" aV="0.0000000000000000e+00" bV="0.0000000000000000e+00" cV="-4.0487351886609478e-05" dV="-1.8291670023231930e-08"/>
+            </geometry>
+            <geometry s="9.6167021890803471e+02" x="9.6846271592250559e+02" y="-2.0916878180578351e+01" hdg="-9.0385845654093799e-02" length="3.7499290493717467e+02">
+                <paramPoly3 pRange="arcLength" aU="0.0000000000000000e+00" bU="1.0000000000000000e+00" cU="-4.3184961204105125e-07" dU="-7.8530743086092201e-10" aV="0.0000000000000000e+00" bV="0.0000000000000000e+00" cV="-8.2544921686899262e-05" dV="6.9161950339447591e-08"/>
+            </geometry>
+            <geometry s="1.3366631238452094e+03" x="1.3411046408297261e+03" y="-6.2683519044891000e+01" hdg="-1.2312652643098421e-01" length="1.3700227722361728e+02">
+                <paramPoly3 pRange="arcLength" aU="0.0000000000000000e+00" bU="1.0000000000000000e+00" cU="-7.9781776674765341e-07" dU="1.8239983485308247e-09" aV="0.0000000000000000e+00" bV="0.0000000000000000e+00" cV="-1.6802258309740026e-04" dV="6.1322343315120183e-07"/>
+            </geometry>
+        </planView>
+        <lateralProfile>
+        </lateralProfile>
+        <lanes>
+            <laneOffset s="0.0000000000000000e+00" a="3.5000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+            <laneOffset s="1.0000000000000000e+02" a="3.5000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+            <laneSection s="0.0000000000000000e+00">
+                <left>
+                    <lane id="2" type="sidewalk" level= "false">
+                        <link>
+                            <successor id="2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <height sOffset="0.0000000000000000e+00" inner="1.1999999731779099e-01" outer="1.1999999731779099e-01"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="bo_3d_sidewalk" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                    <lane id="1" type="border" level= "false">
+                        <link>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.9999999999999999e-01" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <height sOffset="0.0000000000000000e+00" inner="0.0000000000000000e+00" outer="0.0000000000000000e+00"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="bo_cobble" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level= "false">
+                        <link>
+                        </link>
+                        <userData code="viStyleDef">
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level= "false">
+                        <link>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.5000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="both" height="1.9999999552965164e-02">
+                            <type name="broken" width="1.2000000000000000e-01" >
+                                <line length="3.0000000000000000e+00" space="8.0000000000000000e+00" tOffset="0.0000000000000000e+00" sOffset="0.0000000000000000e+00" rule="caution" width="1.2000000000000000e-01"/>
+                            </type>
+                        </roadMark>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="standard" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                    <lane id="-2" type="driving" level= "false">
+                        <link>
+                            <successor id="-2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.5000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="both" height="1.9999999552965164e-02">
+                            <type name="broken" width="1.2000000000000000e-01" >
+                                <line length="3.0000000000000000e+00" space="8.0000000000000000e+00" tOffset="0.0000000000000000e+00" sOffset="0.0000000000000000e+00" rule="caution" width="1.2000000000000000e-01"/>
+                            </type>
+                        </roadMark>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="standard" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                    <lane id="-3" type="driving" level= "false">
+                        <link>
+                            <successor id="-2"/>                        
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.5000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <width sOffset="7.5000000000000000e+01" a="3.5000000000000000e+00" b="0.0000000000000000e+00" c="-1.6800000000000002e-02" d="4.4800000000000005e-04"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="standard" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                    <lane id="-4" type="border" level= "false">
+                        <link>
+                            <successor id="-3"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.9999999999999999e-01" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <height sOffset="0.0000000000000000e+00" inner="0.0000000000000000e+00" outer="0.0000000000000000e+00"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="bo_cobble" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                    <lane id="-5" type="sidewalk" level= "false">
+                        <link>
+                            <successor id="-4"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <height sOffset="0.0000000000000000e+00" inner="1.1999999731779099e-01" outer="1.1999999731779099e-01"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="bo_3d_sidewalk" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="1.0000000000000000e+02">
+                <left>
+                    <lane id="2" type="sidewalk" level= "false">
+                        <link>
+                            <predecessor id="2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <height sOffset="0.0000000000000000e+00" inner="1.1999999731779099e-01" outer="1.1999999731779099e-01"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="bo_3d_sidewalk" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                    <lane id="1" type="border" level= "false">
+                        <link>
+                            <predecessor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.0000001192092896e-01" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <height sOffset="0.0000000000000000e+00" inner="0.0000000000000000e+00" outer="0.0000000000000000e+00"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="bo_cobble" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level= "false">
+                        <link>
+                        </link>
+                        <userData code="viStyleDef">
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level= "false">
+                        <link>
+                            <predecessor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.5000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="both" height="1.9999999552965164e-02">
+                            <type name="broken" width="1.2000000000000000e-01" >
+                                <line length="3.0000000000000000e+00" space="8.0000000000000000e+00" tOffset="0.0000000000000000e+00" sOffset="0.0000000000000000e+00" rule="caution" width="1.2000000000000000e-01"/>
+                            </type>
+                        </roadMark>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="standard" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                    <lane id="-2" type="driving" level= "false">
+                        <link>
+                            <predecessor id="-2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.5000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="standard" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                    <lane id="-3" type="border" level= "false">
+                        <link>
+                            <predecessor id="-4"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.9999999999999999e-01" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <height sOffset="0.0000000000000000e+00" inner="0.0000000000000000e+00" outer="0.0000000000000000e+00"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="bo_cobble" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                    <lane id="-4" type="sidewalk" level= "false">
+                        <link>
+                            <predecessor id="-5"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <height sOffset="0.0000000000000000e+00" inner="1.1999999731779099e-01" outer="1.1999999731779099e-01"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="bo_3d_sidewalk" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+        </objects>
+        <signals>
+        </signals>
+        <surface>
+        </surface>
+    </road>
+    <road name="" length="1.0063988117235961e+02" id="1" junction="-1">
+        <link>
+            <successor elementType="road" elementId="5" contactPoint="start" />
+        </link>
+        <type s="0.0000000000000000e+00" type="motorway"/>
+        <planView>
+            <geometry s="0.0000000000000000e+00" x="-1.4902221753995400e+02" y="-2.7028281966224313e+01" hdg="7.7723731014813058e-01" length="1.7362754186685208e+01">
+                <paramPoly3 pRange="arcLength" aU="0.0000000000000000e+00" bU="1.0000000000000000e+00" cU="-5.1036681777978078e-05" dU="3.3437121099182798e-07" aV="0.0000000000000000e+00" bV="0.0000000000000000e+00" cV="6.2478880921690650e-03" dV="-3.5984429802964768e-04"/>
+            </geometry>
+            <geometry s="1.7362754186685208e+01" x="-1.3665483302611392e+02" y="-1.4861124692484736e+01" hdg="6.6902149242171205e-01" length="1.0123867491175396e+01">
+                <paramPoly3 pRange="arcLength" aU="0.0000000000000000e+00" bU="1.0000000000000000e+00" cU="-2.5402078429887024e-04" dU="-4.6127505620379083e-05" aV="0.0000000000000000e+00" bV="0.0000000000000000e+00" cV="-1.3746043623158340e-02" dV="3.0554276677954612e-04"/>
+            </geometry>
+            <geometry s="2.7486621677860605e+01" x="-1.2809417235828005e+02" y="-9.4844094850122929e+00" hdg="4.8317881228547110e-01" length="1.4991858484647082e+01">
+                <paramPoly3 pRange="arcLength" aU="0.0000000000000000e+00" bU="1.0000000000000000e+00" cU="-1.5249842089390931e-04" dU="-5.9435071354332354e-06" aV="0.0000000000000000e+00" bV="0.0000000000000000e+00" cV="-7.6705152628822456e-03" dV="1.6682038139582720e-04"/>
+            </geometry>
+            <geometry s="4.2478480162507687e+01" x="-1.1432681898085866e+02" y="-3.5733540747314692e+00" hdg="3.6520325966753708e-01" length="1.4058051982434492e+01">
+                <paramPoly3 pRange="arcLength" aU="0.0000000000000000e+00" bU="1.0000000000000000e+00" cU="-4.3315814213227820e-05" dU="-1.8799724557201101e-06" aV="0.0000000000000000e+00" bV="0.0000000000000000e+00" cV="-4.2355675897509061e-03" dV="9.7216643270909764e-05"/>
+            </geometry>
+            <geometry s="5.6536532144942178e+01" x="-1.0100626417703461e+02" y="9.1281992755830288e-01" hdg="3.0368808092197652e-01" length="7.3083272742014813e+00">
+                <paramPoly3 pRange="arcLength" aU="0.0000000000000000e+00" bU="1.0000000000000000e+00" cU="2.3911531449926955e-05" dU="-9.8025733956035306e-06" aV="0.0000000000000000e+00" bV="0.0000000000000000e+00" cV="-1.3045211777413584e-03" dV="-2.1771277574851410e-04"/>
+            </geometry>
+            <geometry s="6.3844859419143660e+01" x="-9.3988547916291282e+01" y="2.9499675808474422e+00" hdg="2.4972163438410983e-01" length="9.7257884733026572e+00">
+                <paramPoly3 pRange="arcLength" aU="0.0000000000000000e+00" bU="1.0000000000000000e+00" cU="9.1473925064661032e-06" dU="-8.7424835061867841e-06" aV="0.0000000000000000e+00" bV="0.0000000000000000e+00" cV="-2.9994273637487588e-03" dV="-3.8224736636843658e-05"/>
+            </geometry>
+            <geometry s="7.3570647892446317e+01" x="-8.4492588901426643e+01" y="5.0427760779857635e+00" hdg="1.8048204817687535e-01" length="2.7069233279913291e+01">
+                <paramPoly3 pRange="arcLength" aU="0.0000000000000000e+00" bU="1.0000000000000000e+00" cU="-4.0500208204465152e-05" dU="4.6964269726655513e-07" aV="0.0000000000000000e+00" bV="0.0000000000000000e+00" cV="-2.6920438966996328e-03" dV="4.9735310570125705e-05"/>
+            </geometry>
+        </planView>
+        <lateralProfile>
+        </lateralProfile>
+        <lanes>
+            <laneOffset s="0.0000000000000000e+00" a="1.7500000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+            <laneSection s="0.0000000000000000e+00">
+                <left>
+                    <lane id="2" type="sidewalk" level= "false">
+                        <link>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <height sOffset="0.0000000000000000e+00" inner="1.1999999731779099e-01" outer="1.1999999731779099e-01"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="bo_3d_sidewalk" mapping="auto" />
+                            <fillet pos="leftOfLane" style="grass" id="3" />
+                        </userData>
+                    </lane>
+                    <lane id="1" type="border" level= "false">
+                        <link>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.0000001192092896e-01" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <height sOffset="0.0000000000000000e+00" inner="0.0000000000000000e+00" outer="0.0000000000000000e+00"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="bo_cobble" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level= "false">
+                        <link>
+                        </link>
+                        <userData code="viStyleDef">
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level= "false">
+                        <link>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.5000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="standard" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                    <lane id="-2" type="border" level= "false">
+                        <link>
+                            <successor id="-2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.0000001192092896e-01" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <height sOffset="0.0000000000000000e+00" inner="0.0000000000000000e+00" outer="0.0000000000000000e+00"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="bo_cobble" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                    <lane id="-3" type="sidewalk" level= "false">
+                        <link>
+                            <successor id="-3"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <height sOffset="0.0000000000000000e+00" inner="1.1999999731779099e-01" outer="1.1999999731779099e-01"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="bo_3d_sidewalk" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+        </objects>
+        <signals>
+        </signals>
+        <surface>
+        </surface>
+    </road>
+    <road name="" length="2.3984274572936641e+02" id="2" junction="-1">
+        <link>
+            <successor elementType="junction" elementId="8"/>
+        </link>
+        <type s="0.0000000000000000e+00" type="motorway"/>
+        <planView>
+            <geometry s="0.0000000000000000e+00" x="-2.3191824620543048e+02" y="2.0950382480397820e+01" hdg="-1.0520310622673001e-02" length="8.7827587823372440e+01">
+                <paramPoly3 pRange="arcLength" aU="0.0000000000000000e+00" bU="1.0000000000000000e+00" cU="-3.1521603295387557e-12" dU="3.9800289602797051e-15" aV="0.0000000000000000e+00" bV="0.0000000000000000e+00" cV="-6.9180636643916106e-07" dV="7.8768685738065941e-09"/>
+            </geometry>
+            <geometry s="8.7827587823372440e+01" x="-1.4409551860298961e+02" y="2.0026426019147038e+01" hdg="-1.0459550938314521e-02" length="8.5846428664217669e+01">
+                <paramPoly3 pRange="arcLength" aU="0.0000000000000000e+00" bU="1.0000000000000000e+00" cU="-3.5478676090468060e-11" dU="1.2941623759634672e-13" aV="0.0000000000000000e+00" bV="0.0000000000000000e+00" cV="1.4155436699266741e-06" dV="-8.2446276027922283e-09"/>
+            </geometry>
+            <geometry s="1.7367401648759011e+02" x="-5.8253731413825150e+01" y="1.9133743016351175e+01" hdg="-1.0398791253956041e-02" length="6.6168729241776319e+01">
+                <paramPoly3 pRange="arcLength" aU="0.0000000000000000e+00" bU="1.0000000000000000e+00" cU="-2.7457378044500766e-08" dU="4.6016902156790426e-11" aV="0.0000000000000000e+00" bV="0.0000000000000000e+00" cV="7.4387129718039280e-05" dV="-1.1242036921433606e-06"/>
+            </geometry>
+        </planView>
+        <lateralProfile>
+        </lateralProfile>
+        <lanes>
+            <laneOffset s="0.0000000000000000e+00" a="3.5000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+            <laneOffset s="1.7367401648759011e+02" a="3.5000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+            <laneSection s="0.0000000000000000e+00">
+                <left>
+                    <lane id="2" type="sidewalk" level= "false">
+                        <link>
+                            <successor id="2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <height sOffset="0.0000000000000000e+00" inner="1.1999999731779099e-01" outer="1.1999999731779099e-01"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="bo_3d_sidewalk" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                    <lane id="1" type="border" level= "false">
+                        <link>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.0000001192092896e-01" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <height sOffset="0.0000000000000000e+00" inner="0.0000000000000000e+00" outer="0.0000000000000000e+00"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="bo_cobble" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level= "false">
+                        <link>
+                        </link>
+                        <userData code="viStyleDef">
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level= "false">
+                        <link>
+                            <successor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.5000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="both" height="1.9999999552965164e-02">
+                            <type name="broken" width="1.2000000000000000e-01" >
+                                <line length="3.0000000000000000e+00" space="8.0000000000000000e+00" tOffset="0.0000000000000000e+00" sOffset="0.0000000000000000e+00" rule="caution" width="1.2000000000000000e-01"/>
+                            </type>
+                        </roadMark>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="standard" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                    <lane id="-2" type="driving" level= "false">
+                        <link>
+                            <successor id="-2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.5000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="standard" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                    <lane id="-3" type="border" level= "false">
+                        <link>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.0000001192092896e-01" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <height sOffset="0.0000000000000000e+00" inner="0.0000000000000000e+00" outer="0.0000000000000000e+00"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="bo_cobble" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                    <lane id="-4" type="sidewalk" level= "false">
+                        <link>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <height sOffset="0.0000000000000000e+00" inner="1.1999999731779099e-01" outer="1.1999999731779099e-01"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="bo_3d_sidewalk" mapping="auto" />
+                            <fillet pos="rightOfLane" style="grass" id="3" />
+                        </userData>
+                    </lane>
+                </right>
+            </laneSection>
+            <laneSection s="1.7367401648759011e+02">
+                <left>
+                    <lane id="2" type="sidewalk" level= "false">
+                        <link>
+                            <predecessor id="2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <height sOffset="0.0000000000000000e+00" inner="1.1999999731779099e-01" outer="1.1999999731779099e-01"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="bo_3d_sidewalk" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                    <lane id="1" type="border" level= "false">
+                        <link>
+                            <predecessor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.0000001192092896e-01" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <height sOffset="0.0000000000000000e+00" inner="0.0000000000000000e+00" outer="0.0000000000000000e+00"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="bo_cobble" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="none" level= "false">
+                        <link>
+                        </link>
+                        <userData code="viStyleDef">
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level= "false">
+                        <link>
+                            <predecessor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.5000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard" color="standard" width="1.2000000000000000e-01" laneChange="both" height="1.9999999552965164e-02">
+                            <type name="broken" width="1.2000000000000000e-01" >
+                                <line length="3.0000000000000000e+00" space="8.0000000000000000e+00" tOffset="0.0000000000000000e+00" sOffset="0.0000000000000000e+00" rule="caution" width="1.2000000000000000e-01"/>
+                            </type>
+                        </roadMark>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="standard" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                    <lane id="-2" type="driving" level= "false">
+                        <link>
+                            <predecessor id="-2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.5000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.3000000000000000e-01" laneChange="none" height="1.9999999552965164e-02">
+                            <type name="solid" width="1.3000000000000000e-01">
+                                <line length="2.3984274572936641e+02" space="0.0000000000000000e+00" tOffset="0.0000000000000000e+00" sOffset="0.0000000000000000e+00" rule="no passing" width="1.3000000000000000e-01" />
+                            </type>
+                        </roadMark>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="standard" mapping="auto" />
+                            <fillet pos="rightOfLane" style="pavement" id="2" />
+                        </userData>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+        </objects>
+        <signals>
+        </signals>
+        <surface>
+        </surface>
+    </road>
+    <road name="" length="6.6139004569146593e+01" id="5" junction="-1">
+        <link>
+            <predecessor elementType="road" elementId="1" contactPoint="end" />
+            <successor elementType="junction" elementId="8"/>
+        </link>
+        <planView>
+            <geometry s="0.0000000000000000e+00" x="-5.7706057497113498e+01" y="8.9280811794847654e+00" hdg="1.4404241997005929e-01" length="6.6139004569146593e+01">
+                <paramPoly3 pRange="arcLength" aU="0.0000000000000000e+00" bU="1.0000000000000000e+00" cU="1.8629611779875546e-05" dU="-6.7115625657949638e-07" aV="0.0000000000000000e+00" bV="0.0000000000000000e+00" cV="1.2297471907300197e-03" dV="-2.4565468987168327e-05"/>
+            </geometry>
+        </planView>
+        <lateralProfile>
+        </lateralProfile>
+        <lanes>
+            <laneOffset s="0.0000000000000000e+00" a="1.7500000000000000e+00" b="0.0000000000000000e+00" c="-2.4003471198206679e-03" d="2.4194974420746893e-05"/>
+            <laneOffset s="6.6138999999999996e+01" a="-1.7500000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+            <laneSection s="0.0000000000000000e+00">
+                <center>
+                    <lane id="0" type="none" level= "false">
+                        <link>
+                        </link>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.3000000000000000e-01" laneChange="none" height="1.9999999552965164e-02">
+                            <type name="solid" width="1.3000000000000000e-01">
+                                <line length="6.6139004569146593e+01" space="0.0000000000000000e+00" tOffset="0.0000000000000000e+00" sOffset="0.0000000000000000e+00" rule="no passing" width="1.3000000000000000e-01" />
+                            </type>
+                        </roadMark>
+                        <userData code="viStyleDef">
+                            <fillet pos="none" style="none" id="2" />
+                        </userData>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level= "false">
+                        <link>
+                            <predecessor id="-1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.5000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="standard" mapping="auto" />
+                            <fillet pos="leftOfLane" style="pavement" id="2" />
+                        </userData>
+                    </lane>
+                    <lane id="-2" type="border" level= "false">
+                        <link>
+                            <predecessor id="-2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.0000001192092896e-01" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <height sOffset="0.0000000000000000e+00" inner="0.0000000000000000e+00" outer="0.0000000000000000e+00"/>
+                        <height sOffset="6.6139004569146593e+01" inner="0.0000000000000000e+00" outer="0.0000000000000000e+00"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="bo_cobble" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                    <lane id="-3" type="sidewalk" level= "false">
+                        <link>
+                            <predecessor id="-3"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <height sOffset="0.0000000000000000e+00" inner="1.1999999731779099e-01" outer="1.1999999731779099e-01"/>
+                        <height sOffset="6.6139004569146593e+01" inner="1.1999999731779099e-01" outer="1.1999999731779099e-01"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="bo_3d_sidewalk" mapping="auto" />
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+        </objects>
+        <signals>
+        </signals>
+        <surface>
+        </surface>
+    </road>
+    <road name="" length="7.4678786415236234e+00" id="7" junction="-1">
+        <link>
+            <predecessor elementType="road" elementId="2" contactPoint="end" />
+            <successor elementType="road" elementId="1" contactPoint="end" />
+        </link>
+        <planView>
+            <geometry s="0.0000000000000000e+00" x="-5.8290126522947872e+01" y="1.5633932236825729e+01" hdg="-1.0398791258924511e-02" length="7.4678786415236234e+00">
+                <arc curvature="-3.9999999809266934e-01"/>
+            </geometry>
+        </planView>
+        <lateralProfile>
+        </lateralProfile>
+        <lanes>
+            <laneSection s="0.0000000000000000e+00">
+                <center>
+                    <lane id="0" type="none" level= "false">
+                        <link>
+                        </link>
+                        <userData code="viStyleDef">
+                            <fillet pos="none" style="none" id="0" />
+                        </userData>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="border" level= "false">
+                        <link>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.0000001192092896e-01" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <height sOffset="0.0000000000000000e+00" inner="0.0000000000000000e+00" outer="0.0000000000000000e+00"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="bo_cobble" mapping="auto" />
+                            <fillet pos="leftOfLane" style="pavement" id="2" />
+                        </userData>
+                    </lane>
+                    <lane id="-2" type="sidewalk" level= "false">
+                        <link>
+                            <successor id="2"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0000000000000000e+00" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="-0.0000000000000000e+00"/>
+                        <height sOffset="0.0000000000000000e+00" inner="1.1999999731779099e-01" outer="1.1999999731779099e-01"/>
+                        <userData code="viStyleDef">
+                            <style sOffset="0.000000" laneStyle="bo_3d_sidewalk" mapping="auto" />
+                            <fillet pos="rightOfLane" style="grass" id="3" />
+                        </userData>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+        </objects>
+        <signals>
+        </signals>
+        <surface>
+        </surface>
+    </road>
+    <junction name="" id="8" type="direct">
+        <connection id="0" incomingRoad="2" linkedRoad="0" contactPoint="start">
+            <laneLink from="2" to="2"/>        
+            <laneLink from="1" to="1"/>
+            <laneLink from="-1" to="-1"/>
+            <laneLink from="-2" to="-2"/>
+         </connection>
+        <connection id="1" incomingRoad="5" linkedRoad="0" contactPoint="start">
+            <laneLink from="-1" to="-3"/>
+            <laneLink from="-2" to="-4"/>
+            <laneLink from="-3" to="-5"/>
+        </connection>
+    </junction>
+</OpenDRIVE>

--- a/packages/drawtonomy-sdk/src/exporter/odrToShapes.ts
+++ b/packages/drawtonomy-sdk/src/exporter/odrToShapes.ts
@@ -43,6 +43,7 @@ import {
   type ImportedCrosswalk,
   type ImportedLane,
   type ImportedLinestring,
+  type ImportedParkingSpace,
   type ImportedPoint,
   type ImportedShapes,
   type ImportedTrafficLight,
@@ -299,6 +300,7 @@ export function odrToShapes(map: OdrMap, options: OdrToShapesOptions = {}): OdrI
     trafficLights: [],
     trafficSigns: [],
     crosswalks: [],
+    parkingSpaces: [],
     bounds: emptyBounds(),
     sidecar: {
       rawXml: map.rawXml,
@@ -807,6 +809,92 @@ export function odrToShapes(map: OdrMap, options: OdrToShapesOptions = {}): OdrI
 
   for (const { road, samples } of signalRoads) {
     materializeCrosswalks(road, samples)
+  }
+
+  /**
+   * Convert `<object type="parkingSpace">` into polygon footprints. Corner
+   * geometry follows the OpenDRIVE object outline model:
+   *   - <cornerLocal u v>: the object origin is the (s, t) station on the
+   *     reference line; each corner sits at (u, v) in the object's local frame,
+   *     whose u axis points along the road heading + the object's own `hdg`.
+   *   - <cornerRoad s t>: each corner is an independent (s, t) station on the
+   *     reference line (no object-local rotation).
+   * When an object carries no outline the footprint is an oriented rectangle
+   * derived from s/t/hdg/length/width (the crosswalk band construction reused,
+   * closed into four corners). Vertices are converted meters -> canvas pixels,
+   * matching every other imported shape. Only the footprint is materialized;
+   * the source <object> stays verbatim in the sidecar for carry-through export.
+   */
+  function materializeParkingSpaces(road: OdrRoad, samples: ReferenceSample[]): void {
+    for (const obj of road.objects) {
+      if (obj.type !== 'parkingSpace') continue
+      let enuCorners: EnuPoint[] = []
+      if (obj.outline.length >= 3) {
+        const localCorners = obj.outline.filter(c => c.u !== undefined && c.v !== undefined)
+        const roadCorners = obj.outline.filter(c => c.s !== undefined && c.t !== undefined)
+        if (localCorners.length >= 3) {
+          const pose = poseAt(samples, obj.s)
+          // Object origin: reference-line pose at s, shifted by t along +normal.
+          const ox = pose.x - Math.sin(pose.hdg) * obj.t
+          const oy = pose.y + Math.cos(pose.hdg) * obj.t
+          const axisHdg = pose.hdg + obj.hdg
+          const cu = Math.cos(axisHdg)
+          const su = Math.sin(axisHdg)
+          enuCorners = localCorners.map(c => ({
+            // Local u axis along axisHdg, v axis 90° to its left (+normal).
+            x: ox + cu * (c.u as number) - su * (c.v as number),
+            y: oy + su * (c.u as number) + cu * (c.v as number),
+          }))
+        } else if (roadCorners.length >= 3) {
+          enuCorners = roadCorners.map(c => {
+            const p = poseAt(samples, c.s as number)
+            return {
+              x: p.x - Math.sin(p.hdg) * (c.t as number),
+              y: p.y + Math.cos(p.hdg) * (c.t as number),
+            }
+          })
+        }
+      }
+      if (enuCorners.length < 3) {
+        // No usable outline: derive an oriented rectangle from s/t/hdg/l/w.
+        if (!(obj.length > 0) || !(obj.width > 0)) continue
+        const pose = poseAt(samples, obj.s)
+        const cx = pose.x - Math.sin(pose.hdg) * obj.t
+        const cy = pose.y + Math.cos(pose.hdg) * obj.t
+        const axisHdg = pose.hdg + obj.hdg
+        const ux = Math.cos(axisHdg)
+        const uy = Math.sin(axisHdg)
+        // Normal (left of the object axis) for the width direction.
+        const nx = -uy
+        const ny = ux
+        const hl = obj.length / 2
+        const hw = obj.width / 2
+        enuCorners = [
+          { x: cx - ux * hl - nx * hw, y: cy - uy * hl - ny * hw },
+          { x: cx + ux * hl - nx * hw, y: cy + uy * hl - ny * hw },
+          { x: cx + ux * hl + nx * hw, y: cy + uy * hl + ny * hw },
+          { x: cx - ux * hl + nx * hw, y: cy - uy * hl + ny * hw },
+        ]
+      }
+
+      const data: ImportedParkingSpace = {
+        id: idAllocator.next('polygon'),
+        points: enuCorners.map(p => ({ x: enuToCanvasX(p.x), y: enuToCanvasY(p.y) })),
+        osmId: '',
+        attributes: {
+          type: 'parking_space',
+          odr_object_id: obj.id,
+          odr_road_id: road.id,
+          odr_type: obj.type,
+        },
+      }
+      ;(result.parkingSpaces ??= []).push(data)
+      convertedObjectCount++
+    }
+  }
+
+  for (const { road, samples } of signalRoads) {
+    materializeParkingSpaces(road, samples)
   }
 
   // Restore right-of-way links stashed by the exporter.

--- a/packages/drawtonomy-sdk/src/exporter/opendriveParser.ts
+++ b/packages/drawtonomy-sdk/src/exporter/opendriveParser.ts
@@ -224,6 +224,14 @@ export interface OdrJunctionLaneLink {
 export interface OdrJunctionConnection {
   id: string
   incomingRoad: string
+  /**
+   * The other road this connection links lanes to. For a standard junction
+   * this is the synthesized `connectingRoad`; for a direct junction
+   * (`<junction type="direct">`, OpenDRIVE 1.5+) the source attribute is
+   * `linkedRoad` instead and the value is the road the incoming road joins
+   * directly (no separate connecting road). Both are normalized here so the
+   * shape converter wires lane links uniformly.
+   */
   connectingRoad: string
   contactPoint: 'start' | 'end'
   laneLinks: OdrJunctionLaneLink[]
@@ -240,6 +248,8 @@ export interface OdrJunctionPriority {
 export interface OdrJunction {
   id: string
   name: string
+  /** Junction type; "default" when absent, "direct" for direct junctions. */
+  type: string
   connections: OdrJunctionConnection[]
   priorities: OdrJunctionPriority[]
 }
@@ -689,23 +699,33 @@ function parseRoad(el: XmlNode): OdrRoad {
 
 function parseJunction(el: XmlNode): OdrJunction {
   const id = requireStrAttr(el, 'id', '<junction>')
-  const connections: OdrJunctionConnection[] = children(el, 'connection').map(conn => {
+  const connections: OdrJunctionConnection[] = []
+  for (const conn of children(el, 'connection')) {
     const ctx = `junction ${id}, <connection>`
-    return {
+    // Standard junctions use `connectingRoad`; direct junctions
+    // (<junction type="direct">) use `linkedRoad`. Accept either so the whole
+    // map does not fail to parse over one unsupported junction flavor.
+    const connectingRoad = conn.attrs.connectingRoad ?? conn.attrs.linkedRoad
+    if (connectingRoad === undefined || connectingRoad === '') {
+      // Tolerant skip: a connection with no target road cannot wire lanes, but
+      // must not abort the whole document (road network stays importable).
+      continue
+    }
+    connections.push({
       id: conn.attrs.id ?? '',
       incomingRoad: requireStrAttr(conn, 'incomingRoad', ctx),
-      connectingRoad: requireStrAttr(conn, 'connectingRoad', ctx),
+      connectingRoad,
       contactPoint: parseContactPoint(conn.attrs.contactPoint) ?? 'start',
       laneLinks: children(conn, 'laneLink').map(ll => ({
         from: requireNumAttr(ll, 'from', ctx),
         to: requireNumAttr(ll, 'to', ctx),
       })),
-    }
-  })
+    })
+  }
   const priorities = children(el, 'priority')
     .map(pr => ({ high: pr.attrs.high ?? '', low: pr.attrs.low ?? '' }))
     .filter(pr => pr.high !== '' && pr.low !== '')
-  return { id, name: el.attrs.name ?? '', connections, priorities }
+  return { id, name: el.attrs.name ?? '', type: el.attrs.type ?? 'default', connections, priorities }
 }
 
 /** Parse an OpenDRIVE XML string into the intermediate `OdrMap` model. */

--- a/packages/drawtonomy-sdk/src/exporter/opendriveParser.ts
+++ b/packages/drawtonomy-sdk/src/exporter/opendriveParser.ts
@@ -153,6 +153,23 @@ export interface OdrSignalReference {
   validity: OdrSignalValidity[]
 }
 
+/**
+ * A single `<outline>/<cornerLocal>` or `<outline>/<cornerRoad>` corner. Exactly
+ * one coordinate pair is present: `u`/`v` for a corner relative to the object's
+ * local frame (origin at s/t, u axis along the object heading), or `s`/`t` for a
+ * corner on the road reference line.
+ */
+export interface OdrObjectCorner {
+  /** Local u coordinate (m) for a <cornerLocal>, else undefined. */
+  u?: number
+  /** Local v coordinate (m) for a <cornerLocal>, else undefined. */
+  v?: number
+  /** Reference-line station (m) for a <cornerRoad>, else undefined. */
+  s?: number
+  /** Reference-line offset (m) for a <cornerRoad>, else undefined. */
+  t?: number
+}
+
 /** Minimal object record (kept for later conversion phases). */
 export interface OdrObject {
   id: string
@@ -167,6 +184,12 @@ export interface OdrObject {
   length: number
   /** Extent along the object's local v axis (m). */
   width: number
+  /**
+   * Corners of the first `<outline>` (cornerLocal or cornerRoad). Empty when
+   * the object has no explicit outline (an oriented rectangle is derived from
+   * s/t/hdg/length/width instead).
+   */
+  outline: OdrObjectCorner[]
   /** <userData code value> records attached to the object (code -> value). */
   userData: Record<string, string>
 }
@@ -615,6 +638,20 @@ function parseRoad(el: XmlNode): OdrRoad {
     : []
 
   const objectsEl = child(el, 'objects')
+  const parseObjectOutline = (obj: XmlNode): OdrObjectCorner[] => {
+    const outlinesEl = child(obj, 'outlines')
+    // The first <outline> defines the footprint; markings reference its corners.
+    const outlineEl = outlinesEl ? child(outlinesEl, 'outline') : undefined
+    if (!outlineEl) return []
+    const corners: OdrObjectCorner[] = []
+    for (const c of children(outlineEl, 'cornerLocal')) {
+      corners.push({ u: numAttr(c, 'u', 0), v: numAttr(c, 'v', 0) })
+    }
+    for (const c of children(outlineEl, 'cornerRoad')) {
+      corners.push({ s: numAttr(c, 's', 0), t: numAttr(c, 't', 0) })
+    }
+    return corners
+  }
   const objects: OdrObject[] = objectsEl
     ? children(objectsEl, 'object').map(obj => ({
         id: obj.attrs.id ?? '',
@@ -626,6 +663,7 @@ function parseRoad(el: XmlNode): OdrRoad {
         hdg: numAttr(obj, 'hdg', 0),
         length: numAttr(obj, 'length', 0),
         width: numAttr(obj, 'width', 0),
+        outline: parseObjectOutline(obj),
         userData: parseUserData(obj),
       }))
     : []

--- a/packages/drawtonomy-sdk/src/exporter/osmToShapes.ts
+++ b/packages/drawtonomy-sdk/src/exporter/osmToShapes.ts
@@ -18,12 +18,12 @@ import { latLonToCanvas, type OsmData } from './osmParser'
  * a custom allocator to coordinate IDs with their own counters.
  */
 export interface ShapeIdAllocator {
-  next(kind: 'point' | 'linestring' | 'lane' | 'traffic_light' | 'traffic_sign' | 'crosswalk'): ShapeId
+  next(kind: 'point' | 'linestring' | 'lane' | 'traffic_light' | 'traffic_sign' | 'crosswalk' | 'polygon'): ShapeId
 }
 
 /** Default allocator: monotonic counter per shape kind. */
 export function createShapeIdAllocator(): ShapeIdAllocator {
-  const counters: Record<string, number> = { point: 0, linestring: 0, lane: 0, traffic_light: 0, traffic_sign: 0, crosswalk: 0 }
+  const counters: Record<string, number> = { point: 0, linestring: 0, lane: 0, traffic_light: 0, traffic_sign: 0, crosswalk: 0, polygon: 0 }
   return {
     next(kind) {
       const id = `shape:${kind}_${counters[kind]}` as ShapeId
@@ -138,6 +138,20 @@ export interface ImportedCrosswalk {
   attributes: Record<string, string>
 }
 
+export interface ImportedParkingSpace {
+  id: ShapeId
+  /** Polygon vertices in canvas coordinates (closed footprint, in order). */
+  points: { x: number; y: number }[]
+  /** OSM id ('' for non-OSM sources). */
+  osmId: string
+  /**
+   * Origin markers (odr_object_id / odr_road_id / odr_type) plus `type` so the
+   * host can re-associate the polygon with its source <object> if needed. Never
+   * stripped by snapshot compression (keyed off odr_* like other import shapes).
+   */
+  attributes: Record<string, string>
+}
+
 export interface ImportBounds {
   minX: number
   maxX: number
@@ -159,6 +173,8 @@ export interface ImportedShapes {
   trafficSigns: ImportedTrafficSign[]
   /** Crosswalks promoted from `crosswalk` regulatory elements / objects. */
   crosswalks: ImportedCrosswalk[]
+  /** Parking spaces promoted from `<object type="parkingSpace">` (OpenDRIVE only). */
+  parkingSpaces?: ImportedParkingSpace[]
   bounds: ImportBounds
   /**
    * Geographic center used as the canvas origin during projection. The host


### PR DESCRIPTION
- Import `<object type="parkingSpace">` as polygon footprints (outline corners when present, otherwise an oriented box from s/t/hdg/length/width)
- Parse `<junction type="direct">` connections that use `linkedRoad` instead of `connectingRoad`; unknown connections are skipped instead of failing the whole parse
- Adds real-world fixtures and regression tests