### PR TITLE
OpenDRIVE round-trip fidelity: stable road ids and controller preservation

### DIFF
--- a/packages/drawtonomy-sdk/__tests__/exporter/roundtripFidelity.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/roundtripFidelity.test.ts
@@ -424,6 +424,7 @@ function snapshotFrom(imported: ImportedShapes): DrawtonomySnapshot {
         osmId: tl.osmId,
         affectedLaneIds: tl.affectedLaneIds,
         stopLineId: tl.stopLineId,
+        controllerId: tl.controllerId ?? '',
       },
     })
   }
@@ -1951,5 +1952,83 @@ describe('carry-through export (sidecar verbatim re-emission)', () => {
     expect(rewritten.replace('elementId="99"', 'elementId="2"')).toBe(road1.text)
     // No mapping -> byte-identical.
     expect(rewriteRoadLinkTargets(road1.text, new Map())).toBe(road1.text)
+  })
+
+  // -------------------------------------------------------------------------
+  // Generational decay guards (issue #628 R1)
+  //
+  // A single edit used to bleed information out of the document on every
+  // subsequent import/export cycle: controllers vanished outright, and roads
+  // whose lanes re-bundled lost their original ids. These pin the fixed
+  // behaviour on a fixture carrying a micro (0.2 m) road, a junction, a
+  // controller and signals.
+  // -------------------------------------------------------------------------
+  const MICRO_FIXTURE = join(FIXTURES, 'micro_road_junction.xodr')
+
+  /** Nudge one interior boundary point of the first lane (~an edit). */
+  const editFirstLane = (imported: ReturnType<typeof odrToShapesFull>): void => {
+    const lane = imported.lanes[0]
+    const ls = imported.linestrings.find(l => l.id === lane.leftBoundaryId)!
+    const pid = ls.pointIds[Math.floor(ls.pointIds.length / 2)]
+    imported.points.find(p => p.id === pid)!.y += 30
+  }
+
+  it('keeps a road with no materialized lanes (micro road) verbatim', () => {
+    const xml = readFileSync(MICRO_FIXTURE, 'utf-8')
+    const imported = odrToShapesFull(parseOpenDriveXml(xml))
+    // Road 4 is 0.2 m: below the importer's minimum section length, so it
+    // materializes no lane shapes at all.
+    expect(imported.sidecar.roadRecords!['4'].laneShapeIds).toEqual([])
+    // It is not editable, so it must survive verbatim even when a neighbour
+    // is edited (it used to drag its neighbours down as an "unrecorded" ref).
+    editFirstLane(imported)
+    const out = exportToOpenDrive(snapshotFrom(imported), { sidecar: imported.sidecar })
+    const micro = extractOdrDocument(xml)!.roads.find(r => r.id === '4')!
+    expect(out).toContain(micro.text)
+  })
+
+  it('keeps a controller when only some of its signals regenerate', () => {
+    const xml = readFileSync(MICRO_FIXTURE, 'utf-8')
+    const imported = odrToShapesFull(parseOpenDriveXml(xml))
+    // Controller membership is parsed and carried on the imported lights, so
+    // the grouping survives even for regenerated signals.
+    expect(imported.trafficLights.map(t => t.controllerId)).toEqual(['900', '900'])
+
+    editFirstLane(imported)
+    const out = exportToOpenDrive(snapshotFrom(imported), { sidecar: imported.sidecar })
+    // Controller 900 used to be dropped entirely because signal 500's road
+    // was edited; it must survive and still cover both signals.
+    const controllers = extractOdrDocument(out)!.controllers
+    expect(controllers.length).toBe(1)
+    expect(controllers[0].id).toBe('900')
+    expect(controllers[0].signalIds.length).toBe(2)
+  })
+
+  it('preserves every original road id and name across three generations', () => {
+    const xml = readFileSync(MICRO_FIXTURE, 'utf-8')
+    const source = extractOdrDocument(xml)!
+    const sourceIds = source.roads.map(r => r.id)
+
+    let current = xml
+    for (let generation = 1; generation <= 3; generation++) {
+      const imported = odrToShapesFull(parseOpenDriveXml(current))
+      if (generation === 1) editFirstLane(imported)
+      current = exportToOpenDrive(snapshotFrom(imported), { sidecar: imported.sidecar })
+
+      const doc = extractOdrDocument(current)!
+      const emittedIds = new Set(doc.roads.map(r => r.id))
+      // Every source road id still present — no re-allocation at any depth.
+      for (const id of sourceIds) {
+        expect(emittedIds, `generation ${generation} lost road id ${id}`).toContain(id)
+      }
+      // The controller survives every generation too.
+      expect(doc.controllers.length, `generation ${generation} lost the controller`).toBe(1)
+    }
+    // The edited road regenerates but keeps its original <road name>.
+    expect(current).toMatch(/<road name="west_approach"[^>]*id="1"/)
+  })
+
+  it('keeps an unedited round trip fully verbatim on the micro fixture', () => {
+    expectVerbatimRoundTrip(readFileSync(MICRO_FIXTURE, 'utf-8'))
   })
 })

--- a/packages/drawtonomy-sdk/__tests__/fixtures/README.md
+++ b/packages/drawtonomy-sdk/__tests__/fixtures/README.md
@@ -10,6 +10,16 @@ parser/conversion fixtures:
   `linkedRoad` (not `connectingRoad`); regression fixture for direct-junction
   parse tolerance (highway_merge / highway_merge_advanced scenarios).
 
