### PR TITLE
fix(sdk): createLinestring dropped every optional prop, killing path trajectories

### DIFF
--- a/packages/drawtonomy-sdk/__tests__/linestringOptionalProps.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/linestringOptionalProps.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createLaneWithBoundaries,
+  createLinestring,
+  createPathWithFootprints,
+  createPoint,
+  createSnapshot,
+} from '../src/helpers.js'
+import { exportToOpenScenario } from '../src/exporter/openscenario.js'
+
+/**
+ * `createLinestring` accepts `Partial<LinestringProps>` but used to enumerate
+ * only 5 of the 12 props when building the shape, silently discarding the rest
+ * (isPath, arrowHead, arrowHeadSize, opacity, smooth, segments, footprint,
+ * footprintIds). Callers got no type error, so the loss was invisible.
+ *
+ * The visible consequence was in `createPathWithFootprints`: it passes
+ * `isPath: true`, that flag was dropped, and the OpenSCENARIO exporter — which
+ * gates trajectory emission on `props.isPath` — skipped the path. Scenes built
+ * from code therefore exported N parked cars instead of one car following a
+ * trajectory, i.e. no animation could be authored headlessly at all.
+ */
+describe('createLinestring keeps optional props', () => {
+  it('passes through every optional prop it is given', () => {
+    const pts = [createPoint(0, 0), createPoint(100, 0)]
+    const ls = createLinestring(0, 0, pts.map((p) => p.id), {
+      isPath: true,
+      arrowHead: 'end',
+      arrowHeadSize: 15,
+      opacity: 0.85,
+      smooth: true,
+      footprintIds: ['veh_1'],
+      footprint: { interval: 50, offset: 0, templateId: 'sedan' },
+    })
+
+    expect(ls.props.isPath).toBe(true)
+    expect(ls.props.arrowHead).toBe('end')
+    expect(ls.props.arrowHeadSize).toBe(15)
+    expect(ls.props.opacity).toBe(0.85)
+    expect(ls.props.smooth).toBe(true)
+    expect(ls.props.footprintIds).toEqual(['veh_1'])
+    expect(ls.props.footprint?.templateId).toBe('sedan')
+  })
+
+  it('still applies defaults and never lets options override pointIds', () => {
+    const pts = [createPoint(0, 0), createPoint(100, 0)]
+    const ids = pts.map((p) => p.id)
+    const ls = createLinestring(0, 0, ids, { pointIds: ['bogus'] })
+
+    expect(ls.props.pointIds).toEqual(ids)
+    expect(ls.props.color).toBe('black')
+    expect(ls.props.strokeWidth).toBe(2)
+    expect(ls.props.attributes).toEqual({ type: 'linestring', subtype: 'solid' })
+    expect(ls.props.osmId).toBe('')
+  })
+})
+
+describe('a headlessly built path becomes a followable trajectory', () => {
+  it('emits one moving entity with a Polyline, not N parked cars', () => {
+    const lane = createLaneWithBoundaries(
+      [{ x: 0, y: 0 }, { x: 500, y: 0 }],
+      [{ x: 0, y: 50 }, { x: 500, y: 50 }],
+    )
+    const path = createPathWithFootprints(
+      [{ x: 0, y: 25 }, { x: 250, y: 25 }, { x: 500, y: 25 }],
+      { count: 5 },
+    )
+    const xosc = exportToOpenScenario(createSnapshot([...lane, ...path]), {})
+
+    // The follower footprints collapse into the leading entity.
+    expect(xosc.match(/<ScenarioObject /g) ?? []).toHaveLength(1)
+    expect(xosc).toContain('<FollowTrajectoryAction>')
+    expect(xosc).toContain('<Polyline>')
+    expect(xosc.match(/<Vertex /g) ?? []).toHaveLength(5)
+
+    // Vertices carry timestamps and meter coordinates (500 px = ~30 m).
+    const xs = [...xosc.matchAll(/<WorldPosition x="([-\d.]+)"/g)].map((m) => Number(m[1]))
+    expect(Math.max(...xs)).toBeCloseTo(29.99, 1)
+  })
+})

