### PR TITLE
fix(sdk): createPedestrian emitted a shape type no consumer recognises

### DIFF
--- a/packages/drawtonomy-sdk/__tests__/helpersFactoryContract.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/helpersFactoryContract.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { createLaneWithBoundaries, createPedestrian, createSnapshot, createVehicle } from '../src/helpers.js'
+import { exportToOpenScenario } from '../src/exporter/openscenario.js'
+
+/**
+ * The factories must produce shapes that the rest of the SDK actually consumes.
+ *
+ * `createPedestrian` used to emit `type: 'pedestrian'`, a shape type no consumer
+ * recognises: the editor has only ever stored placed participants as `vehicle`,
+ * and the OpenSCENARIO exporter selects `<Pedestrian>` vs `<Vehicle>` from
+ * `templateId`. Scenes built with it silently lost every pedestrian — the
+ * exporter emitted zero ScenarioObjects for them.
+ *
+ * Asserting the shape type alone is not enough (it would not have caught the
+ * consequence), so these tests run the factory output through the exporter.
+ */
+describe('factory output is consumable by the exporters', () => {
+  const lane = createLaneWithBoundaries(
+    [{ x: 0, y: 0 }, { x: 500, y: 0 }],
+    [{ x: 0, y: 50 }, { x: 500, y: 50 }],
+  )
+
+  it('createPedestrian produces a shape the OpenSCENARIO exporter emits', () => {
+    const pedestrian = createPedestrian(300, 25)
+    const xosc = exportToOpenScenario(createSnapshot([...lane, pedestrian]), {})
+
+    expect(xosc).toContain('<Pedestrian ')
+    expect(xosc).toContain('pedestrianCategory="pedestrian"')
+    expect(xosc.match(/<ScenarioObject /g) ?? []).toHaveLength(1)
+  })
+
+  it('vehicles and pedestrians coexist and are told apart', () => {
+    const xosc = exportToOpenScenario(
+      createSnapshot([...lane, createVehicle(100, 25), createPedestrian(300, 25)]),
+      {},
+    )
+    const names = [...xosc.matchAll(/<ScenarioObject name="([^"]+)"/g)].map((m) => m[1])
+
+    expect(names).toEqual(['Vehicle_0', 'Pedestrian_1'])
+    expect(xosc).toContain('<Vehicle ')
+    expect(xosc).toContain('<Pedestrian ')
+  })
+})

--- a/packages/drawtonomy-sdk/src/helpers.ts
+++ b/packages/drawtonomy-sdk/src/helpers.ts
@@ -181,14 +181,26 @@ export function createVehicle(
 
 // --- Pedestrian ---
 
+/**
+ * Pedestrians are stored as `type: 'vehicle'` with a pedestrian `templateId`.
+ *
+ * This is not a quirk of this helper: the editor has only ever had the
+ * `vehicle` shape type for placed participants, and the OpenSCENARIO
+ * exporter decides `<Pedestrian>` vs `<Vehicle>` from `templateId`
+ * (see PEDESTRIAN_PATTERNS in exporter/openscenario.ts).
+ *
+ * Emitting `type: 'pedestrian'` here produced shapes that no consumer
+ * recognised — they were skipped by the exporter (0 ScenarioObjects) and
+ * unknown to the editor.
+ */
 export function createPedestrian(
   x: number,
   y: number,
   options?: Partial<PedestrianProps> & { id?: string }
-): BaseShape<'pedestrian', PedestrianProps> {
+): BaseShape<'vehicle', PedestrianProps> {
   return {
     id: options?.id ?? nextId('ped'),
-    type: 'pedestrian',
+    type: 'vehicle',
     x,
     y,
     rotation: 0,


### PR DESCRIPTION
## Problem

Scenes built with `createPedestrian` silently lose every pedestrian:

```js
const snapshot = createSnapshot([...lane, createVehicle(100, 25), createPedestrian(300, 25)])
exportToOpenScenario(snapshot, {})
// → 1 ScenarioObject (the vehicle). The pedestrian is gone, with no warning.
```

## Cause

`createPedestrian` returned `type: 'pedestrian'`, but nothing in the SDK or the editor handles that shape type:

- the editor has only ever stored placed participants as `vehicle` — pedestrians are a `templateId`, not a shape type
- `exporter/openscenario.ts` skips anything that is not `vehicle`, then picks `<Pedestrian>` vs `<Vehicle>` from `PEDESTRIAN_PATTERNS`

So the factory disagreed with its own consumers. `createVehicle` and `createPedestrian` differ only in the default `templateId` (`'filled'`), which already matches the exporter's pedestrian patterns — the shape type was the only thing wrong.

## Fix

Return `type: 'vehicle'`, and document why in a doc comment: the name `createPedestrian` naturally invites `type: 'pedestrian'`, so without an explanation the same change is likely to be reintroduced.

## Verification

With plain Node against the built `dist/`:

```
pedestrian shape type: vehicle / templateId: filled
entities: 2 [ 'Vehicle_0', 'Pedestrian_1' ]
has <Pedestrian>: true
pedestrianCategory: pedestrian
```

Existing suite: **325 passed, 4 skipped**.

## Test

Added `__tests__/helpersFactoryContract.test.ts`.

It runs factory output **through the exporter** instead of asserting the shape type. Asserting `shape.type === 'vehicle'` would pass while telling us nothing about whether a pedestrian actually survives export — and the consequence is the part that was broken.

**No existing test referenced `createPedestrian` at all**, which is why this went unnoticed. I confirmed both new cases fail when the old type is restored.