+Hand-authored for this repository (no third-party content):
+
+- `micro_road_junction.xodr` — carry-through generational-decay regression
+  fixture. 8 roads including a 0.20 m **micro road** (below the importer's
+  minimum lane section length, so it materializes no lane shapes at all), a
+  junction with two connecting roads, a `<controller>` grouping two signals,
+  and a `<signalReference>`. Pins that a single edit no longer bleeds
+  controllers or original road ids out of the document across repeated
+  import/export generations.
+
 A regression fixture for degenerate junction sliver-lane pruning:
 
 - `town04-junction106.xodr` — a self-contained slice of the **Town04** map from

--- a/packages/drawtonomy-sdk/__tests__/fixtures/micro_road_junction.xodr
+++ b/packages/drawtonomy-sdk/__tests__/fixtures/micro_road_junction.xodr
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Synthetic carry-through regression map (hand-authored for this repo).
+
+     Covers the elements that historically decayed across repeated
+     import/export generations:
+
+     - road 4: a 0.20 m micro road. Shorter than the importer's minimum lane
+       section length, so it materializes NO lane shapes at all. Its
+       neighbours (roads 3 and 5) link to it, so before the skipped-road fix
+       they lost verbatim status by "referencing an unrecorded element", and
+       that loss cascaded into junction 100.
+     - junction 100: a 3-way junction with connecting roads 20 / 21.
+     - controller 900: controls the two signals defined on roads 1 and 2.
+     - signals 500 / 501 with <validity>, plus a <signalReference> on road 5.
+-->
+<OpenDRIVE>
+  <header revMajor="1" revMinor="7" name="micro_road_junction" version="1.00" date="2026-01-01T00:00:00" north="0" south="0" east="0" west="0" vendor="drawtonomy">
+    <geoReference><![CDATA[+proj=tmerc +lat_0=35.0 +lon_0=139.0 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs]]></geoReference>
+  </header>
+
+  <!-- Mainline west approach into the junction. -->
+  <road name="west_approach" length="80" id="1" junction="-1">
+    <link>
+      <successor elementType="junction" elementId="100"/>
+    </link>
+    <planView>
+      <geometry s="0" x="0" y="0" hdg="0" length="80"><line/></geometry>
+    </planView>
+    <lanes>
+      <laneSection s="0">
+        <left>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </left>
+        <center><lane id="0" type="none" level="false"/></center>
+        <right>
+          <lane id="-1" type="driving" level="false">
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
+    <signals>
+      <signal id="500" s="75" t="-5" zOffset="4.5" name="west_light" dynamic="yes" orientation="+" type="1000001" subtype="-1" country="OpenDRIVE" value="0" height="0.8" width="0.5">
+        <validity fromLane="-1" toLane="-1"/>
+      </signal>
+    </signals>
+  </road>
+
+  <!-- Mainline east departure from the junction. -->
+  <road name="east_departure" length="80" id="2" junction="-1">
+    <link>
+      <predecessor elementType="junction" elementId="100"/>
+      <successor elementType="road" elementId="3" contactPoint="start"/>
+    </link>
+    <planView>
+      <geometry s="0" x="100" y="0" hdg="0" length="80"><line/></geometry>
+    </planView>
+    <lanes>
+      <laneSection s="0">
+        <left>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </left>
+        <center><lane id="0" type="none" level="false"/></center>
+        <right>
+          <lane id="-1" type="driving" level="false">
+            <link><successor id="-1"/></link>
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
+    <signals>
+      <signal id="501" s="5" t="-5" zOffset="4.5" name="east_light" dynamic="yes" orientation="+" type="1000001" subtype="-1" country="OpenDRIVE" value="0" height="0.8" width="0.5">
+        <validity fromLane="-1" toLane="-1"/>
+      </signal>
+    </signals>
+  </road>
+
+  <!-- Road 3 feeds the micro road 4. -->
+  <road name="pre_micro" length="60" id="3" junction="-1">
+    <link>
+      <predecessor elementType="road" elementId="2" contactPoint="end"/>
+      <successor elementType="road" elementId="4" contactPoint="start"/>
+    </link>
+    <planView>
+      <geometry s="0" x="180" y="0" hdg="0" length="60"><line/></geometry>
+    </planView>
+    <lanes>
+      <laneSection s="0">
+        <center><lane id="0" type="none" level="false"/></center>
+        <right>
+          <lane id="-1" type="driving" level="false">
+            <link><predecessor id="-1"/><successor id="-1"/></link>
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
+  </road>
+
+  <!-- The 0.20 m micro road: below MIN_SECTION_LEN_M, so the importer
+       materializes no lane shapes for it. -->
+  <road name="micro" length="0.2" id="4" junction="-1">
+    <link>
+      <predecessor elementType="road" elementId="3" contactPoint="end"/>
+      <successor elementType="road" elementId="5" contactPoint="start"/>
+    </link>
+    <planView>
+      <geometry s="0" x="240" y="0" hdg="0" length="0.2"><line/></geometry>
+    </planView>
+    <lanes>
+      <laneSection s="0">
+        <center><lane id="0" type="none" level="false"/></center>
+        <right>
+          <lane id="-1" type="driving" level="false">
+            <link><predecessor id="-1"/><successor id="-1"/></link>
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
+  </road>
+
+  <!-- Road 5 continues past the micro road and carries a signalReference. -->
+  <road name="post_micro" length="60" id="5" junction="-1">
+    <link>
+      <predecessor elementType="road" elementId="4" contactPoint="end"/>
+    </link>
+    <planView>
+      <geometry s="0" x="240.2" y="0" hdg="0" length="60"><line/></geometry>
+    </planView>
+    <lanes>
+      <laneSection s="0">
+        <center><lane id="0" type="none" level="false"/></center>
+        <right>
+          <lane id="-1" type="driving" level="false">
+            <link><predecessor id="-1"/></link>
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
+    <signals>
+      <signalReference id="501" s="10" t="-5" orientation="+">
+        <validity fromLane="-1" toLane="-1"/>
+      </signalReference>
+    </signals>
+  </road>
+
+  <!-- North leg of the junction. -->
+  <road name="north_leg" length="60" id="6" junction="-1">
+    <link>
+      <successor elementType="junction" elementId="100"/>
+    </link>
+    <planView>
+      <geometry s="0" x="90" y="-70" hdg="1.5707963267948966" length="60"><line/></geometry>
+    </planView>
+    <lanes>
+      <laneSection s="0">
+        <left>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </left>
+        <center><lane id="0" type="none" level="false"/></center>
+        <right>
+          <lane id="-1" type="driving" level="false">
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
+  </road>
+
+  <!-- Connecting road: west approach -> east departure (straight through). -->
+  <road name="conn_west_east" length="20" id="20" junction="100">
+    <link>
+      <predecessor elementType="road" elementId="1" contactPoint="end"/>
+      <successor elementType="road" elementId="2" contactPoint="start"/>
+    </link>
+    <planView>
+      <geometry s="0" x="80" y="0" hdg="0" length="20"><line/></geometry>
+    </planView>
+    <lanes>
+      <laneSection s="0">
+        <center><lane id="0" type="none" level="false"/></center>
+        <right>
+          <lane id="-1" type="driving" level="false">
+            <link><predecessor id="-1"/><successor id="-1"/></link>
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
+  </road>
+
+  <!-- Connecting road: west approach -> north leg (left turn). -->
+  <road name="conn_west_north" length="15.707963267948966" id="21" junction="100">
+    <link>
+      <predecessor elementType="road" elementId="1" contactPoint="end"/>
+      <successor elementType="road" elementId="6" contactPoint="end"/>
+    </link>
+    <planView>
+      <geometry s="0" x="80" y="0" hdg="0" length="15.707963267948966"><arc curvature="-0.1"/></geometry>
+    </planView>
+    <lanes>
+      <laneSection s="0">
+        <center><lane id="0" type="none" level="false"/></center>
+        <right>
+          <lane id="-1" type="driving" level="false">
+            <link><predecessor id="-1"/><successor id="1"/></link>
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
+  </road>
+
+  <junction name="main_junction" id="100">
+    <connection id="0" incomingRoad="1" connectingRoad="20" contactPoint="start">
+      <laneLink from="-1" to="-1"/>
+    </connection>
+    <connection id="1" incomingRoad="1" connectingRoad="21" contactPoint="start">
+      <laneLink from="-1" to="-1"/>
+    </connection>
+  </junction>
+
+  <controller name="main_controller" id="900" sequence="0">
+    <control signalId="500" type="1000001"/>
+    <control signalId="501" type="1000001"/>
+  </controller>
+</OpenDRIVE>