--- a/packages/drawtonomy-sdk/src/helpers.ts
+++ b/packages/drawtonomy-sdk/src/helpers.ts
@@ -53,6 +53,14 @@ export function createLinestring(
   pointIds: string[],
   options?: Partial<LinestringProps> & { id?: string }
 ): BaseShape<'linestring', LinestringProps> {
+  // Optional props are spread through rather than enumerated. Enumerating them
+  // silently dropped everything the explicit list did not mention (isPath,
+  // arrowHead, footprint, footprintIds, smooth, segments, opacity), even though
+  // the signature accepts Partial<LinestringProps> — so callers got no type
+  // error and lost the values at runtime. That is how paths built by
+  // createPathWithFootprints ended up without isPath, which made the
+  // OpenSCENARIO exporter skip their <Trajectory> entirely.
+  const { id: _id, pointIds: _pointIds, color, strokeWidth, attributes, osmId, ...rest } = options ?? {}
   return {
     id: options?.id ?? nextId('ls'),
     type: 'linestring',
@@ -61,11 +69,12 @@ export function createLinestring(
     rotation: 0,
     zIndex: 0,
     props: {
+      ...rest,
       pointIds,
-      color: options?.color ?? 'black',
-      strokeWidth: options?.strokeWidth ?? 2,
-      attributes: options?.attributes ?? { type: 'linestring', subtype: 'solid' },
-      osmId: options?.osmId ?? '',
+      color: color ?? 'black',
+      strokeWidth: strokeWidth ?? 2,
+      attributes: attributes ?? { type: 'linestring', subtype: 'solid' },
+      osmId: osmId ?? '',
     },
   }
 }


### PR DESCRIPTION
## Problem

A path built from code exported as **N parked cars** instead of **one car following a trajectory**:

```js
const path = createPathWithFootprints([{x:0,y:25},{x:250,y:25},{x:500,y:25}], { count: 5 })
exportToOpenScenario(createSnapshot([...lane, ...path]), {})
```

| | entities | `<Trajectory>` | `<FollowTrajectoryAction>` |
|---|---|---|---|
| before | 5 | ✗ | ✗ |
| after | **1** | **✓** | **✓** |

So **no animated scenario could be authored headlessly at all** — only static layouts. This was the last blocker for generating driving scenarios programmatically.

## Cause

`createLinestring` accepts `Partial<LinestringProps>` but enumerated only 5 of the 12 props when constructing the shape:

```js
props: {
  pointIds,
  color: options?.color ?? 'black',
  strokeWidth: options?.strokeWidth ?? 2,
  attributes: options?.attributes ?? { ... },
  osmId: options?.osmId ?? '',
}   // isPath, arrowHead, arrowHeadSize, opacity, smooth, segments,
    // footprint, footprintIds → all silently discarded
```

Callers got no type error, so the loss was invisible. `createPathWithFootprints` passes `isPath: true`, that flag was dropped, and the OpenSCENARIO exporter gates trajectory emission on `props.isPath` — so it skipped the path and each footprint became its own static entity.

## Fix

Spread the remaining options through instead of listing them, while keeping `pointIds` authoritative from the positional argument and preserving every default.

## Verification

With plain Node against the built `dist/`, the emitted trajectory is a real, playable Polyline:

```xml
<Trajectory name="path0_Vehicle_0" closed="false">
  <Shape><Polyline>
    <Vertex time="0.000000">
      <Position><WorldPosition x="0.000000" y="-1.499700" z="0" h="0.000000" .../></Position>
    </Vertex>
    <Vertex time="0.749850">
      <Position><WorldPosition x="7.498500" y="-1.499700" z="0" h="0.000000" .../></Position>
    </Vertex>
    ...
```

5 vertices, timestamps present, coordinates spanning 0..29.99 m (500 px = 30 m), heading 0.

Existing suite: **326 passed, 4 skipped**.

## Tests

`__tests__/linestringOptionalProps.test.ts` covers both layers:

1. **the factory** — every optional prop survives; defaults still apply; `options.pointIds` cannot override the positional argument
2. **the consequence** — a headlessly built path yields 1 entity with a `<Polyline>` of 5 timestamped vertices in meters

The second group matters because prop-level assertions alone would not have revealed what was actually broken. Nothing in the existing suite exercised `isPath` through `createLinestring`, which is why this survived.