### PR TITLE
OpenDRIVE round-trip: keep left lanes on the left, regenerate lateral edits surgically

### DIFF
--- a/packages/drawtonomy-sdk/__tests__/exporter/roundtripFidelity.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/roundtripFidelity.test.ts
@@ -510,6 +510,7 @@ function viaOpenDrive(imported: ImportedShapes): ImportedShapes {
 const FIXTURES = join(__dirname, '..', 'fixtures')
 const FABRIKSGATAN = join(FIXTURES, 'fabriksgatan.xodr')
 const TWO_PLUS_ONE = join(FIXTURES, 'two_plus_one.xodr')
+const SODERLEDEN = join(FIXTURES, 'soderleden.xodr')
 const LANELET2_REAL = process.env.ROUNDTRIP_LANELET2_OSM ?? ''
 /** Optional extra OpenDRIVE map for the debug matrix (path to a .xodr). */
 const XODR_REAL = process.env.ROUNDTRIP_XODR ?? ''
@@ -1907,7 +1908,10 @@ describe('carry-through export (sidecar verbatim re-emission)', () => {
     const lane = imported.lanes.find(l => l.id === laneId)!
     const ls = imported.linestrings.find(l => l.id === lane.leftBoundaryId)!
     const midPid = ls.pointIds[Math.floor(ls.pointIds.length / 2)]
-    imported.points.find(p => p.id === midPid)!.y += 20
+    // out_b runs along +x (hdg 0); drag the point ALONG the road so the edit is
+    // longitudinal, forcing full regeneration (a lateral nudge would be handled
+    // surgically, keeping the road — and its junction — verbatim).
+    imported.points.find(p => p.id === midPid)!.x += 20
 
     const out = exportToOpenDrive(snapshotFrom(imported), { sidecar: imported.sidecar })
     const doc = extractOdrDocument(SYNTHETIC_XODR)!
@@ -2030,6 +2034,132 @@ describe('carry-through export (sidecar verbatim re-emission)', () => {
 
   it('keeps an unedited round trip fully verbatim on the micro fixture', () => {
     expectVerbatimRoundTrip(readFileSync(MICRO_FIXTURE, 'utf-8'))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Surgical (lateral-only) regeneration
+//
+// When an edit moves boundary points only across the travel direction, the
+// road's plan view / laneOffset / elevation / signals / links are all still
+// valid — only the lane widths changed. Such a road keeps its original <road>
+// element (plan view, laneOffset, s frame, elevation, signals) and rewrites
+// only its lane <width> records, instead of the full-regen exporter rebuilding
+// the reference line from the leftmost boundary (which drops the laneOffset,
+// shifts s, coarsens the elevation profile and drops signals / objects).
+//
+// Any non-lateral edit (a point dragged along the road) must fall back to full
+// regeneration, so the surgical path can never silently emit wrong widths.
+// ---------------------------------------------------------------------------
+describe('surgical (lateral-only) regeneration', () => {
+  /**
+   * Move the middle interior point of a road's first lane boundary
+   * perpendicular to the local road direction (lateral) or along it
+   * (longitudinal). Returns the road id and the moved point's new position.
+   */
+  const nudgeFirstLane = (
+    imported: ReturnType<typeof odrToShapesFull>,
+    roadId: string,
+    direction: 'lateral' | 'longitudinal',
+    amountPx = 12
+  ): { pointId: string; x: number; y: number } => {
+    // Edit the outer boundary of the road's outermost right lane: an unshared
+    // edge, so the lateral move is expressible as a pure width change of that
+    // one lane (a shared edge would redistribute width across two lanes).
+    const record = imported.sidecar.roadRecords![roadId]
+    const rightLanes = record.laneShapeIds
+      .map(id => imported.lanes.find(l => l.id === id)!)
+      .filter(l => Number(l.attributes?.odr_lane_id) < 0)
+      .sort((a, b) => Number(a.attributes!.odr_lane_id) - Number(b.attributes!.odr_lane_id))
+    const lane = rightLanes[0] ?? imported.lanes.find(l => l.id === record.laneShapeIds[0])!
+    const ls = imported.linestrings.find(l => l.id === lane.rightBoundaryId)!
+    const k = Math.floor(ls.pointIds.length / 2)
+    const pid = ls.pointIds[k]
+    const pt = imported.points.find(p => p.id === pid)!
+    const prev = imported.points.find(p => p.id === ls.pointIds[Math.max(0, k - 1)])!
+    const next = imported.points.find(p => p.id === ls.pointIds[Math.min(ls.pointIds.length - 1, k + 1)])!
+    let dx = next.x - prev.x
+    let dy = next.y - prev.y
+    const len = Math.hypot(dx, dy) || 1
+    dx /= len
+    dy /= len
+    if (direction === 'lateral') {
+      pt.x += -dy * amountPx
+      pt.y += dx * amountPx
+    } else {
+      pt.x += dx * amountPx
+      pt.y += dy * amountPx
+    }
+    return { pointId: pid, x: pt.x, y: pt.y }
+  }
+
+  it('keeps plan view / laneOffset / length / elevation and rewrites only widths on a lateral edit (soderleden road 0)', () => {
+    if (!existsSync(SODERLEDEN)) return
+    const xml = readFileSync(SODERLEDEN, 'utf-8')
+    const imported = odrToShapesFull(parseOpenDriveXml(xml))
+    const moved = nudgeFirstLane(imported, '0', 'lateral')
+
+    const out = exportToOpenDrive(snapshotFrom(imported), { sidecar: imported.sidecar })
+
+    const before = parseOpenDriveXml(xml).roads.find(r => r.id === '0')!
+    const after = parseOpenDriveXml(out).roads.find(r => r.id === '0')!
+
+    // The reference line frame is untouched: same length, same plan-view
+    // primitive count, same laneOffset polynomial, same elevation records.
+    expect(after.length).toBeCloseTo(before.length, 6)
+    expect(after.planView.length).toBe(before.planView.length)
+    expect(after.laneOffsets.length).toBe(before.laneOffsets.length)
+    expect(after.laneOffsets[0].a).toBeCloseTo(before.laneOffsets[0].a, 6)
+    expect(after.elevations.length).toBe(before.elevations.length)
+
+    // Every OTHER road stays byte-verbatim (no regeneration blast radius).
+    const baseDoc = extractOdrDocument(xml)!
+    const outDoc = extractOdrDocument(out)!
+    const outById = new Map(outDoc.roads.map(r => [r.id, r]))
+    expect(outDoc.roads.length).toBe(baseDoc.roads.length)
+    for (const r of baseDoc.roads) {
+      if (r.id === '0') continue
+      expect(outById.get(r.id)?.text).toBe(r.text)
+    }
+
+    // The lateral edit survived: a re-imported boundary point sits on the
+    // moved position (the width was recomputed to reproduce it).
+    const re = importXodr(out)
+    const hit = re.points.some(p => Math.hypot(p.x - moved.x, p.y - moved.y) < 1)
+    expect(hit).toBe(true)
+
+    // Semantic identity through the round trip.
+    const rep = measureFidelity(imported, re)
+    expect(rep.matchedLanes).toBe(rep.laneCountBefore)
+    expect(rep.edgesPreserved).toBe(rep.edgesBefore)
+  })
+
+  it('falls back to full regeneration on a longitudinal edit (soderleden road 0)', () => {
+    if (!existsSync(SODERLEDEN)) return
+    const xml = readFileSync(SODERLEDEN, 'utf-8')
+    const imported = odrToShapesFull(parseOpenDriveXml(xml))
+    nudgeFirstLane(imported, '0', 'longitudinal', 30)
+
+    const out = exportToOpenDrive(snapshotFrom(imported), { sidecar: imported.sidecar })
+    const before = parseOpenDriveXml(xml).roads.find(r => r.id === '0')!
+    const after = parseOpenDriveXml(out).roads.find(r => r.id === '0')!
+
+    // Full regeneration: the reference line is rebuilt from the boundaries, so
+    // the laneOffset is folded in (no <laneOffset a=3.5> survives) and the
+    // fitted length differs from the original. This is the safe fallback.
+    const laneOffsetGone =
+      after.laneOffsets.length === 0 || Math.abs((after.laneOffsets[0]?.a ?? 0) - before.laneOffsets[0].a) > 0.5
+    const lengthChanged = Math.abs(after.length - before.length) > 0.1
+    expect(laneOffsetGone || lengthChanged).toBe(true)
+  })
+
+  it('keeps an unedited round trip verbatim on soderleden (surgical never fires without an edit)', () => {
+    if (!existsSync(SODERLEDEN)) return
+    const xml = readFileSync(SODERLEDEN, 'utf-8')
+    const imported = odrToShapesFull(parseOpenDriveXml(xml))
+    const out = exportToOpenDrive(snapshotFrom(imported), { sidecar: imported.sidecar })
+    const doc = extractOdrDocument(xml)!
+    for (const road of doc.roads) expect(out).toContain(road.text)
   })
 })
 

--- a/packages/drawtonomy-sdk/__tests__/exporter/roundtripFidelity.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/roundtripFidelity.test.ts
@@ -2032,3 +2032,146 @@ describe('carry-through export (sidecar verbatim re-emission)', () => {
     expectVerbatimRoundTrip(readFileSync(MICRO_FIXTURE, 'utf-8'))
   })
 })
+
+// ---------------------------------------------------------------------------
+// Left-side bundles (imported <left> lanes regenerated on the left side)
+//
+// Left lanes (positive ODR ids) travel against the reference line. The
+// exporter used to regenerate them as <right> lanes of a reversed reference
+// line: the lane-id signs flipped (+2 -> -2) and the road's s coordinate ran
+// backwards (s_new = L - s_orig), breaking every s-based cross-reference an
+// external tool held on the original road. These pin the fixed behaviour: a
+// bundle made entirely of imported left lanes keeps the original reference
+// direction and emits its lanes on the <left> side.
+// ---------------------------------------------------------------------------
+describe('left-side bundle regeneration (lane-id sign + reference direction)', () => {
+  // Two chained left-lane roads: travel runs against s (right to left).
+  // Road 1 spans x 60..120, road 2 spans x 0..60; the travel order is
+  // road 1 lane +1 (x 120 -> 60) then road 2 lane +1 (x 60 -> 0), so road 1's
+  // travel exit is its geometric start (predecessor contact).
+  const LEFT_CHAIN_XODR = `<?xml version="1.0"?>
+<OpenDRIVE>
+  <header revMajor="1" revMinor="6" name="left_chain">
+    <geoReference><![CDATA[+proj=tmerc +lat_0=35.0 +lon_0=139.0 +datum=WGS84]]></geoReference>
+  </header>
+  <road name="up" length="60" id="1" junction="-1">
+    <link><predecessor elementType="road" elementId="2" contactPoint="end"/></link>
+    <planView><geometry s="0" x="60" y="0" hdg="0" length="60"><line/></geometry></planView>
+    <lanes>
+      <laneSection s="0">
+        <left>
+          <lane id="1" type="driving" level="false">
+            <link><predecessor id="1"/></link>
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </left>
+        <center>
+          <lane id="0" type="none" level="false"/>
+        </center>
+      </laneSection>
+    </lanes>
+  </road>
+  <road name="down" length="60" id="2" junction="-1">
+    <link><successor elementType="road" elementId="1" contactPoint="start"/></link>
+    <planView><geometry s="0" x="0" y="0" hdg="0" length="60"><line/></geometry></planView>
+    <lanes>
+      <laneSection s="0">
+        <left>
+          <lane id="1" type="driving" level="false">
+            <link><successor id="1"/></link>
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </left>
+        <center>
+          <lane id="0" type="none" level="false"/>
+        </center>
+      </laneSection>
+    </lanes>
+  </road>
+</OpenDRIVE>`
+
+  const roadBlock = (xml: string, id: string): string => {
+    const m = xml.match(new RegExp(`<road [^>]*id="${id}"[^>]*>[\\s\\S]*?</road>`))
+    expect(m, `road ${id} present`).not.toBeNull()
+    return m![0]
+  }
+
+  it('imports the chain as left lanes with a travel edge', () => {
+    const imported = odrToShapesFull(parseOpenDriveXml(LEFT_CHAIN_XODR))
+    expect(imported.lanes.length).toBe(2)
+    expect(imported.lanes.map(l => l.attributes.odr_lane_id)).toEqual(['1', '1'])
+    expect(imported.lanes.every(l => l.invertLeft && l.invertRight)).toBe(true)
+    const r1 = imported.lanes.find(l => l.attributes.odr_road_id === '1')!
+    const r2 = imported.lanes.find(l => l.attributes.odr_road_id === '2')!
+    expect(r1.next).toEqual([r2.id])
+  })
+
+  it('keeps lane-id sign and reference direction when a left road regenerates', () => {
+    const imported = odrToShapesFull(parseOpenDriveXml(LEFT_CHAIN_XODR))
+    // Nudge an interior point of road 1's lane so only road 1 goes dirty.
+    const lane = imported.lanes.find(l => l.attributes.odr_road_id === '1')!
+    const ls = imported.linestrings.find(l => l.id === lane.leftBoundaryId)!
+    const pid = ls.pointIds[Math.floor(ls.pointIds.length / 2)]
+    imported.points.find(p => p.id === pid)!.y += 30
+
+    const out = exportToOpenDrive(snapshotFrom(imported), { sidecar: imported.sidecar })
+    // Road 2 stays verbatim; road 1 regenerates under its original id.
+    const doc = extractOdrDocument(LEFT_CHAIN_XODR)!
+    expect(out).toContain(doc.roads.find(r => r.id === '2')!.text)
+    const r1 = roadBlock(out, '1')
+
+    // Lane-id sign preserved: the lane stays on the <left> side as +1.
+    expect(r1).toContain('<left>')
+    expect(r1).toMatch(/<lane id="1" type="driving"/)
+    expect(r1).not.toMatch(/<lane id="-1"/)
+
+    // Reference direction preserved: the plan view still starts at x=60
+    // (not at the far end x=120 with the heading turned around).
+    const g = r1.match(/<geometry [^>]*x="([^"]+)" y="([^"]+)" hdg="([^"]+)"/)!
+    expect(Math.abs(parseFloat(g[1]) - 60)).toBeLessThan(0.5)
+    expect(Math.abs(parseFloat(g[2]))).toBeLessThan(0.5)
+    expect(Math.abs(parseFloat(g[3]))).toBeLessThan(0.5)
+
+    // Length stays in the source's ballpark (the edit itself bends the road
+    // and lengthens it by ~1 m; a reversal bug would not change the length
+    // but the start-point assertion above pins the direction).
+    const len = parseFloat(r1.match(/<road [^>]*length="([^"]+)"/)![1])
+    expect(Math.abs(len - 60) / 60).toBeLessThan(0.02)
+
+    // Links keep the original ODR semantics: the travel exit of a left road
+    // is its geometric start, so road 2 stays the road-level predecessor
+    // (contact at road 2's end) and the lane link rides on <predecessor>.
+    expect(r1).toContain('<predecessor elementType="road" elementId="2" contactPoint="end"/>')
+    expect(r1).toContain('<predecessor id="1"/>')
+
+    // Round trip: the re-import restores the same left lanes and edge.
+    const re = importXodr(out)
+    expect(re.lanes.length).toBe(2)
+    expect(re.lanes.map(l => l.attributes.odr_lane_id)).toEqual(['1', '1'])
+    const rep = measureFidelity(imported, re)
+    expect(rep.matchedLanes).toBe(2)
+    expect(rep.edgesPreserved).toBe(rep.edgesBefore)
+    expect(rep.edgesBefore).toBe(1)
+  })
+
+  it('re-emits the unedited left chain verbatim', () => {
+    const imported = odrToShapesFull(parseOpenDriveXml(LEFT_CHAIN_XODR))
+    const out = exportToOpenDrive(snapshotFrom(imported), { sidecar: imported.sidecar })
+    const doc = extractOdrDocument(LEFT_CHAIN_XODR)!
+    for (const road of doc.roads) expect(out).toContain(road.text)
+  })
+
+  it('keeps left lanes on the left side in a full (no-sidecar) regeneration', () => {
+    // town04-junction106: every driving lane sits on the <left> side of its
+    // road. A full regeneration (no sidecar) must keep them there.
+    const xml = readFileSync(join(FIXTURES, 'town04-junction106.xodr'), 'utf-8')
+    const imported = importXodr(xml)
+    const leftBefore = imported.lanes.filter(l => parseInt(l.attributes.odr_lane_id!, 10) > 0).length
+    expect(leftBefore).toBeGreaterThan(0)
+    const out = exportToOpenDrive(snapshotFrom(imported))
+    const re = importXodr(out)
+    const leftAfter = re.lanes.filter(l => parseInt(l.attributes.odr_lane_id!, 10) > 0).length
+    expect(re.lanes.length).toBe(imported.lanes.length)
+    expect(leftAfter).toBe(leftBefore)
+  })
+})

--- a/packages/drawtonomy-sdk/src/exporter/odrCarryThrough.ts
+++ b/packages/drawtonomy-sdk/src/exporter/odrCarryThrough.ts
@@ -32,6 +32,14 @@ export interface OdrRoadRecord {
   laneShapeIds: string[]
   /** Hash of the road's editable shape state at import time. */
   stateHash: string
+  /**
+   * Hash of the road's *non-geometric* state only (lane attributes /
+   * connectivity / right-of-way and the regulatory shapes, with all boundary
+   * and stop-line point sequences removed). When this still matches at export
+   * but `stateHash` does not, the edit touched only boundary geometry — the
+   * precondition for surgical (lateral-only) width regeneration.
+   */
+  semanticHash?: string
 }
 
 /** Editable state of one lane shape, as fed into the road state hash. */
@@ -112,6 +120,22 @@ export function hashRoadState(
   return (
     (a >>> 0).toString(16).padStart(8, '0') + (b >>> 0).toString(16).padStart(8, '0')
   )
+}
+
+/**
+ * Hash of a road's non-geometric state: `hashRoadState` with every boundary
+ * and stop-line point sequence removed, so only lane attributes /
+ * connectivity / right-of-way and the regulatory shapes' identity contribute.
+ * Used to detect "geometry changed, everything else unchanged" (the surgical
+ * precondition).
+ */
+export function hashRoadSemantics(
+  lanes: readonly CarryLaneState[],
+  regulatory: readonly CarryRegulatoryState[]
+): string {
+  const geomFreeLanes = lanes.map(l => ({ ...l, leftPts: null, rightPts: null }))
+  const geomFreeReg = regulatory.map(r => ({ ...r, stopLinePts: null }))
+  return hashRoadState(geomFreeLanes, geomFreeReg)
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/drawtonomy-sdk/src/exporter/odrSurgical.ts
+++ b/packages/drawtonomy-sdk/src/exporter/odrSurgical.ts
@@ -1,0 +1,462 @@
+// Surgical regeneration for OpenDRIVE round trips.
+//
+// When a road is edited but the edit only moved boundary points *laterally*
+// (across the travel direction, not along it), the road's plan view, lane
+// offset, elevation profile, signals, objects and links are all still valid —
+// only the lane <width> polynomials changed. Regenerating the whole road with
+// the fitting exporter would needlessly rebuild the reference line from the
+// leftmost boundary (dropping the original laneOffset, shifting s, coarsening
+// the elevation profile and dropping signals/objects).
+//
+// This module instead keeps the original <road> element verbatim and rewrites
+// only the <width> records inside each <lane>, computed from the edited
+// boundaries measured against the *original* reference line. Any edit that is
+// not lateral-only (a point dragged along the road, an end point moved, a lane
+// added / removed, or connectivity changed) makes the check fail and the road
+// falls back to full regeneration (handled by the caller).
+
+import type { BaseShape, LaneProps, LinestringProps, PointProps } from '../types.js'
+import { evalPoly3, sampleReferenceLine, type ReferenceSample } from './odrGeometry.js'
+import type { OdrLane, OdrLaneSection, OdrRoad } from './opendriveParser.js'
+import { fmt, fmtPrecise, pxToEnuX, pxToEnuY } from './units.js'
+
+type LaneShape = BaseShape<'lane', LaneProps>
+type LinestringShape = BaseShape<'linestring', LinestringProps>
+type PointShape = BaseShape<'point', PointProps>
+
+interface Enu {
+  x: number
+  y: number
+}
+
+// Opt-in tracing for local debugging (globalThis.__SURGICAL_DEBUG = true);
+// never on in production, and free of any node-only globals.
+function dbg(...a: unknown[]): void {
+  if ((globalThis as Record<string, unknown>).__SURGICAL_DEBUG) console.warn('[surgical]', ...a)
+}
+
+/** Micro sections are skipped by the importer, so their lanes have no shapes. */
+const MIN_SECTION_LEN_M = 0.3
+const S_EPS = 1e-6
+/**
+ * Maximum longitudinal drift (m) a boundary end point may show against its
+ * original station before the edit counts as non-lateral. Conservative: an
+ * edit that drags a point along the road by more than a few centimetres must
+ * fall back to full regeneration rather than silently recompute wrong widths.
+ */
+const LATERAL_S_TOL_M = 0.1
+/**
+ * Maximum drift (m) a lane's inner boundary may show from the datum
+ * accumulated so far (the outer offset of the previous lane, or 0 at the
+ * center). A shared inner boundary that both neighbours moved together stays
+ * on the datum; a boundary the user moved independently of its inner neighbour
+ * — the road's fixed reference/laneOffset center, or one side of a shared edge
+ * moved without the other — drifts off it. Such an edit is not expressible as
+ * a width-only change (it would need a new laneOffset or reference line), so
+ * the road falls back to full regeneration.
+ */
+const INNER_DATUM_TOL_M = 0.02
+/** Width simplification tolerance (m), matching the full-regen exporter. */
+const WIDTH_SIMPLIFY_TOL_M = 0.01
+
+/**
+ * Signed lateral offset of a boundary point from a reference pose, measured
+ * along the pose's right normal (sin h, -cos h) — the same convention the
+ * fitting exporter uses. Returns null when the point does not project cleanly
+ * onto the boundary near this pose.
+ */
+function offsetAlongNormal(pose: ReferenceSample, bnd: readonly Enu[], refVal: number): number | null {
+  const nx = Math.sin(pose.hdg)
+  const ny = -Math.cos(pose.hdg)
+  let best: number | null = null
+  for (let i = 0; i < bnd.length - 1; i++) {
+    const dx = bnd[i + 1].x - bnd[i].x
+    const dy = bnd[i + 1].y - bnd[i].y
+    const det = dx * ny - dy * nx
+    if (Math.abs(det) < 1e-12) continue
+    const rx = bnd[i].x - pose.x
+    const ry = bnd[i].y - pose.y
+    const w = (nx * ry - ny * rx) / det
+    if (w < -1e-9 || w > 1 + 1e-9) continue
+    const t = (dx * ry - dy * rx) / det
+    if (best === null || Math.abs(t - refVal) < Math.abs(best - refVal)) best = t
+  }
+  return best
+}
+
+/**
+ * Longitudinal station of a point projected onto the reference polyline.
+ * Used only for the lateral-only test (does the edit keep s?). Returns the
+ * projected s, or null when the polyline is degenerate.
+ */
+function projectStation(p: Enu, poses: readonly ReferenceSample[]): number | null {
+  let best: number | null = null
+  let bestD = Infinity
+  for (let i = 0; i < poses.length - 1; i++) {
+    const a = poses[i]
+    const b = poses[i + 1]
+    const dx = b.x - a.x
+    const dy = b.y - a.y
+    const len2 = dx * dx + dy * dy
+    if (len2 < 1e-18) continue
+    let u = ((p.x - a.x) * dx + (p.y - a.y) * dy) / len2
+    if (u < 0) u = 0
+    if (u > 1) u = 1
+    const projX = a.x + u * dx
+    const projY = a.y + u * dy
+    const d = Math.hypot(p.x - projX, p.y - projY)
+    if (d < bestD) {
+      bestD = d
+      best = a.s + (b.s - a.s) * u
+    }
+  }
+  return best
+}
+
+/** Piecewise-linear (a + b*ds) width records, greedily simplified. */
+function widthRecords(sArr: readonly number[], wArr: readonly number[]): { s: number; a: number; b: number }[] {
+  const recs: { s: number; a: number; b: number }[] = []
+  if (sArr.length < 2) {
+    recs.push({ s: 0, a: wArr[0] ?? 0, b: 0 })
+    return recs
+  }
+  let i0 = 0
+  while (i0 < sArr.length - 1) {
+    let end = i0 + 1
+    for (let j = i0 + 2; j < sArr.length; j++) {
+      const slope = (wArr[j] - wArr[i0]) / (sArr[j] - sArr[i0])
+      let ok = true
+      for (let k = i0 + 1; k < j; k++) {
+        if (Math.abs(wArr[i0] + slope * (sArr[k] - sArr[i0]) - wArr[k]) > WIDTH_SIMPLIFY_TOL_M) {
+          ok = false
+          break
+        }
+      }
+      if (!ok) break
+      end = j
+    }
+    recs.push({ s: sArr[i0], a: wArr[i0], b: (wArr[end] - wArr[i0]) / (sArr[end] - sArr[i0]) })
+    i0 = end
+  }
+  return recs
+}
+
+/** laneOffset polynomial value at station s (last record with rec.s <= s). */
+function laneOffsetAt(road: OdrRoad, s: number): number {
+  let active: OdrRoad['laneOffsets'][number] | null = null
+  for (const rec of road.laneOffsets) {
+    if (rec.s <= s + S_EPS) active = rec
+    else break
+  }
+  return active ? evalPoly3(active, s - active.s) : 0
+}
+
+/** Original lane width (importer read) at ds past the section start. */
+function laneWidthAt(lane: OdrLane, ds: number): number {
+  let active: OdrLane['widths'][number] | null = null
+  for (const rec of lane.widths) {
+    if (rec.sOffset <= ds + S_EPS) active = rec
+    else break
+  }
+  if (!active) return 0
+  const w = evalPoly3(active, ds - active.sOffset)
+  return w > 0 ? w : 0
+}
+
+/** ENU boundary polyline of a linestring shape, in reference-line order. */
+function boundaryEnu(
+  shapeMap: Map<string, BaseShape>,
+  boundaryId: string | null,
+  invert: boolean
+): Enu[] | null {
+  if (!boundaryId) return null
+  const ls = shapeMap.get(boundaryId) as unknown as LinestringShape | undefined
+  if (!ls) return null
+  const ids = invert ? [...ls.props.pointIds].reverse() : ls.props.pointIds
+  const pts: Enu[] = []
+  for (const id of ids) {
+    const p = shapeMap.get(id) as unknown as PointShape | undefined
+    if (!p) return null
+    pts.push({ x: pxToEnuX(p.x), y: pxToEnuY(p.y) })
+  }
+  return pts.length >= 2 ? pts : null
+}
+
+/**
+ * Reconstruct the original inner/outer boundary of every lane in ENU, exactly
+ * as the importer built it (reference line + laneOffset, then accumulate widths
+ * from the center outward). Used to seed the width datum and cross-check the
+ * edit is lateral-only.
+ */
+function originalBoundaries(
+  road: OdrRoad,
+  sec: OdrLaneSection,
+  stations: readonly ReferenceSample[]
+): { center: Enu[]; leftOuter: Enu[][]; rightOuter: Enu[][] } {
+  const normals = stations.map(st => ({ x: -Math.sin(st.hdg), y: Math.cos(st.hdg) }))
+  const center: Enu[] = stations.map((st, j) => {
+    const off = laneOffsetAt(road, st.s)
+    return { x: st.x + normals[j].x * off, y: st.y + normals[j].y * off }
+  })
+  const accumulate = (lanes: OdrLane[], sign: 1 | -1): Enu[][] => {
+    const out: Enu[][] = []
+    let prev = center
+    for (const lane of lanes) {
+      const next = prev.map((p, j) => {
+        const w = laneWidthAt(lane, stations[j].s - sec.s)
+        return { x: p.x + sign * normals[j].x * w, y: p.y + sign * normals[j].y * w }
+      })
+      out.push(next)
+      prev = next
+    }
+    return out
+  }
+  return { center, leftOuter: accumulate(sec.left, 1), rightOuter: accumulate(sec.right, -1) }
+}
+
+/** Lane shape keyed by (odr_lane_id, odr_section_s). */
+export type LaneShapeKey = string
+export function laneShapeKey(laneId: number, sectionS: number): LaneShapeKey {
+  return `${laneId} ${fmt(sectionS)}`
+}
+/** Internal key for the recomputed-width map (uses the parsed section s). */
+function widthKey(laneId: number, sectionS: number): string {
+  return `${laneId} ${fmt(sectionS)}`
+}
+
+/**
+ * Attempt to rewrite only the <width> records of a road's <lanes> subtree,
+ * keeping every other byte of the original <road> element. Returns the new
+ * road text, or null when the edit is not lateral-only (fall back to full
+ * regeneration).
+ *
+ * `road` is the parsed original road; `roadText` its verbatim element text;
+ * `laneShapes` maps (laneId, sectionS) to the live (possibly edited) lane
+ * shape for this road.
+ */
+export function buildSurgicalRoad(
+  road: OdrRoad,
+  roadText: string,
+  laneShapes: Map<LaneShapeKey, LaneShape>,
+  shapeMap: Map<string, BaseShape>
+): string | null {
+  if (road.laneSections.length === 0) {
+    dbg('road', road.id, 'no lane sections')
+    return null
+  }
+
+  const extraStations: number[] = []
+  for (const sec of road.laneSections) {
+    extraStations.push(sec.s)
+    for (const lane of [...sec.left, ...sec.right]) {
+      for (const w of lane.widths) extraStations.push(sec.s + w.sOffset)
+    }
+  }
+  for (const lo of road.laneOffsets) extraStations.push(lo.s)
+
+  const samples = sampleReferenceLine(road, { extraStations })
+  if (samples.length < 2) {
+    dbg('road', road.id, 'too few samples')
+    return null
+  }
+
+  // laneId+section -> new <width> record set. Only lanes that materialize a
+  // shape are entered; center / skipped lanes are left untouched.
+  const newWidths = new Map<string, { s: number; a: number; b: number }[]>()
+
+  for (let secIdx = 0; secIdx < road.laneSections.length; secIdx++) {
+    const sec = road.laneSections[secIdx]
+    const secEnd = secIdx + 1 < road.laneSections.length ? road.laneSections[secIdx + 1].s : road.length
+    if (secEnd - sec.s < MIN_SECTION_LEN_M) {
+      dbg('road', road.id, 'micro section', secIdx)
+      return null
+    }
+    const stations = samples.filter(st => st.s >= sec.s - S_EPS && st.s <= secEnd + S_EPS)
+    if (stations.length < 2) {
+      dbg('road', road.id, 'section', secIdx, 'too few stations')
+      return null
+    }
+
+    const orig = originalBoundaries(road, sec, stations)
+
+    // The center offset line (reference + laneOffset) is the datum widths are
+    // measured from; poses share the reference heading.
+    const centerPoses: ReferenceSample[] = stations.map((st, j) => ({
+      s: st.s,
+      x: orig.center[j].x,
+      y: orig.center[j].y,
+      hdg: st.hdg,
+      z: st.z,
+    }))
+    const sPerStation = stations.map(st => st.s - sec.s)
+
+    // Projected station of every original boundary point, index-aligned to the
+    // station grid, so the edited boundary can be compared point-for-point.
+    const origStationOf = (bnd: readonly Enu[]): (number | null)[] =>
+      bnd.map(p => projectStation(p, centerPoses))
+
+    // `sideDir` is the direction of *outward* lane growth measured along the
+    // reference right normal (sin h, -cos h): right-side lanes grow toward +t,
+    // left-side lanes toward -t. (This is the opposite of the importer's
+    // accumulate `sign`, which is expressed against the +t / left normal.)
+    const handleSide = (lanes: OdrLane[], sideDir: 1 | -1, origOuter: Enu[][]): boolean => {
+      // Cumulative signed offset (along the right normal) of the current lane's
+      // inner boundary, seeded at 0 (the center) and advanced by each lane's
+      // recomputed outer offset so a skipped (dropped) lane still shifts the
+      // datum for its outer neighbours.
+      let innerOffset = centerPoses.map(() => 0)
+      let origInner: Enu[] = orig.center
+      for (let i = 0; i < lanes.length; i++) {
+        const lane = lanes[i]
+        const origOuterBnd = origOuter[i]
+        const shape = laneShapes.get(laneShapeKey(lane.id, sec.s))
+        if (!shape) {
+          // Lane was dropped on import (zero width / sliver). Advance the datum
+          // by the ORIGINAL width so neighbours stay aligned; do not emit.
+          innerOffset = innerOffset.map((o, j) => o + sideDir * laneWidthAt(lane, stations[j].s - sec.s))
+          origInner = origOuterBnd
+          continue
+        }
+        // The lane shape stores boundaries in reference-line order; read them
+        // in that order (invert=false) so they align with the station poses.
+        const inner = boundaryEnu(shapeMap, shape.props.leftBoundaryId, false)
+        const outer = boundaryEnu(shapeMap, shape.props.rightBoundaryId, false)
+        if (!inner || !outer) {
+          dbg('road', road.id, 'lane', lane.id, 'no inner/outer boundary')
+          return false
+        }
+
+        // Lateral-only test: the edited boundaries must have the same point
+        // count as the originals (a lateral drag preserves the vertex set),
+        // and every edited point must project onto the reference line at the
+        // same station as the original point it replaces — no longitudinal
+        // drift. Reconstructed originals are index-aligned to the stations.
+        const pairs: [Enu[], Enu[]][] = [
+          [inner, origInner],
+          [outer, origOuterBnd],
+        ]
+        for (const [edited, original] of pairs) {
+          if (edited.length !== original.length) {
+            dbg('road', road.id, 'lane', lane.id, 'point count changed', edited.length, 'vs', original.length)
+            return false
+          }
+          const origS = origStationOf(original)
+          for (let k = 0; k < edited.length; k++) {
+            const sNew = projectStation(edited[k], centerPoses)
+            const sOld = origS[k]
+            if (sNew === null || sOld === null) {
+              dbg('road', road.id, 'lane', lane.id, 'point off polyline at', k)
+              return false
+            }
+            if (Math.abs(sNew - sOld) > LATERAL_S_TOL_M) {
+              dbg('road', road.id, 'lane', lane.id, 'point', k, 's drift', sNew, 'vs', sOld)
+              return false
+            }
+          }
+        }
+
+        // Widths at each station: offset of outer minus offset of inner, both
+        // measured along the center-line normal. `sign` orients the search.
+        const wArr: number[] = []
+        const sArr: number[] = []
+        const newInnerOffset: number[] = []
+        for (let j = 0; j < centerPoses.length; j++) {
+          const ref = innerOffset[j]
+          const tInner = offsetAlongNormal(centerPoses[j], inner, ref)
+          const tOuter = offsetAlongNormal(centerPoses[j], outer, ref + sideDir)
+          if (tInner === null || tOuter === null) {
+            dbg('road', road.id, 'lane', lane.id, 'station', j, 't null', tInner, tOuter, 'ref', ref)
+            return false
+          }
+          // The inner boundary must still sit on the accumulated datum (the
+          // center / the previous lane's outer). If it drifted laterally, the
+          // edit moved the fixed reference frame or a shared edge one-sidedly,
+          // which no width record can express — fall back.
+          if (Math.abs(tInner - ref) > INNER_DATUM_TOL_M) {
+            dbg('road', road.id, 'lane', lane.id, 'station', j, 'inner datum drift', tInner, 'vs', ref)
+            return false
+          }
+          // Width is the outward span from inner to outer along the right
+          // normal; `sideDir` makes it positive on both sides.
+          const width = Math.max(0, sideDir * (tOuter - tInner))
+          wArr.push(width)
+          sArr.push(sPerStation[j])
+          newInnerOffset.push(tOuter)
+        }
+
+        newWidths.set(widthKey(lane.id, sec.s), widthRecords(sArr, wArr))
+        innerOffset = newInnerOffset
+        origInner = origOuterBnd
+      }
+      return true
+    }
+
+    if (!handleSide(sec.left, -1, orig.leftOuter)) return null
+    if (!handleSide(sec.right, 1, orig.rightOuter)) return null
+  }
+
+  // Rewrite the <width> records lane by lane, in original document order,
+  // keeping everything else (links, roadMark, userData, lane type) verbatim.
+  const out = rewriteLaneWidths(roadText, road, newWidths)
+  if (out === null) dbg('road', road.id, 'rewriteLaneWidths failed')
+  return out
+}
+
+/**
+ * Replace the <width .../> records of each lane that has recomputed widths,
+ * matching lanes structurally by walking <laneSection> / <lane> blocks in
+ * document order. Every non-<width> byte is preserved.
+ */
+function rewriteLaneWidths(
+  roadText: string,
+  road: OdrRoad,
+  newWidths: Map<string, { s: number; a: number; b: number }[]>
+): string | null {
+  const lanesStart = roadText.indexOf('<lanes>')
+  const lanesEnd = roadText.indexOf('</lanes>')
+  if (lanesStart < 0 || lanesEnd < 0 || lanesEnd < lanesStart) return null
+
+  const before = roadText.slice(0, lanesStart)
+  const lanesBlock = roadText.slice(lanesStart, lanesEnd + '</lanes>'.length)
+  const after = roadText.slice(lanesEnd + '</lanes>'.length)
+
+  const sectionRe = /<laneSection\b[^>]*>[\s\S]*?<\/laneSection>/g
+  let sectionIdx = 0
+  let failed = false
+
+  const rewrittenLanes = lanesBlock.replace(sectionRe, secBlock => {
+    const sec = road.laneSections[sectionIdx++]
+    if (!sec) return secBlock
+    // Match a self-closing <lane .../> (e.g. the center lane) or a full
+    // <lane ...>...</lane> pair. Anchoring the pair form on a `>` that is not
+    // `/>` prevents a self-closing lane from swallowing the next lane's body.
+    const laneRe = /<lane\b([^>]*?)\/>|<lane\b([^>]*[^/])>([\s\S]*?)<\/lane>/g
+    return secBlock.replace(laneRe, (full, selfAttrs: string, pairAttrs: string, inner: string) => {
+      if (selfAttrs !== undefined) return full // self-closing lane: no widths
+      const openAttrs = pairAttrs
+      const idMatch = openAttrs.match(/\bid="(-?\d+)"/)
+      if (!idMatch) return full
+      const laneId = parseInt(idMatch[1], 10)
+      const recs = newWidths.get(widthKey(laneId, sec.s))
+      if (!recs) return full // center lane / skipped lane: untouched
+      const widthLineMatch = inner.match(/([^\S\n]*)<width\b/)
+      const indent = widthLineMatch ? widthLineMatch[1] : '                        '
+      const widthXml = recs
+        .map(r => `<width sOffset="${fmt(r.s)}" a="${fmt(r.a)}" b="${fmtPrecise(r.b)}" c="0" d="0"/>`)
+        .join(`\n${indent}`)
+      let replaced = false
+      const newInner = inner.replace(/([^\S\n]*<width\b[^>]*\/>\s*)+/, () => {
+        replaced = true
+        return `${indent}${widthXml}\n`
+      })
+      if (!replaced) {
+        failed = true
+        return full
+      }
+      return `<lane${openAttrs}>${newInner}</lane>`
+    })
+  })
+
+  if (failed) return null
+  return before + rewrittenLanes + after
+}

--- a/packages/drawtonomy-sdk/src/exporter/odrToShapes.ts
+++ b/packages/drawtonomy-sdk/src/exporter/odrToShapes.ts
@@ -55,6 +55,7 @@ import {
 import { PIXELS_PER_METER } from './units.js'
 import {
   hashRoadState,
+  hashRoadSemantics,
   type CarryLaneState,
   type CarryRegulatoryState,
   type OdrRoadRecord,
@@ -1717,6 +1718,7 @@ export function odrToShapes(map: OdrMap, options: OdrToShapesOptions = {}): OdrI
       roadRecords[road.id] = {
         laneShapeIds: regLanes.map(r => r.shapeId),
         stateHash: hashRoadState(laneStates, regStatesByRoad.get(road.id) ?? []),
+        semanticHash: hashRoadSemantics(laneStates, regStatesByRoad.get(road.id) ?? []),
       }
     }
     result.sidecar.roadRecords = roadRecords

--- a/packages/drawtonomy-sdk/src/exporter/opendrive.ts
+++ b/packages/drawtonomy-sdk/src/exporter/opendrive.ts
@@ -88,9 +88,36 @@ interface BundleGeometry {
 
 /** A road bundle: laterally adjacent lanes emitted as one <road>. */
 interface ExportBundle {
-  /** Lanes ordered left→right in travel direction; index i ⇒ ODR lane -(i+1). */
+  /**
+   * Lanes ordered left→right in travel direction; index i ⇒ ODR lane -(i+1),
+   * or +(i+1) when `leftSide` (index counts inner→outer on the left side).
+   */
   lanes: LaneShape[]
   geom: BundleGeometry
+  /**
+   * True when every lane came from the `<left>` side of an imported road
+   * (positive `odr_lane_id`). Such lanes travel opposite to the original
+   * reference line; keeping them on the left side preserves the original
+   * lane-id signs and reference-line direction (s does not flip) across the
+   * round trip.
+   */
+  leftSide: boolean
+}
+
+/**
+ * Imported left-side lanes carry a positive `odr_lane_id` and are stored with
+ * `invertLeft` / `invertRight` set (their boundaries are kept in original
+ * reference-line order and reversed into travel order on read). Only when the
+ * whole bundle is such lanes can the road be emitted on the `<left>` side
+ * with the reference line kept in its original direction.
+ */
+function isLeftSideBundle(lanes: LaneShape[]): boolean {
+  return lanes.every(l => {
+    const id = parseInt(l.props.attributes?.odr_lane_id ?? '', 10)
+    return (
+      Number.isFinite(id) && id > 0 && l.props.invertLeft === true && l.props.invertRight === true
+    )
+  })
 }
 
 /** O(1) shape lookup by id. */
@@ -248,14 +275,23 @@ function distancePointToPolyline(p: Point2D, pts: readonly Point2D[]): number {
  */
 const OFFSET_JUMP_TOL_M = 5
 
-function normalOffsets(poses: readonly FittedSamplePose[], bnd: readonly Point2D[]): number[] {
+function normalOffsets(
+  poses: readonly FittedSamplePose[],
+  bnd: readonly Point2D[],
+  fallbackSign: 1 | -1 = 1
+): number[] {
   const out: number[] = []
   let prev: number | null = null
   for (const pose of poses) {
     // Right normal of heading h in ENU: (sin h, -cos h).
     const nx = Math.sin(pose.hdg)
     const ny = -Math.cos(pose.hdg)
-    const fallback = distancePointToPolyline({ x: pose.x, y: pose.y }, bnd)
+    // The closest-point distance is unsigned; `fallbackSign` orients it to
+    // the side the bundle's boundaries actually lie on (-1 for left-side
+    // bundles, whose true offsets are negative along the right normal —
+    // otherwise the first station's reference value would sit a full road
+    // width away from every intersection and discard them all).
+    const fallback = fallbackSign * distancePointToPolyline({ x: pose.x, y: pose.y }, bnd)
     const refVal = prev ?? fallback
     let best: number | null = null
     for (let i = 0; i < bnd.length - 1; i++) {
@@ -294,15 +330,30 @@ function normalOffsets(poses: readonly FittedSamplePose[], bnd: readonly Point2D
 function buildBundleGeometry(
   shapeMap: Map<string, BaseShape>,
   bundleLanes: LaneShape[],
-  pointOverrides: Map<string, Point2D>
+  pointOverrides: Map<string, Point2D>,
+  leftSide: boolean = false
 ): BundleGeometry | null {
   const first = bundleLanes[0]
   const boundaries: BoundaryPoint[][] = []
-  const left = boundaryPointsOf(shapeMap, first.props.leftBoundaryId, first.props.invertLeft, pointOverrides)
+  // Left-side bundles keep their boundaries in original reference-line order
+  // (not reversed into travel order): the reference line must run in the
+  // original s direction so the round trip preserves it, with the lanes
+  // emitted on the <left> side (offsets toward +t).
+  const left = boundaryPointsOf(
+    shapeMap,
+    first.props.leftBoundaryId,
+    leftSide ? false : first.props.invertLeft,
+    pointOverrides
+  )
   if (!left) return null
   boundaries.push(left)
   for (const lane of bundleLanes) {
-    const right = boundaryPointsOf(shapeMap, lane.props.rightBoundaryId, lane.props.invertRight, pointOverrides)
+    const right = boundaryPointsOf(
+      shapeMap,
+      lane.props.rightBoundaryId,
+      leftSide ? false : lane.props.invertRight,
+      pointOverrides
+    )
     if (!right) return null
     boundaries.push(right)
   }
@@ -366,7 +417,7 @@ function buildBundleGeometry(
   }
   if (samplePoses.length < 2) return null
 
-  const offsets = bndOdr.map(b => normalOffsets(samplePoses, b))
+  const offsets = bndOdr.map(b => normalOffsets(samplePoses, b, leftSide ? -1 : 1))
   // Contact stations measure each boundary's own endpoint (projected onto
   // the contact normal) instead of the ray/polyline crossing: the endpoints
   // are the welded corners shared with the neighbouring road, so both sides
@@ -383,8 +434,12 @@ function buildBundleGeometry(
     offsets[b][0] = projectEndpoint(samplePoses[0], bnd[0], offsets[b][0])
     offsets[b][lastIdx] = projectEndpoint(samplePoses[lastIdx], bnd[bnd.length - 1], offsets[b][lastIdx])
   }
+  // Widths grow toward -t (right) for right-side bundles and toward +t
+  // (left) for left-side bundles; `normalOffsets` measures toward -t.
   const laneWidths = bundleLanes.map((_, i) =>
-    samplePoses.map((_, j) => Math.max(0, offsets[i + 1][j] - offsets[i][j]))
+    samplePoses.map((_, j) =>
+      Math.max(0, leftSide ? offsets[i][j] - offsets[i + 1][j] : offsets[i + 1][j] - offsets[i][j])
+    )
   )
 
   // Elevation samples: the reference boundary's own vertices already have a
@@ -689,27 +744,37 @@ function emitLanes(
   const geom = bundle.geom
   const lines: string[] = []
   lines.push(`    <lanes>`)
-  // The plan view follows the bundle's leftmost boundary, so lane 0 (center)
-  // lies on the left edge of lane -1 and no laneOffset is required. Lanes are
-  // emitted -1, -2, ... from the reference line outward (left→right in travel
-  // direction), each spanning its full drawn width.
+  // The plan view follows the bundle's innermost boundary, so lane 0 (center)
+  // lies on that edge and no laneOffset is required. Right-side bundles emit
+  // -1, -2, ... outward (left→right in travel direction); left-side bundles
+  // emit +1, +2, ... outward on the <left> side (their travel direction runs
+  // against the reference line), each lane spanning its full drawn width.
+  const emitOneLane = (lane: LaneShape, i: number): void => {
+    const odrId = bundle.leftSide ? i + 1 : -(i + 1)
+    lines.push(`          <lane id="${odrId}" type="${odrLaneTypeFor(lane)}" level="false">`)
+    emitLaneLink(lines, plan.lanePredecessor.get(lane.id), plan.laneSuccessor.get(lane.id))
+    emitWidthEntries(geom, i, lines)
+    lines.push(`            ${roadMarkElementFor(shapeMap, lane.props.rightBoundaryId)}`)
+    lines.push(`          </lane>`)
+  }
   lines.push(`      <laneSection s="0">`)
+  if (bundle.leftSide) {
+    // Left lanes are conventionally listed outermost first (descending id).
+    lines.push(`        <left>`)
+    for (let i = bundle.lanes.length - 1; i >= 0; i--) emitOneLane(bundle.lanes[i], i)
+    lines.push(`        </left>`)
+  }
   lines.push(`        <center>`)
   lines.push(`          <lane id="0" type="none" level="false">`)
   lines.push(`            <link/>`)
   lines.push(`            ${roadMarkElementFor(shapeMap, bundle.lanes[0].props.leftBoundaryId)}`)
   lines.push(`          </lane>`)
   lines.push(`        </center>`)
-  lines.push(`        <right>`)
-  bundle.lanes.forEach((lane, i) => {
-    const odrId = -(i + 1)
-    lines.push(`          <lane id="${odrId}" type="${odrLaneTypeFor(lane)}" level="false">`)
-    emitLaneLink(lines, plan.lanePredecessor.get(lane.id), plan.laneSuccessor.get(lane.id))
-    emitWidthEntries(geom, i, lines)
-    lines.push(`            ${roadMarkElementFor(shapeMap, lane.props.rightBoundaryId)}`)
-    lines.push(`          </lane>`)
-  })
-  lines.push(`        </right>`)
+  if (!bundle.leftSide) {
+    lines.push(`        <right>`)
+    bundle.lanes.forEach(emitOneLane)
+    lines.push(`        </right>`)
+  }
   lines.push(`      </laneSection>`)
   lines.push(`    </lanes>`)
   return lines.join('\n')
@@ -784,7 +849,17 @@ function emitWidthEntries(geom: BundleGeometry, laneIndex: number, out: string[]
   }
 }
 
-type RoadLinkTarget = { kind: 'road' | 'junction'; id: number }
+type RoadLinkTarget = {
+  kind: 'road' | 'junction'
+  id: number
+  /**
+   * Contact point on the linked road (road links only). Defaults to the
+   * classic convention (predecessor@end / successor@start); a left-side
+   * linked road flips it because its travel entry/exit sits on the opposite
+   * geometric end.
+   */
+  contactPoint?: 'start' | 'end'
+}
 
 /** Length (m) of a synthesized junction connecting road. Kept below the
  * importer's micro-section threshold so re-imports skip it and bridge the
@@ -829,6 +904,16 @@ interface ConnectingRoadSpec {
   source: ConnectingSource
   /** Heading / width of the target lane at its start (see ConnectingTarget). */
   target: ConnectingTarget | null
+  /**
+   * Contact point on the incoming road (travel exit): 'end' for right-side
+   * source lanes, 'start' for left-side ones.
+   */
+  incomingContact: 'start' | 'end'
+  /**
+   * Contact point on the outgoing road (travel entry): 'start' for
+   * right-side target lanes, 'end' for left-side ones.
+   */
+  outgoingContact: 'start' | 'end'
 }
 
 /**
@@ -1007,11 +1092,28 @@ function planConnectivity(
       e => (validNext.get(e.from) ?? []).length === 1 && (validPrev.get(e.to) ?? []).length === 1
     )
     if (uniquePair && lanesOneToOne) {
-      plan.roadSuccessor.set(fromRoad, { kind: 'road', id: toRoad })
-      plan.roadPredecessor.set(toRoad, { kind: 'road', id: fromRoad })
+      // Lane / road links are ODR-semantic (predecessor = the road's s=0
+      // contact). A travel edge exits a right-side lane at its road's end
+      // but a left-side lane (positive ODR id, travel against s) at its
+      // road's start, so the slot and the linked contact point both follow
+      // the lane-id signs.
+      const fromLeft = (odrIdOf.get(laneEdges[0].from) ?? -1) > 0
+      const toLeft = (odrIdOf.get(laneEdges[0].to) ?? -1) > 0
+      ;(fromLeft ? plan.roadPredecessor : plan.roadSuccessor).set(fromRoad, {
+        kind: 'road',
+        id: toRoad,
+        contactPoint: toLeft ? 'end' : 'start',
+      })
+      ;(toLeft ? plan.roadSuccessor : plan.roadPredecessor).set(toRoad, {
+        kind: 'road',
+        id: fromRoad,
+        contactPoint: fromLeft ? 'start' : 'end',
+      })
       for (const e of laneEdges) {
-        plan.laneSuccessor.set(e.from, odrIdOf.get(e.to)!)
-        plan.lanePredecessor.set(e.to, odrIdOf.get(e.from)!)
+        const eFromLeft = (odrIdOf.get(e.from) ?? -1) > 0
+        const eToLeft = (odrIdOf.get(e.to) ?? -1) > 0
+        ;(eFromLeft ? plan.lanePredecessor : plan.laneSuccessor).set(e.from, odrIdOf.get(e.to)!)
+        ;(eToLeft ? plan.laneSuccessor : plan.lanePredecessor).set(e.to, odrIdOf.get(e.from)!)
       }
     } else {
       junctionPairs.push({ incoming: fromRoad, outgoing: toRoad, laneEdges })
@@ -1075,6 +1177,8 @@ function planConnectivity(
         toOdrLaneId: odrIdOf.get(e.to)!,
         source,
         target: connectingTargetFor(e.to),
+        incomingContact: odrIdOf.get(e.from)! > 0 ? 'start' : 'end',
+        outgoingContact: odrIdOf.get(e.to)! > 0 ? 'end' : 'start',
       }
       plan.connectingRoads.push(spec)
       junction.connections.push({
@@ -1086,8 +1190,19 @@ function planConnectivity(
       list.push(spec)
       connectingByLane.set(e.from, list)
     }
-    plan.roadSuccessor.set(pair.incoming, { kind: 'junction', id: junction.id })
-    plan.roadPredecessor.set(pair.outgoing, { kind: 'junction', id: junction.id })
+    // The junction sits at the travel exit of the incoming road and the
+    // travel entry of the outgoing road; for left-side roads those are the
+    // geometric start / end respectively (see the road-link case above).
+    const incomingLeft = (odrIdOf.get(pair.laneEdges[0].from) ?? -1) > 0
+    const outgoingLeft = (odrIdOf.get(pair.laneEdges[0].to) ?? -1) > 0
+    ;(incomingLeft ? plan.roadPredecessor : plan.roadSuccessor).set(pair.incoming, {
+      kind: 'junction',
+      id: junction.id,
+    })
+    ;(outgoingLeft ? plan.roadSuccessor : plan.roadPredecessor).set(pair.outgoing, {
+      kind: 'junction',
+      id: junction.id,
+    })
   }
 
   // Right-of-way: a lane pair (X has priority, Y yields) whose maneuvers both
@@ -1221,10 +1336,10 @@ function emitConnectingRoad(spec: ConnectingRoadSpec): string {
   )
   lines.push(`    <link>`)
   lines.push(
-    `      <predecessor elementType="road" elementId="${spec.incomingRoadId}" contactPoint="end"/>`
+    `      <predecessor elementType="road" elementId="${spec.incomingRoadId}" contactPoint="${spec.incomingContact}"/>`
   )
   lines.push(
-    `      <successor elementType="road" elementId="${spec.outgoingRoadId}" contactPoint="start"/>`
+    `      <successor elementType="road" elementId="${spec.outgoingRoadId}" contactPoint="${spec.outgoingContact}"/>`
   )
   lines.push(`    </link>`)
   lines.push(`    <planView>`)
@@ -1272,7 +1387,7 @@ function emitLink(roadId: number, plan: ConnectivityPlan): string {
     lines.push(
       pred.kind === 'junction'
         ? `      <predecessor elementType="junction" elementId="${pred.id}"/>`
-        : `      <predecessor elementType="road" elementId="${pred.id}" contactPoint="end"/>`
+        : `      <predecessor elementType="road" elementId="${pred.id}" contactPoint="${pred.contactPoint ?? 'end'}"/>`
     )
   }
   const succ = plan.roadSuccessor.get(roadId)
@@ -1280,7 +1395,7 @@ function emitLink(roadId: number, plan: ConnectivityPlan): string {
     lines.push(
       succ.kind === 'junction'
         ? `      <successor elementType="junction" elementId="${succ.id}"/>`
-        : `      <successor elementType="road" elementId="${succ.id}" contactPoint="start"/>`
+        : `      <successor elementType="road" elementId="${succ.id}" contactPoint="${succ.contactPoint ?? 'start'}"/>`
     )
   }
   lines.push(`    </link>`)
@@ -1864,7 +1979,7 @@ function emitObjects(objects: ObjectEntry[]): string {
  * attributes stay separate in multi-lane roads, and restored by the importer.
  * `odr_*` meta attributes are excluded: they are regenerated on import.
  */
-function emitLaneAttributesUserData(bundleLanes: LaneShape[]): string | null {
+function emitLaneAttributesUserData(bundleLanes: LaneShape[], leftSide: boolean): string | null {
   const byLane: Record<string, Record<string, string>> = {}
   bundleLanes.forEach((lane, i) => {
     const stash: Record<string, string> = {}
@@ -1873,7 +1988,7 @@ function emitLaneAttributesUserData(bundleLanes: LaneShape[]): string | null {
       if (v === undefined || v === null || v === '') continue
       stash[k] = String(v)
     }
-    if (Object.keys(stash).length > 0) byLane[String(-(i + 1))] = stash
+    if (Object.keys(stash).length > 0) byLane[String(leftSide ? i + 1 : -(i + 1))] = stash
   })
   if (Object.keys(byLane).length === 0) return null
   return `    <userData code="laneAttributes" value="${escapeXml(JSON.stringify(byLane))}"/>`
@@ -1906,7 +2021,7 @@ function emitYieldLanesUserData(
     }
     if (targets.length > 0) {
       targets.sort((a, b) => Number(a[0]) - Number(b[0]) || Number(a[1]) - Number(b[1]))
-      byLane[String(-(i + 1))] = targets
+      byLane[String(laneIdToOdrLaneId.get(lane.id) ?? -(i + 1))] = targets
     }
   })
   if (Object.keys(byLane).length === 0) return null
@@ -1979,6 +2094,13 @@ function emitRoad(
   const lines: string[] = []
   // Mainline (bundle) roads never belong to a junction; junction membership
   // is carried by the synthesized connecting roads (emitConnectingRoad).
+  // Known limitation: a regenerated road that originally sat inside a
+  // junction (odr_junction_id on its lanes) is demoted to a mainline road.
+  // Stamping the original junction id here alone would dangle — the original
+  // <junction> element is regenerated as synthesized stubs whenever one of
+  // its member roads goes dirty — so restoring the attribute requires
+  // rebuilding the original junction's <connection> records around this
+  // road instead of synthesizing stubs.
   lines.push(
     `  <road name="${name}" length="${fmt(emittedRoadLength(bundle.geom))}" id="${roadId}" junction="-1">`
   )
@@ -1994,7 +2116,7 @@ function emitRoad(
   lines.push(emitLanes(bundle, plan, shapeMap))
   lines.push(emitObjects(objects))
   lines.push(emitSignals(signals, signalRefs))
-  const userData = emitLaneAttributesUserData(bundle.lanes)
+  const userData = emitLaneAttributesUserData(bundle.lanes, bundle.leftSide)
   if (userData) lines.push(userData)
   const yieldUserData = emitYieldLanesUserData(
     bundle.lanes,
@@ -2447,13 +2569,15 @@ export function exportToOpenDrive(snapshot: DrawtonomySnapshot, options: OpenDri
   // its neighbours.
   const exportBundles: ExportBundle[] = []
   for (const bundleLanes of detectBundles(regenLanes)) {
-    const geom = buildBundleGeometry(shapeMap, bundleLanes, pointOverrides)
+    const leftSide = isLeftSideBundle(bundleLanes)
+    const geom = buildBundleGeometry(shapeMap, bundleLanes, pointOverrides, leftSide)
     if (geom && geom.length >= 0.01) {
-      exportBundles.push({ lanes: bundleLanes, geom })
+      exportBundles.push({ lanes: bundleLanes, geom, leftSide })
     } else if (bundleLanes.length > 1) {
       for (const lane of bundleLanes) {
-        const g = buildBundleGeometry(shapeMap, [lane], pointOverrides)
-        if (g && g.length >= 0.01) exportBundles.push({ lanes: [lane], geom: g })
+        const laneLeft = isLeftSideBundle([lane])
+        const g = buildBundleGeometry(shapeMap, [lane], pointOverrides, laneLeft)
+        if (g && g.length >= 0.01) exportBundles.push({ lanes: [lane], geom: g, leftSide: laneLeft })
       }
     }
   }
@@ -2532,7 +2656,7 @@ export function exportToOpenDrive(snapshot: DrawtonomySnapshot, options: OpenDri
     roadIdByBundle.set(bundle, roadId)
     bundle.lanes.forEach((lane, i) => {
       laneIdToRoadId.set(lane.id, roadId)
-      laneIdToOdrLaneId.set(lane.id, -(i + 1))
+      laneIdToOdrLaneId.set(lane.id, bundle.leftSide ? i + 1 : -(i + 1))
     })
   }
 
@@ -2565,18 +2689,23 @@ export function exportToOpenDrive(snapshot: DrawtonomySnapshot, options: OpenDri
     const loc = laneLocation.get(laneShapeId)
     if (loc) {
       const geom = loc.bundle.geom
-      const lastGeom = geom.planView[geom.planView.length - 1]
-      const endPose = evalGeometry(lastGeom, lastGeom.length)
-      // Lane boundaries sit toward -t (right of the reference direction): the
-      // inner boundary of lane -(i+1) is offset by the widths of lanes 0..i-1.
-      const lastIdx = geom.samplePoses.length - 1
+      // The travel exit of a left-side bundle is the geometric start of its
+      // reference line (left lanes run against s); the travel heading there
+      // is the reference heading turned around. In the travel frame the
+      // lanes sit toward the right normal either way, so the same offset
+      // formula applies with the travel pose.
+      const leftSide = loc.bundle.leftSide
+      const exitGeom = leftSide ? geom.planView[0] : geom.planView[geom.planView.length - 1]
+      const pose = evalGeometry(exitGeom, leftSide ? 0 : exitGeom.length)
+      const hdg = leftSide ? wrapAngleRad(pose.hdg + Math.PI) : pose.hdg
+      const exitIdx = leftSide ? 0 : geom.samplePoses.length - 1
       let offset = 0
-      for (let m = 0; m < loc.index; m++) offset += geom.laneWidths[m][lastIdx]
+      for (let m = 0; m < loc.index; m++) offset += geom.laneWidths[m][exitIdx]
       return {
-        x: endPose.x + Math.sin(endPose.hdg) * offset,
-        y: endPose.y - Math.cos(endPose.hdg) * offset,
-        hdg: endPose.hdg,
-        width: geom.laneWidths[loc.index][lastIdx],
+        x: pose.x + Math.sin(hdg) * offset,
+        y: pose.y - Math.cos(hdg) * offset,
+        hdg,
+        width: geom.laneWidths[loc.index][exitIdx],
         laneType: odrLaneTypeFor(loc.bundle.lanes[loc.index]),
       }
     }
@@ -2607,15 +2736,20 @@ export function exportToOpenDrive(snapshot: DrawtonomySnapshot, options: OpenDri
     if (loc) {
       const geom = loc.bundle.geom
       if (geom.samplePoses.length === 0) return null
-      const pose = geom.samplePoses[0]
-      // Lane boundaries sit toward -t (right of the reference direction).
+      // The travel entry of a left-side bundle is the geometric end of its
+      // reference line, with the travel heading turned around (see
+      // connectingSourceFor).
+      const leftSide = loc.bundle.leftSide
+      const entryIdx = leftSide ? geom.samplePoses.length - 1 : 0
+      const refPose = geom.samplePoses[entryIdx]
+      const hdg = leftSide ? wrapAngleRad(refPose.hdg + Math.PI) : refPose.hdg
       let offset = 0
-      for (let m = 0; m < loc.index; m++) offset += geom.laneWidths[m][0]
+      for (let m = 0; m < loc.index; m++) offset += geom.laneWidths[m][entryIdx]
       return {
-        x: pose.x + Math.sin(pose.hdg) * offset,
-        y: pose.y - Math.cos(pose.hdg) * offset,
-        hdg: pose.hdg,
-        width: geom.laneWidths[loc.index][0],
+        x: refPose.x + Math.sin(hdg) * offset,
+        y: refPose.y - Math.cos(hdg) * offset,
+        hdg,
+        width: geom.laneWidths[loc.index][entryIdx],
       }
     }
     const lane = externalLanes.get(laneShapeId)
@@ -2645,7 +2779,10 @@ export function exportToOpenDrive(snapshot: DrawtonomySnapshot, options: OpenDri
     if (loc) {
       const widths = loc.bundle.geom.laneWidths[loc.index]
       if (!widths || widths.length === 0) return null
-      return contact === 'start' ? widths[0] : widths[widths.length - 1]
+      // `contact` is travel-semantic; a left-side bundle's travel start sits
+      // at the geometric end of its width samples.
+      const atFirst = (contact === 'start') !== loc.bundle.leftSide
+      return atFirst ? widths[0] : widths[widths.length - 1]
     }
     const lane = externalLanes.get(laneShapeId)
     if (!lane) return null

--- a/packages/drawtonomy-sdk/src/exporter/opendrive.ts
+++ b/packages/drawtonomy-sdk/src/exporter/opendrive.ts
@@ -37,13 +37,15 @@ import { sampleAtParam, type Point2D } from './laneCenterline.js'
 import { evalGeometry } from './odrGeometry.js'
 import { fitPlanView, type FittedSamplePose } from './odrGeometryFit.js'
 import { fitElevationProfile, type ElevationSample } from './odrElevationFit.js'
-import type { OdrGeometry } from './opendriveParser.js'
+import { parseOpenDriveXml, type OdrGeometry, type OdrRoad } from './opendriveParser.js'
+import { buildSurgicalRoad, laneShapeKey, type LaneShapeKey } from './odrSurgical.js'
 import { originToProjString } from './projection.js'
 import { escapeXml, fmt, fmtPrecise, pxToEnuX, pxToEnuY, pxToMeter } from './units.js'
 import {
   appendControlRecords,
   dropControlRecords,
   extractOdrDocument,
+  hashRoadSemantics,
   hashRoadState,
   rewriteRoadLinkTargets,
   type CarryLaneState,
@@ -2163,6 +2165,13 @@ interface CarryPlan {
   consumedShapeIds: Set<string>
   headerText: string | null
   verbatimRoads: OdrDocRoad[]
+  /**
+   * Surgically regenerated roads (edit was lateral-only): the original <road>
+   * text with only its lane <width> records rewritten, keyed by road id.
+   * These roads are treated as clean (kept verbatim except for the widths),
+   * so their lanes are excluded from full regeneration.
+   */
+  surgicalRoadText: Map<string, string>
   /** Original junction ids that must be regenerated (members changed). */
   dirtyJunctionIds: Set<string>
   verbatimJunctionTexts: string[]
@@ -2209,6 +2218,16 @@ function planCarryThrough(
   if (!doc) return null
   const docRoadById = new Map(doc.roads.map(r => [r.id, r]))
   const docJunctionById = new Map(doc.junctions.map(j => [j.id, j]))
+
+  // Parsed original roads, for surgical (lateral-only) width recomputation.
+  // Parsing failures leave `parsedRoadById` empty, disabling the surgical
+  // path and falling back to full regeneration for every edited road.
+  const parsedRoadById = new Map<string, OdrRoad>()
+  try {
+    for (const r of parseOpenDriveXml(sidecar.rawXml).roads) parsedRoadById.set(r.id, r)
+  } catch {
+    // ignore; surgical simply stays unavailable
+  }
 
   // laneShapeId -> recorded road id (over every record).
   const laneRoadOf = new Map<string, string>()
@@ -2320,9 +2339,28 @@ function planCarryThrough(
     return states
   }
 
+  // Live lane shapes of a recorded road keyed by (odr_lane_id, odr_section_s),
+  // for surgical width recomputation. Null when any recorded lane shape is
+  // missing or lacks the odr identifiers.
+  const laneShapesByKey = (rec: OdrRoadRecord): Map<LaneShapeKey, LaneShape> | null => {
+    const map = new Map<LaneShapeKey, LaneShape>()
+    for (const lid of rec.laneShapeIds) {
+      const shape = shapeMap.get(lid)
+      if (!shape || shape.type !== 'lane') return null
+      const lane = shape as unknown as LaneShape
+      const odrLaneId = parseInt(lane.props.attributes?.odr_lane_id ?? '', 10)
+      const sectionS = parseFloat(lane.props.attributes?.odr_section_s ?? '')
+      if (!Number.isFinite(odrLaneId) || !Number.isFinite(sectionS)) return null
+      map.set(laneShapeKey(odrLaneId, sectionS), lane)
+    }
+    return map
+  }
+
   // Seed dirtiness: hash mismatch, missing shapes, or references that leave
-  // the recorded set.
+  // the recorded set. An edited road whose edit is purely lateral is rewritten
+  // surgically (only its lane widths change) and stays clean.
   const dirty = new Set<string>()
+  const surgicalRoadText = new Map<string, string>()
   for (const [rid, rec] of Object.entries(records)) {
     const docRoad = docRoadById.get(rid)
     if (!docRoad) {
@@ -2337,8 +2375,27 @@ function planCarryThrough(
       continue
     }
     const laneStates = exportLaneStates(rec)
-    if (!laneStates || hashRoadState(laneStates, regStatesByRoad.get(rid) ?? []) !== rec.stateHash) {
-      dirty.add(rid)
+    const regStates = regStatesByRoad.get(rid) ?? []
+    if (!laneStates || hashRoadState(laneStates, regStates) !== rec.stateHash) {
+      // The road changed. When only its boundary geometry moved (the road's
+      // non-geometric state — lane attributes / connectivity / right-of-way /
+      // regulatory shapes — still matches) AND the geometry moved only
+      // laterally, keep its plan view / laneOffset / elevation / signals /
+      // objects / links verbatim and rewrite only the lane <width> records.
+      // Any other change (moved traffic light, edited attributes, longitudinal
+      // drag, lane add/remove) fails the check and the road regenerates fully.
+      const semanticUnchanged =
+        laneStates != null &&
+        rec.semanticHash !== undefined &&
+        hashRoadSemantics(laneStates, regStates) === rec.semanticHash
+      const parsed = semanticUnchanged ? parsedRoadById.get(rid) : undefined
+      const laneShapes = parsed ? laneShapesByKey(rec) : null
+      const surgical =
+        parsed && laneShapes
+          ? buildSurgicalRoad(parsed, docRoad.text, laneShapes, shapeMap)
+          : null
+      if (surgical !== null) surgicalRoadText.set(rid, surgical)
+      else dirty.add(rid)
     }
   }
 
@@ -2482,6 +2539,7 @@ function planCarryThrough(
     consumedShapeIds,
     headerText: doc.headerText,
     verbatimRoads,
+    surgicalRoadText,
     dirtyJunctionIds,
     verbatimJunctionTexts,
     verbatimControllers,
@@ -2861,7 +2919,10 @@ export function exportToOpenDrive(snapshot: DrawtonomySnapshot, options: OpenDri
           junctionMap.set(jref, String(replacement))
         }
       }
-      lines.push(rewriteRoadLinkTargets(r.text, rewriteMap, junctionMap ?? new Map()))
+      // Surgical roads reuse the verbatim emission path (same link rewriting)
+      // but start from the width-rewritten text instead of the original.
+      const baseText = carry.surgicalRoadText.get(r.id) ?? r.text
+      lines.push(rewriteRoadLinkTargets(baseText, rewriteMap, junctionMap ?? new Map()))
     }
   }
 


### PR DESCRIPTION
## Summary

Two fixes for how edited roads regenerate on OpenDRIVE export.

**Left-side lanes** — a bundle made entirely of imported left lanes (positive lane ids) used to come back as `<right>` lanes of a reversed reference line: lane-id signs flipped (+2 → -2) and the road's s coordinate ran backwards. The exporter now keeps these bundles on the `<left>` side with the original reference direction. A sign bug in the closest-point width fallback (unsigned distance rejected left-side intersections) is fixed along the way.

**Surgical (lateral-only) regeneration** — editing one boundary point used to regenerate the whole road: reference line refit, `laneOffset` dropped, elevation coarsened, s drifting over the full length. When every moved point's displacement is lateral (no s-direction component), the exporter now keeps the original `planView` / `laneOffset` / `elevationProfile` / signals / objects verbatim and rewrites only the `<width>` records, recomputed against the original reference line. Anything else — longitudinal drags, structural changes, ambiguous cases — falls back to full regeneration. A geometry-free semantic hash per road distinguishes the two.

## Verification

- 335 tests passing (7 new regression pins: lane-id sign, reference direction, links, surgical keep/fallback)
- Unedited round trips stay 100% verbatim on all bundled fixtures
- On the soderleden fixture, a lateral edit keeps width, length, laneOffset and elevation; a longitudinal drag falls back to full regeneration