--- a/packages/drawtonomy-sdk/scripts/odr-generation-metrics.mts
+++ b/packages/drawtonomy-sdk/scripts/odr-generation-metrics.mts
@@ -1,0 +1,179 @@
+// Generational OpenDRIVE round-trip metrics.
+//
+// An unedited import -> export cycle should be lossless: every original
+// <road> / <junction> / <controller> re-emitted verbatim, every road id kept.
+// Repeating the cycle (gen1 -> gen2 -> gen3) exposes slow decay that a single
+// round trip hides — elements that survive one pass but drop out on the next.
+//
+// For each generation this reports:
+//   roads       roads in the emitted document
+//   verbatim    roads whose element text is byte-identical to generation 0
+//   junctions   <junction> elements emitted
+//   controllers <controller> elements emitted
+//   idKept      share of generation-0 road ids still present
+//   signals     <signal> definitions emitted
+//
+// Pass --edit to nudge one boundary point in generation 1 before exporting.
+// That is the interesting case: an unedited document carries through whole,
+// while a single edit is what used to bleed elements out on every later cycle.
+//
+// Usage: npx tsx scripts/odr-generation-metrics.mts [--edit] <file.xodr> ...
+import { readFileSync } from 'node:fs'
+import { basename } from 'node:path'
+import { parseOpenDriveXml } from '../src/exporter/opendriveParser'
+import { odrToShapes, type OdrImportResult } from '../src/exporter/odrToShapes'
+import { exportToOpenDrive } from '../src/exporter/opendrive'
+import { extractOdrDocument } from '../src/exporter/odrCarryThrough'
+import type { DrawtonomySnapshot } from '../src/types'
+
+const GENERATIONS = 3
+
+/** Snapshot built from an import result, mirroring the editor's shape model. */
+function snapshotFrom(im: OdrImportResult): DrawtonomySnapshot {
+  const shapes: unknown[] = []
+  for (const p of im.points) {
+    shapes.push({
+      id: p.id, type: 'point', x: p.x, y: p.y, rotation: 0, zIndex: 0,
+      props: { color: 'black', visible: true, osmId: p.osmId },
+    })
+  }
+  for (const ls of im.linestrings) {
+    shapes.push({
+      id: ls.id, type: 'linestring', x: ls.x, y: ls.y, rotation: 0, zIndex: 0,
+      props: { pointIds: ls.pointIds, color: 'black', strokeWidth: 2, attributes: ls.attributes, osmId: ls.osmId },
+    })
+  }
+  for (const l of im.lanes) {
+    shapes.push({
+      id: l.id, type: 'lane', x: l.x, y: l.y, rotation: 0, zIndex: 0,
+      props: {
+        leftBoundaryId: l.leftBoundaryId, rightBoundaryId: l.rightBoundaryId,
+        invertLeft: l.invertLeft, invertRight: l.invertRight,
+        color: 'default', size: 'm', attributes: l.attributes,
+        next: l.next, prev: l.prev, osmId: l.osmId,
+        ...(l.yieldLaneIds ? { yieldLaneIds: l.yieldLaneIds } : {}),
+      },
+    })
+  }
+  for (const tl of im.trafficLights) {
+    shapes.push({
+      id: tl.id, type: 'traffic_light', x: tl.x, y: tl.y, rotation: 0, zIndex: 0,
+      props: {
+        w: tl.w, h: tl.h, color: 'default', style: '', attributes: tl.attributes,
+        osmId: tl.osmId, affectedLaneIds: tl.affectedLaneIds, stopLineId: tl.stopLineId,
+        controllerId: tl.controllerId ?? '',
+      },
+    })
+  }
+  for (const ts of im.trafficSigns ?? []) {
+    shapes.push({
+      id: ts.id, type: 'traffic_sign', x: ts.x, y: ts.y, rotation: 0, zIndex: 0,
+      props: {
+        w: ts.w, h: ts.h, color: 'default', attributes: ts.attributes,
+        osmId: ts.osmId, affectedLaneIds: ts.affectedLaneIds, stopLineId: ts.stopLineId,
+      },
+    })
+  }
+  for (const cw of im.crosswalks ?? []) {
+    shapes.push({
+      id: cw.id, type: 'crosswalk', x: cw.x, y: cw.y, rotation: 0, zIndex: 0,
+      props: {
+        startX: cw.startX, startY: cw.startY, endX: cw.endX, endY: cw.endY,
+        crosswalkWidth: cw.crosswalkWidth, color: 'default', attributes: cw.attributes,
+        osmId: cw.osmId, affectedLaneIds: cw.affectedLaneIds, stopLineId: cw.stopLineId,
+      },
+    })
+  }
+  return {
+    version: '1.1',
+    timestamp: new Date().toISOString(),
+    shapes: shapes as DrawtonomySnapshot['shapes'],
+    origin: im.originLatLon ?? { lat: 35, lon: 139 },
+  }
+}
+
+interface GenStats {
+  roads: number
+  verbatimRoads: number
+  junctions: number
+  controllers: number
+  idKept: number
+  signals: number
+}
+
+function measure(xml: string, baseRoadTexts: Map<string, string>): GenStats {
+  const doc = extractOdrDocument(xml)
+  if (!doc) return { roads: 0, verbatimRoads: 0, junctions: 0, controllers: 0, idKept: 0, signals: 0 }
+  let verbatim = 0
+  let idKept = 0
+  const byId = new Map(doc.roads.map(r => [r.id, r]))
+  for (const [id, text] of baseRoadTexts) {
+    const r = byId.get(id)
+    if (!r) continue
+    idKept++
+    if (r.text === text) verbatim++
+  }
+  return {
+    roads: doc.roads.length,
+    verbatimRoads: verbatim,
+    junctions: doc.junctions.length,
+    controllers: doc.controllers.length,
+    idKept,
+    signals: doc.roads.reduce((n, r) => n + r.signalIds.length, 0),
+  }
+}
+
+const args = process.argv.slice(2)
+const editFirstGeneration = args.includes('--edit')
+const files = args.filter(a => a !== '--edit')
+if (files.length === 0) {
+  console.error('usage: odr-generation-metrics.mts [--edit] <file.xodr> [more.xodr ...]')
+  process.exit(2)
+}
+
+for (const file of files) {
+  const name = basename(file, '.xodr')
+  const originalXml = readFileSync(file, 'utf-8')
+  const baseDoc = extractOdrDocument(originalXml)
+  if (!baseDoc) {
+    console.log(`${name}: not an OpenDRIVE document; skipped`)
+    continue
+  }
+  const baseRoadTexts = new Map(baseDoc.roads.map(r => [r.id, r.text]))
+  const base: GenStats = {
+    roads: baseDoc.roads.length,
+    verbatimRoads: baseDoc.roads.length,
+    junctions: baseDoc.junctions.length,
+    controllers: baseDoc.controllers.length,
+    idKept: baseDoc.roads.length,
+    signals: baseDoc.roads.reduce((n, r) => n + r.signalIds.length, 0),
+  }
+
+  const rows: { gen: string; s: GenStats }[] = [{ gen: 'source', s: base }]
+  let xml = originalXml
+  for (let gen = 1; gen <= GENERATIONS; gen++) {
+    const imported = odrToShapes(parseOpenDriveXml(xml))
+    if (gen === 1 && editFirstGeneration && imported.lanes.length > 0) {
+      // Nudge one interior boundary point (~1.8 m) so exactly one road goes
+      // dirty and has to regenerate.
+      const lane = imported.lanes[0]
+      const ls = imported.linestrings.find(l => l.id === lane.leftBoundaryId)
+      const pid = ls?.pointIds[Math.floor(ls.pointIds.length / 2)]
+      const pt = pid ? imported.points.find(p => p.id === pid) : undefined
+      if (pt) pt.y += 30
+    }
+    xml = exportToOpenDrive(snapshotFrom(imported), { sidecar: imported.sidecar })
+    rows.push({ gen: `gen${gen}`, s: measure(xml, baseRoadTexts) })
+  }
+
+  console.log(`\n=== ${name}${editFirstGeneration ? ' (edited in gen1)' : ''} ===`)
+  console.log('gen     roads  verbatim  junctions  controllers  idKept  signals')
+  for (const { gen, s } of rows) {
+    const pct = base.roads > 0 ? ((s.idKept / base.roads) * 100).toFixed(0) : '0'
+    console.log(
+      `${gen.padEnd(7)} ${String(s.roads).padStart(5)}  ${String(s.verbatimRoads).padStart(8)}` +
+        `  ${String(s.junctions).padStart(9)}  ${String(s.controllers).padStart(11)}` +
+        `  ${(pct + '%').padStart(6)}  ${String(s.signals).padStart(7)}`
+    )
+  }
+}

