### PR TITLE
README: link the CommonRoad replay demo from Scenario mode

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -49,6 +49,7 @@ drawtonomy には二つの顔があります。
 - **[再生機能](https://docs.drawtonomy.com/ja/scenario/playback/)** — シーク・Follow Ego・ゴーストトレイル・`.webm` 書き出し
 - **[PASS / FAIL 判定](https://docs.drawtonomy.com/ja/scenario/end-and-fail-conditions/)** — 実行のたびに判定
 - **[esmini 対応 zip](https://docs.drawtonomy.com/ja/guides/export-asam/)** — `.xodr` + `.xosc` を書き出し
+- **[CommonRoad](https://docs.drawtonomy.com/ja/integrations/commonroad/)** — シナリオを書き出し、planner の solution を公式判定つきで再生: **[CommonRoad シナリオを再生してみる](https://www.drawtonomy.com/?open=https://github.com/kosuke55/drawtonomy/blob/main/packages/drawtonomy-commonroad/tests/fixtures/cutin_commonroad.xml&trace=planner_solution.planning-trace.json&verdict=planner_solution.verdict.json)**
 
 GitHub 上の公開 `.xosc` はワンクリックで再生できます:
 **[シナリオを再生してみる](https://drawtonomy.com/?open=https://github.com/esmini/esmini/blob/master/resources/xosc/acc-test.xosc)**。

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ author a full OpenSCENARIO storyboard yourself.
 - **[Full playback](https://docs.drawtonomy.com/scenario/playback/)** — seek, Follow Ego, ghost trails, `.webm` export
 - **[PASS / FAIL verdicts](https://docs.drawtonomy.com/scenario/end-and-fail-conditions/)** on every run
 - **[esmini-ready export](https://docs.drawtonomy.com/guides/export-asam/)** — `.xodr` + `.xosc` zip for desktop esmini
+- **[CommonRoad](https://docs.drawtonomy.com/integrations/commonroad/)** — export scenarios, replay planner solutions with the official verdict: **[Play a CommonRoad scenario](https://www.drawtonomy.com/?open=https://github.com/kosuke55/drawtonomy/blob/main/packages/drawtonomy-commonroad/tests/fixtures/cutin_commonroad.xml&trace=planner_solution.planning-trace.json&verdict=planner_solution.verdict.json)**
 
 Any public `.xosc` on GitHub runs with one click:
 **[Play a live scenario](https://drawtonomy.com/?open=https://github.com/esmini/esmini/blob/master/resources/xosc/acc-test.xosc)**.


### PR DESCRIPTION
Adds one bullet to the Scenario mode list in README.md and README.ja.md: CommonRoad export and replay, linking the integration docs and a one-click demo (cut-in scenario, planner solution with trace and verdict).

- https://www.drawtonomy.com/?open=https://github.com/kosuke55/drawtonomy/blob/main/packages/drawtonomy-commonroad/tests/fixtures/cutin_commonroad.xml&trace=planner_solution.planning-trace.json&verdict=planner_solution.verdict.json
- https://www.drawtonomy.com/?open=https://github.com/kosuke55/drawtonomy/blob/main/packages/drawtonomy-commonroad/tests/fixtures/straight_commonroad.xml&trace=straight_idm_solution.planning-trace.json&verdict=straight_idm_solution.verdict.json