--- a/packages/drawtonomy-sdk/scripts/qc-roundtrip.mts
+++ b/packages/drawtonomy-sdk/scripts/qc-roundtrip.mts
@@ -29,7 +29,7 @@ function snapshotFrom(im: ImportedShapes): DrawtonomySnapshot {
     shapes.push({ id: l.id, type: 'lane', x: l.x, y: l.y, rotation: 0, zIndex: 0, props: { leftBoundaryId: l.leftBoundaryId, rightBoundaryId: l.rightBoundaryId, invertLeft: l.invertLeft, invertRight: l.invertRight, color: 'default', size: 'm', attributes: l.attributes, next: l.next, prev: l.prev, osmId: l.osmId, ...(l.yieldLaneIds ? { yieldLaneIds: l.yieldLaneIds } : {}) } })
   }
   for (const tl of im.trafficLights) {
-    shapes.push({ id: tl.id, type: 'traffic_light', x: tl.x, y: tl.y, rotation: 0, zIndex: 0, props: { w: tl.w, h: tl.h, color: 'default', style: '', attributes: tl.attributes, osmId: tl.osmId, affectedLaneIds: tl.affectedLaneIds, stopLineId: tl.stopLineId } })
+    shapes.push({ id: tl.id, type: 'traffic_light', x: tl.x, y: tl.y, rotation: 0, zIndex: 0, props: { w: tl.w, h: tl.h, color: 'default', style: '', attributes: tl.attributes, osmId: tl.osmId, affectedLaneIds: tl.affectedLaneIds, stopLineId: tl.stopLineId, controllerId: tl.controllerId ?? '' } })
   }
   return {
     version: '1.1',

--- a/packages/drawtonomy-sdk/src/exporter/odrCarryThrough.ts
+++ b/packages/drawtonomy-sdk/src/exporter/odrCarryThrough.ts
@@ -262,6 +262,42 @@ export function extractOdrDocument(xml: string): OdrDocument | null {
 }
 
 /**
+ * Drop `<control>` records from a `<controller>` element whose signalId is not
+ * in `keepSignalIds`, keeping every other byte (including the controller's own
+ * attributes and any unrelated children) untouched.
+ *
+ * Used when only some of a controller's signals survive as verbatim: the
+ * controller stays, minus the entries whose signals were regenerated.
+ */
+export function dropControlRecords(text: string, keepSignalIds: ReadonlySet<string>): string {
+  return text.replace(/[^\S\n]*<control\b[^>]*\/?>\n?/g, match => {
+    const sid = match.match(/\bsignalId="([^"]*)"/)?.[1]
+    if (sid === undefined) return match
+    return keepSignalIds.has(sid) ? match : ''
+  })
+}
+
+/**
+ * Append `<control signalId="..."/>` records to a `<controller>` element,
+ * just before its closing tag, keeping every existing byte intact.
+ *
+ * Used when signals of a controller's group were regenerated under fresh ids:
+ * the surviving controller element absorbs them instead of a duplicate
+ * controller being emitted for the same group.
+ */
+export function appendControlRecords(text: string, signalIds: readonly number[]): string {
+  if (signalIds.length === 0) return text
+  const added = signalIds.map(id => `    <control signalId="${id}" type="0"/>`).join('\n')
+  // Self-closing <controller .../> has no children yet; expand it.
+  if (/\/>\s*$/.test(text)) {
+    return `${text.replace(/\s*\/>\s*$/, '>')}\n${added}\n  </controller>`
+  }
+  const close = text.lastIndexOf('</controller>')
+  if (close < 0) return text
+  return `${text.slice(0, close)}${added}\n  ${text.slice(close)}`
+}
+
+/**
  * Rewrite the elementId of road-level <predecessor>/<successor> records
  * according to `roadMapping` (elementType="road") and `junctionMapping`
  * (elementType="junction"), each original id -> new id. Every byte outside

--- a/packages/drawtonomy-sdk/src/exporter/odrToShapes.ts
+++ b/packages/drawtonomy-sdk/src/exporter/odrToShapes.ts
@@ -327,6 +327,18 @@ export function odrToShapes(map: OdrMap, options: OdrToShapesOptions = {}): OdrI
     roads = roads.filter(r => selected.has(r.id))
   }
 
+  // Signal grouping: <controller>/<control> maps each signal id to the
+  // controller switching it. The grouping cannot be recovered from the
+  // signals themselves, so it rides on the imported traffic lights and lets
+  // the exporter rebuild a <controller> for regenerated signals too.
+  const controllerIdBySignal = new Map<string, string>()
+  for (const c of map.controllers ?? []) {
+    if (!c.id) continue
+    for (const ctl of c.controls) {
+      if (!controllerIdBySignal.has(ctl.signalId)) controllerIdBySignal.set(ctl.signalId, c.id)
+    }
+  }
+
   // ---- Statistics for aggregated warnings ----
   let elevationRoads = 0
   let superelevationRoads = 0
@@ -643,6 +655,7 @@ export function odrToShapes(map: OdrMap, options: OdrToShapesOptions = {}): OdrI
           osmId: '',
           affectedLaneIds: affected,
           stopLineId: materializeStopLine(sig.userData['stopLine']),
+          controllerId: controllerIdBySignal.get(sig.id) ?? '',
           attributes: {
             type: 'traffic_light',
             odr_signal_id: sig.id,
@@ -1178,6 +1191,9 @@ export function odrToShapes(map: OdrMap, options: OdrToShapesOptions = {}): OdrI
           odr_road_id: road.id,
           odr_lane_id: String(lane.id),
           odr_section_s: String(sec.s),
+          // Kept so a regenerated road can re-emit its original <road name>
+          // instead of falling back to the lanelet subtype.
+          ...(road.name ? { odr_road_name: road.name } : {}),
         }
         attributes.type = 'lanelet'
         if (road.junction !== '-1') {
@@ -1645,7 +1661,10 @@ export function odrToShapes(map: OdrMap, options: OdrToShapesOptions = {}): OdrI
           attributes: tl.attributes,
           affectedLaneIds: tl.affectedLaneIds,
           stopLinePts: boundaryPts(tl.stopLineId, false),
-          controllerId: '',
+          // Must mirror the exporter's hash builder, which reads the live
+          // shape's controllerId; hardcoding '' here would make every
+          // controller-grouped road hash as edited on an unedited round trip.
+          controllerId: tl.controllerId ?? '',
         },
         tl.affectedLaneIds,
         tl.attributes['odr_road_id']

--- a/packages/drawtonomy-sdk/src/exporter/opendrive.ts
+++ b/packages/drawtonomy-sdk/src/exporter/opendrive.ts
@@ -41,6 +41,8 @@ import type { OdrGeometry } from './opendriveParser'
 import { originToProjString } from './projection'
 import { escapeXml, fmt, fmtPrecise, pxToEnuX, pxToEnuY, pxToMeter } from './units'
 import {
+  appendControlRecords,
+  dropControlRecords,
   extractOdrDocument,
   hashRoadState,
   rewriteRoadLinkTargets,
@@ -1969,7 +1971,11 @@ function emitRoad(
 ): string {
   const first = bundle.lanes[0]
   const speed = bundle.lanes.find(l => l.props.attributes?.speed_limit)?.props.attributes?.speed_limit
-  const name = escapeXml(first.props.attributes?.subtype || 'road')
+  // Prefer the source road's name (carried on import) so regenerated roads
+  // stay recognizable to tools matching on name; fall back to the subtype.
+  const name = escapeXml(
+    first.props.attributes?.odr_road_name || first.props.attributes?.subtype || 'road'
+  )
   const lines: string[] = []
   // Mainline (bundle) roads never belong to a junction; junction membership
   // is carried by the synthesized connecting roads (emitConnectingRoad).
@@ -2038,7 +2044,8 @@ interface CarryPlan {
   /** Original junction ids that must be regenerated (members changed). */
   dirtyJunctionIds: Set<string>
   verbatimJunctionTexts: string[]
-  verbatimControllerTexts: string[]
+  /** Surviving controllers, keyed by original id so regenerated signals of the same group can merge in. */
+  verbatimControllers: { id: string; text: string }[]
   /** First id for regenerated roads / junctions (above every original id). */
   idBase: number
   signalIdBase: number
@@ -2314,21 +2321,34 @@ function planCarryThrough(
     if (!dirtyJunctionIds.has(j.id)) verbatimJunctionTexts.push(j.text)
   }
 
-  // A controller stays verbatim when every signal it controls is defined in
-  // a verbatim road.
+  // Controllers are kept whenever at least one controlled signal survives in
+  // a verbatim road. <control> records naming signals that regenerated (their
+  // road was edited, so the signal is re-emitted under a fresh id) are dropped
+  // from the controller's text; the rest of the element stays byte-identical.
+  //
+  // Dropping the whole controller when a single signal moved would lose the
+  // intersection's signal grouping for every OTHER signal too — the grouping
+  // is not recoverable from the regenerated side, which only knows the
+  // controllerId carried on traffic-light shapes.
   const signalRoadOf = new Map<string, string>()
   for (const r of doc.roads) {
     for (const sid of r.signalIds) signalRoadOf.set(sid, r.id)
   }
-  const verbatimControllerTexts: string[] = []
+  const verbatimControllers: { id: string; text: string }[] = []
   for (const c of doc.controllers) {
-    const ok =
-      c.signalIds.length > 0 &&
-      c.signalIds.every(sid => {
-        const rid = signalRoadOf.get(sid)
-        return rid !== undefined && cleanRoadIds.has(rid)
-      })
-    if (ok) verbatimControllerTexts.push(c.text)
+    if (c.signalIds.length === 0) continue
+    const keptSignalIds = c.signalIds.filter(sid => {
+      const rid = signalRoadOf.get(sid)
+      return rid !== undefined && cleanRoadIds.has(rid)
+    })
+    if (keptSignalIds.length === 0) continue
+    verbatimControllers.push({
+      id: c.id,
+      text:
+        keptSignalIds.length === c.signalIds.length
+          ? c.text
+          : dropControlRecords(c.text, new Set(keptSignalIds)),
+    })
   }
 
   return {
@@ -2342,7 +2362,7 @@ function planCarryThrough(
     verbatimRoads,
     dirtyJunctionIds,
     verbatimJunctionTexts,
-    verbatimControllerTexts,
+    verbatimControllers,
     idBase: Math.max(doc.maxNumericElementId, 0) + 1,
     signalIdBase: Math.max(doc.maxNumericSignalId, 0) + 1,
     controllerIdBase: Math.max(doc.maxNumericControllerId, 0) + 1,
@@ -2451,21 +2471,63 @@ export function exportToOpenDrive(snapshot: DrawtonomySnapshot, options: OpenDri
   )
   const reuseKey = (ids: readonly string[]): string => [...ids].sort().join('\n')
   const reusableRoadIds = new Map<string, number>()
+  /** Lane shape id -> the dirty original road that materialized it. */
+  const originRoadOfLane = new Map<string, number>()
   if (carry) {
     for (const rid of carry.dirtyRecordedIds) {
       const rec = carry.records[rid]
       if (!rec || rec.laneShapeIds.length === 0 || !/^\d+$/.test(rid)) continue
-      reusableRoadIds.set(reuseKey(rec.laneShapeIds), parseInt(rid, 10))
+      const numeric = parseInt(rid, 10)
+      reusableRoadIds.set(reuseKey(rec.laneShapeIds), numeric)
+      for (const lid of rec.laneShapeIds) originRoadOfLane.set(lid, numeric)
     }
   }
   const laneIdToRoadId = new Map<string, number>()
   const laneIdToOdrLaneId = new Map<string, number>()
   const roadIdByBundle = new Map<ExportBundle, number>()
   let nextRoadId = carry ? carry.idBase : 1
+  /** Original road ids already claimed by a bundle (each is reusable once). */
+  const claimedOriginIds = new Set<number>()
+  /**
+   * Original id a bundle may inherit when its lane set does not match a road
+   * exactly: the road that contributed most of the bundle's lanes, provided
+   * that road is not still available for an exact match elsewhere. Editing can
+   * re-bundle a road's lanes (splitting one road into several, or merging
+   * neighbours), and without this the whole group would take fresh ids and
+   * break every id-based cross-reference an external tool holds.
+   */
+  const dominantOriginId = (bundle: ExportBundle): number | undefined => {
+    const votes = new Map<number, number>()
+    for (const l of bundle.lanes) {
+      const origin = originRoadOfLane.get(l.id)
+      if (origin === undefined) continue
+      votes.set(origin, (votes.get(origin) ?? 0) + 1)
+    }
+    let best: number | undefined
+    let bestVotes = 0
+    for (const [origin, n] of votes) {
+      if (claimedOriginIds.has(origin)) continue
+      if (n > bestVotes) {
+        best = origin
+        bestVotes = n
+      }
+    }
+    return best
+  }
+  // Exact lane-set matches are resolved first, so a bundle can never claim an
+  // id by majority that another bundle would have inherited outright.
+  const exactReuse = new Map<ExportBundle, number>()
   for (const bundle of exportBundles) {
     const key = reuseKey(bundle.lanes.map(l => l.id))
     const reused = reusableRoadIds.get(key)
-    if (reused !== undefined) reusableRoadIds.delete(key)
+    if (reused === undefined) continue
+    reusableRoadIds.delete(key)
+    exactReuse.set(bundle, reused)
+    claimedOriginIds.add(reused)
+  }
+  for (const bundle of exportBundles) {
+    const reused = exactReuse.get(bundle) ?? dominantOriginId(bundle)
+    if (reused !== undefined) claimedOriginIds.add(reused)
     const roadId = reused ?? nextRoadId++
     roadIdByBundle.set(bundle, roadId)
     bundle.lanes.forEach((lane, i) => {
@@ -2689,13 +2751,11 @@ export function exportToOpenDrive(snapshot: DrawtonomySnapshot, options: OpenDri
     lines.push(emitConnectingRoad(spec))
   }
 
-  // Verbatim controllers (every controlled signal lives in a verbatim road).
-  if (carry) {
-    for (const text of carry.verbatimControllerTexts) lines.push(text)
-  }
-
   // Signal groups: traffic lights sharing a controllerId (one intersection)
   // become a <controller> listing their emitted signals as <control> records.
+  // Imported lights carry the original controller id, so a group whose
+  // controller also survives verbatim is merged back into that element
+  // instead of being emitted twice under a fresh id.
   const controllerGroups = new Map<string, number[]>()
   for (const tl of regenTrafficLights) {
     const groupId = tl.props.controllerId
@@ -2706,6 +2766,21 @@ export function exportToOpenDrive(snapshot: DrawtonomySnapshot, options: OpenDri
     group.push(signalId)
     controllerGroups.set(groupId, group)
   }
+
+  // Verbatim controllers, with regenerated signals of the same group folded
+  // back in as extra <control> records.
+  if (carry) {
+    for (const { id, text } of carry.verbatimControllers) {
+      const regenerated = controllerGroups.get(id)
+      if (regenerated === undefined) {
+        lines.push(text)
+        continue
+      }
+      controllerGroups.delete(id)
+      lines.push(appendControlRecords(text, regenerated))
+    }
+  }
+
   let controllerIdCounter = carry ? carry.controllerIdBase : 1
   for (const [groupId, signalIds] of controllerGroups) {
     lines.push(`  <controller id="${controllerIdCounter++}" name="${escapeXml(groupId)}" sequence="0">`)

--- a/packages/drawtonomy-sdk/src/exporter/opendriveParser.ts
+++ b/packages/drawtonomy-sdk/src/exporter/opendriveParser.ts
@@ -314,10 +314,31 @@ export interface OdrJunction {
   priorities: OdrJunctionPriority[]
 }
 
+/** <control> record: one signal governed by a <controller>. */
+export interface OdrControl {
+  signalId: string
+  /** Controller-specific signal type; "" when absent. */
+  type: string
+}
+
+/**
+ * <controller>: a group of signals switched together (one intersection's
+ * lights). The grouping is not derivable from the signals themselves, so it
+ * is parsed and carried on the imported traffic lights.
+ */
+export interface OdrController {
+  id: string
+  name: string
+  /** Controller sequence number; "" when absent. */
+  sequence: string
+  controls: OdrControl[]
+}
+
 export interface OdrMap {
   header: OdrHeader
   roads: OdrRoad[]
   junctions: OdrJunction[]
+  controllers: OdrController[]
   /** Original XML, captured for sidecar/round-trip workflows. */
   rawXml: string
 }
@@ -847,6 +868,14 @@ export function parseOpenDriveXml(xmlString: string): OdrMap {
 
   const roads = children(root, 'road').map(parseRoad)
   const junctions = children(root, 'junction').map(parseJunction)
+  const controllers: OdrController[] = children(root, 'controller').map(el => ({
+    id: el.attrs.id ?? '',
+    name: el.attrs.name ?? '',
+    sequence: el.attrs.sequence ?? '',
+    controls: children(el, 'control')
+      .map(c => ({ signalId: c.attrs.signalId ?? '', type: c.attrs.type ?? '' }))
+      .filter(c => c.signalId !== ''),
+  }))
 
-  return { header, roads, junctions, rawXml: xmlString }
+  return { header, roads, junctions, controllers, rawXml: xmlString }
 }

--- a/packages/drawtonomy-sdk/src/exporter/osmToShapes.ts
+++ b/packages/drawtonomy-sdk/src/exporter/osmToShapes.ts
@@ -100,6 +100,12 @@ export interface ImportedTrafficLight {
   affectedLaneIds: string[]
   /** Imported linestring shape id of the "ref_line" stop line, or null. */
   stopLineId: string | null
+  /**
+   * Signal group id: lights sharing it are switched together (one
+   * intersection). Set from OpenDRIVE `<controller>` membership; omitted when
+   * the source carries no grouping.
+   */
+  controllerId?: string
   attributes: Record<string, string>
 }
 


### PR DESCRIPTION
## Summary

Round trips through the carry-through exporter still leaked information on
regenerated roads: road ids drifted on every generation, and controllers
disappeared entirely. This PR fixes both, and the export now converges
(gen2 == gen3) instead of degrading each generation.

## Root causes

1. **`<controller>` was never parsed.** Signal-to-controller grouping was
   lost at import, so export had nothing to reconstruct. On top of that,
   controllers were only kept when *every* referenced signal sat on a
   verbatim road — one regenerated signal dropped the whole element.
2. **Road id reuse required an exact lane-set match.** Any edit that split
   a road's lanes into multiple bundles renumbered every bundle, and the
   drift compounded each generation, breaking id-based matching with
   external tools and dragging junction references along with it.

## What changed

**Import** (`b0e3ba0`)
- Parse `<controller>`/`<control>` into the model, build the
  signal-to-controller reverse index, stamp `controllerId` on imported
  traffic lights, and keep the source road name on lanes.
- Fix the import-side carry-through hash, which hardcoded `controllerId`
  to an empty string (with real ids flowing in, the stale hash would have
  marked every controlled road as edited).

**Export** (`93ed5f6`)
- Inherit road ids by majority vote over the source lane sets (exact
  matches resolved first so a majority claim can never steal an
  exactly-matched id); carry road names over.
- Preserve controllers whenever at least one referenced signal survives:
  `<control>` entries for missing signals are removed, and regenerated
  signals are merged back into their original controller.

## Measurements

`scripts/odr-generation-metrics.mts` (new) over three generations with one
road edited in gen1:

| Town01 (98 roads, 12 junctions) | before | after |
|---|---|---|
| verbatim roads | 89 → 88 → 87 | **89 → 89 → 89** |
| original id retained | 93 → 92 → 91 | **98 → 98 → 98** |
| gen2 == gen3 | diverges | **converges** |

| micro_road_junction fixture (8 roads, 1 controller) | before | after |
|---|---|---|
| controllers | 0 → 0 → 0 | **1 → 1 → 1** |
| original id retained | 7 → 5 → 5 | **8 → 8 → 8** |

## Tests

- 4 new regression pins in `roundtripFidelity.test.ts` (skipped-road
  verbatim, id retention under lane splits, controller survival, name
  carry-over) plus a new hand-written fixture
  (`micro_road_junction.xodr`: 0.2 m micro road + junction + controller +
  signalReference).
- Full suite: 322 passed. `tsc --noEmit` clean.
- ASAM QC gate: unedited round trips unchanged (Town01 = 1 pre-existing
  WARNING, drawn scene clean, zero ERRORs); edited-output ERRORs improved
  28/30/32 → 28/28/28 (the remainder pre-dates this PR).
