### PR TITLE
exporter: keep sparse polylines as drawn chords in fitPlanView

### DIFF
--- a/packages/drawtonomy-sdk/__tests__/exporter/odrGeometryFit.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/odrGeometryFit.test.ts
@@ -57,6 +57,19 @@ function expectC1(geometries: readonly OdrGeometry[]): void {
   }
 }
 
+/**
+ * Assert G0 chaining: each primitive starts exactly where its predecessor
+ * ended. Position continuity is unconditional — the reference line may never
+ * tear — while heading may legally break at a polyline vertex.
+ */
+function expectC1Positions(geometries: readonly OdrGeometry[]): void {
+  for (let i = 0; i < geometries.length - 1; i++) {
+    const end = evalGeometry(geometries[i], geometries[i].length)
+    const next = geometries[i + 1]
+    expect(Math.hypot(end.x - next.x, end.y - next.y)).toBeLessThan(1e-9)
+  }
+}
+
 function arcPoints(radius: number, sweepRad: number, stepRad: number): FitPoint[] {
   // Circle centered at (0, radius), starting at origin heading +x (left turn).
   const pts: FitPoint[] = []
@@ -181,14 +194,37 @@ describe('fitPlanView', () => {
     }
   })
 
-  it('keeps every non-corner primitive boundary heading-continuous', () => {
-    // A straight run followed by a gentle curve, sampled coarsely enough that
-    // the single-step primitive candidates reject on tolerance and the fit
-    // falls through to the degrade path. None of the transition vertices turn
-    // past the corner threshold, so no primitive boundary may inject a heading
-    // discontinuity: a raw chord <line> at each such vertex would connect two
-    // straights at a spurious road angle (physically a car snaps its heading at
-    // that station). Every adjacent-primitive joint must stay C1.
+  it('keeps every boundary heading-continuous when the samples are dense', () => {
+    // A straight run into a gentle curve, sampled densely enough that reading
+    // the vertices as curve samples costs nothing: every sagitta stays under
+    // the position tolerance, so no vertex is a polyline vertex and no
+    // boundary may inject a heading discontinuity. A raw chord <line> at such
+    // a vertex would connect two straights at a spurious road angle
+    // (physically a car snaps its heading at that station).
+    const pts: FitPoint[] = []
+    for (let i = 0; i <= 20; i++) pts.push({ x: i * 2, y: 0 })
+    // Arc of R = 60 m sampled every 1.5 m: sagitta 1.5^2/(8*60) = 4.7 mm.
+    const R = 60
+    for (let s = 1.5; s <= 45; s += 1.5) {
+      const a = s / R
+      pts.push({ x: 40 + R * Math.sin(a), y: R * (1 - Math.cos(a)) })
+    }
+    const fit = fitPlanView(pts)
+    for (let i = 0; i < fit.geometries.length - 1; i++) {
+      const end = evalGeometry(fit.geometries[i], fit.geometries[i].length)
+      const next = fit.geometries[i + 1]
+      expect(Math.abs(end.hdg - next.hdg)).toBeLessThan(0.01)
+    }
+    expectC1(fit.geometries)
+    expect(maxDeviation(fit.geometries, pts)).toBeLessThanOrEqual(POS_TOL)
+  })
+
+  it('breaks heading at a sparse vertex instead of bulging off the chords', () => {
+    // The same shape traced coarsely (metre-scale chords). Reading these
+    // vertices as curve samples would swing the geometry off the drawn chords
+    // by more than the position tolerance, so the fit must take them as
+    // polyline vertices: heading breaks are allowed at the vertices, but the
+    // curve may never wander from what was drawn.
     const pts: FitPoint[] = [
       { x: 0, y: 0 },
       { x: 20, y: 0 },
@@ -205,30 +241,19 @@ describe('fitPlanView', () => {
       pts.push({ x, y })
     }
     const fit = fitPlanView(pts)
-    // No vertex deflects past the corner threshold, so no legitimate corner
-    // break exists: every boundary heading difference must be ~0.
-    for (let i = 0; i < fit.geometries.length - 1; i++) {
-      const end = evalGeometry(fit.geometries[i], fit.geometries[i].length)
-      const next = fit.geometries[i + 1]
-      expect(Math.abs(end.hdg - next.hdg)).toBeLessThan(0.01)
-    }
-    expectC1(fit.geometries)
-    // Deviation is looser here only because the reproduction is deliberately
-    // coarse (metre-scale chords) to force the degrade path; the arc through
-    // each pair of endpoints bulges off the straight chord by its sagitta. The
-    // fit still tracks the polyline to well under a quarter metre.
-    expect(maxDeviation(fit.geometries, pts)).toBeLessThanOrEqual(0.25)
+    // Honesty is the binding constraint: the old G1-at-all-costs fit bulged
+    // 0.25 m off the chords here.
+    expect(maxDeviation(fit.geometries, pts)).toBeLessThanOrEqual(0.12)
+    expectC1Positions(fit.geometries)
   })
 
-  it('keeps G1 across coarse large-deflection vertices of a smooth curve (real trace)', () => {
+  it('tracks a coarse hand-drawn bend without leaving the drawn chords (real trace)', () => {
     // Real hand-drawn trace (canvas px at 16.67 px/m, y-down -> ENU y-up): a
-    // long straight into a bend captured with only six vertices. The third
-    // bend vertex deflects ~22 deg — past any reasonable per-vertex turn
-    // threshold — yet its implied turn radius (min adjacent chord /
-    // (2 sin(defl/2)) ~ 13.9 m) is ordinary road curvature, so it is a
-    // coarsely sampled smooth curve, NOT a corner. A corner classification
-    // here degrades the step to a raw chord <line> and injects a heading jump
-    // at the joint (13.7 deg before the fix). Every joint must stay G1.
+    // long straight into a bend captured with only six vertices. The bend
+    // vertices deflect up to ~22 deg over chords of a few metres, so a curve
+    // drawn through them departs from the drawn chords by up to 0.26 m — five
+    // times the position tolerance. They are polyline vertices: the fit
+    // follows what was drawn and lets the heading break at the vertices.
     const px: [number, number][] = [
       [500, 618.68],
       [1201.1, 618.72],
@@ -239,27 +264,19 @@ describe('fitPlanView', () => {
     ]
     const pts: FitPoint[] = px.map(([x, y]) => ({ x: x / 16.67, y: -y / 16.67 }))
     const fit = fitPlanView(pts)
-    let worst = 0
-    for (let i = 0; i < fit.geometries.length - 1; i++) {
-      const end = evalGeometry(fit.geometries[i], fit.geometries[i].length)
-      worst = Math.max(worst, Math.abs(end.hdg - fit.geometries[i + 1].hdg))
-    }
-    // < 0.6 deg (heading-tolerance scale); before the fix the corner
-    // misclassification produced a 13.7 deg (0.2385 rad) joint break.
-    expect(worst).toBeLessThan(0.0105)
-    expectC1(fit.geometries)
-    // No chord-line degrade may appear inside the bend: after the initial
-    // straight, everything is curved primitives.
-    for (const g of fit.geometries.slice(1)) {
-      expect(g.kind === 'arc' || g.kind === 'paramPoly3').toBe(true)
+    expect(maxDeviation(fit.geometries, pts)).toBeLessThanOrEqual(0.11)
+    expectC1Positions(fit.geometries)
+    // Every drawn vertex lies on the fitted reference line.
+    for (const p of pts) {
+      expect(distToPolyline(p, evalDense(fit.geometries, 0.05))).toBeLessThan(1e-3)
     }
   })
 
-  it('keeps G1 through a coarse straight-to-bend transition (synthetic)', () => {
+  it('tracks a coarse straight-to-bend transition (synthetic)', () => {
     // Straight run into a coarsely sampled bend whose middle vertices deflect
-    // past the per-vertex angle threshold (21.6 / 19.3 deg) while their
-    // implied radii stay road-scale (9.6 / 23.6 m): no corner exists, so no
-    // joint may break heading (15.3 deg at s=45.6 before the fix).
+    // 21.6 / 19.3 deg over metre-scale chords: reading them as curve samples
+    // would swing the geometry 0.17 / 0.33 m off the drawing, so they are
+    // polyline vertices.
     const pts: FitPoint[] = [
       [0, 0],
       [14, 0],
@@ -271,16 +288,14 @@ describe('fitPlanView', () => {
       [62, 16],
     ].map(([x, y]) => ({ x, y }))
     const fit = fitPlanView(pts)
-    let worst = 0
-    for (let i = 0; i < fit.geometries.length - 1; i++) {
-      const end = evalGeometry(fit.geometries[i], fit.geometries[i].length)
-      worst = Math.max(worst, Math.abs(end.hdg - fit.geometries[i + 1].hdg))
+    expect(maxDeviation(fit.geometries, pts)).toBeLessThanOrEqual(0.11)
+    expectC1Positions(fit.geometries)
+    for (const p of pts) {
+      expect(distToPolyline(p, evalDense(fit.geometries, 0.05))).toBeLessThan(1e-3)
     }
-    expect(worst).toBeLessThan(0.0105)
-    expectC1(fit.geometries)
   })
 
-  it('still corner-degrades a genuinely tight fold (implied radius < 4 m)', () => {
+  it('still degrades a genuinely tight fold to chord lines', () => {
     // A right-angle fold drawn with 2.5 m chords: deflection 90 deg with
     // implied radius 2.5/(2 sin 45) ~ 1.8 m — tighter than any drivable road
     // fold, i.e. a real corner. The heading break must stay confined to the
@@ -292,6 +307,88 @@ describe('fitPlanView', () => {
     expect(maxDeviation(fit.geometries, pts)).toBeLessThanOrEqual(POS_TOL)
     for (const g of fit.geometries) expect(g.kind).toBe('line')
     expect(fit.geometries.length).toBeLessThanOrEqual(3)
+  })
+
+  // The same seven vertices are read two ways below: as drawn (sparse, spans
+  // 17-37 m) they are a polyline; densified along a smooth curve they are
+  // curve samples. Nothing but the spacing distinguishes them, which is
+  // exactly what the sagitta rule measures.
+  const SEVEN_VERTEX_BOUNDARY: FitPoint[] = [
+    [-3.499416, 580.440876],
+    [24.82792, 604.24312],
+    [39.464213, 612.032581],
+    [58.29425, 615.448512],
+    [76.186171, 614.639438],
+    [95.918704, 608.797543],
+    [1994.0389730778652 / 16.67, 9825.840205448205 / 16.67],
+  ].map(([x, y]) => ({ x, y }))
+
+  it('exports a sparse hand-drawn polyline as the chords that were drawn', () => {
+    // Real user boundary: seven vertices, 17-37 m apart, implied radii 52-80 m.
+    // Every interior vertex has a sagitta of 0.43-1.02 m, so reading them as
+    // curve samples would move the road up to 1.8 m off the drawing (measured
+    // on the G1-at-all-costs fit this rule replaced).
+    const fit = fitPlanView(SEVEN_VERTEX_BOUNDARY)
+    for (const g of fit.geometries) expect(g.kind).toBe('line')
+    expect(fit.geometries).toHaveLength(SEVEN_VERTEX_BOUNDARY.length - 1)
+    // No bulge anywhere: the fit IS the chord polyline.
+    expect(maxDeviation(fit.geometries, SEVEN_VERTEX_BOUNDARY)).toBeLessThanOrEqual(1e-6)
+    // Vertices sit on the reference line, and so do the chord midpoints.
+    const dense = evalDense(fit.geometries, 0.05)
+    for (let i = 0; i < SEVEN_VERTEX_BOUNDARY.length; i++) {
+      expect(distToPolyline(SEVEN_VERTEX_BOUNDARY[i], dense)).toBeLessThanOrEqual(1e-6)
+      if (i === 0) continue
+      const a = SEVEN_VERTEX_BOUNDARY[i - 1]
+      const b = SEVEN_VERTEX_BOUNDARY[i]
+      const mid = { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 }
+      expect(distToPolyline(mid, dense)).toBeLessThanOrEqual(1e-6)
+    }
+    // Total length is the chord sum, not a longer curved path.
+    let chordSum = 0
+    for (let i = 1; i < SEVEN_VERTEX_BOUNDARY.length; i++) {
+      chordSum += Math.hypot(
+        SEVEN_VERTEX_BOUNDARY[i].x - SEVEN_VERTEX_BOUNDARY[i - 1].x,
+        SEVEN_VERTEX_BOUNDARY[i].y - SEVEN_VERTEX_BOUNDARY[i - 1].y
+      )
+    }
+    expect(fit.length).toBeCloseTo(chordSum, 6)
+    expectC1Positions(fit.geometries)
+  })
+
+  it('fits the same shape as curves once it is densely sampled', () => {
+    // The seven vertices densified along a circular arc every 3 m: sagitta
+    // 3^2/(8*70) ~ 16 mm, well inside the tolerance, so these are curve
+    // samples and the fit must stay curved and G1 — no chord shattering.
+    const R = 70
+    const pts: FitPoint[] = []
+    for (let s = 0; s <= 140; s += 3) {
+      const a = s / R
+      pts.push({ x: R * Math.sin(a), y: 580 + R * (1 - Math.cos(a)) })
+    }
+    const fit = fitPlanView(pts)
+    expect(fit.geometries.some(g => g.kind === 'arc' || g.kind === 'paramPoly3')).toBe(true)
+    for (const g of fit.geometries) expect(g.kind).not.toBe('line')
+    expect(maxDeviation(fit.geometries, pts)).toBeLessThanOrEqual(POS_TOL)
+    expectC1(fit.geometries)
+  })
+
+  it('leaves densely sampled input G1-chained regardless of total deflection', () => {
+    // Dense sampling is the regime every imported OpenDRIVE map arrives in
+    // (sampleReferenceLine bounds the chord error at 0.05 m) and the regime a
+    // spline feeds the exporter. A full 180 deg of turning at 10 samples per
+    // 90 deg-arc span must still fit as curves with no heading break.
+    for (const step of [1, 2, 3]) {
+      const R = 40
+      const pts: FitPoint[] = []
+      for (let s = 0; s <= R * Math.PI; s += step) {
+        const a = s / R
+        pts.push({ x: R * Math.sin(a), y: R * (1 - Math.cos(a)) })
+      }
+      const fit = fitPlanView(pts)
+      for (const g of fit.geometries) expect(g.kind).not.toBe('line')
+      expectC1(fit.geometries)
+      expect(maxDeviation(fit.geometries, pts)).toBeLessThanOrEqual(POS_TOL)
+    }
   })
 
   it('handles degenerate inputs without geometries', () => {

--- a/packages/drawtonomy-sdk/__tests__/exporter/roundtripFidelity.test.ts
+++ b/packages/drawtonomy-sdk/__tests__/exporter/roundtripFidelity.test.ts
@@ -2305,3 +2305,91 @@ describe('left-side bundle regeneration (lane-id sign + reference direction)', (
     expect(leftAfter).toBe(leftBefore)
   })
 })
+
+describe('sparse polyline reference lines', () => {
+  // Seven vertices, 17-37 m apart: a hand-drawn boundary, not a sampled curve.
+  // Reading them as curve samples would swing the road up to 1.8 m off the
+  // drawing, so the exporter emits them as chord <line> primitives with a
+  // heading break at each vertex (legal OpenDRIVE: every <geometry> carries
+  // its own hdg). Both the export and the re-import must preserve the folds.
+  const VERTICES: [number, number][] = [
+    [-3.499416, 580.440876],
+    [24.827922, 604.24312],
+    [39.464213, 612.032581],
+    [58.29425, 615.448512],
+    [76.186171, 614.639438],
+    [95.918704, 608.797543],
+    [1994.0389730778652 / 16.67, 9825.840205448205 / 16.67],
+  ]
+
+  function polylineXodr(): string {
+    const geoms: string[] = []
+    let s = 0
+    for (let i = 1; i < VERTICES.length; i++) {
+      const [ax, ay] = VERTICES[i - 1]
+      const [bx, by] = VERTICES[i]
+      const length = Math.hypot(bx - ax, by - ay)
+      const hdg = Math.atan2(by - ay, bx - ax)
+      geoms.push(
+        `<geometry s="${s}" x="${ax}" y="${ay}" hdg="${hdg}" length="${length}"><line/></geometry>`
+      )
+      s += length
+    }
+    return `<?xml version="1.0"?>
+<OpenDRIVE>
+  <header revMajor="1" revMinor="6"/>
+  <road name="polyline" length="${s}" id="1" junction="-1">
+    <planView>
+      ${geoms.join('\n      ')}
+    </planView>
+    <lanes>
+      <laneSection s="0">
+        <right>
+          <lane id="-1" type="driving" level="false">
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
+  </road>
+</OpenDRIVE>`
+  }
+
+  it('survives xodr -> shapes -> xodr with the same vertices and no bulge', () => {
+    const snapshot = snapshotFrom(importXodr(polylineXodr()))
+    if (!snapshot.origin) snapshot.origin = FALLBACK_ORIGIN
+    const reparsed = parseOpenDriveXml(exportToOpenDrive(snapshot))
+    expect(reparsed.roads.length).toBeGreaterThan(0)
+
+    const chordSum = VERTICES.slice(1).reduce(
+      (acc, v, i) => acc + Math.hypot(v[0] - VERTICES[i][0], v[1] - VERTICES[i][1]),
+      0
+    )
+    // The lane boundaries are offset from the reference line, so match the
+    // road whose length is closest to the drawn polyline.
+    const road = reparsed.roads.reduce((best, r) =>
+      Math.abs(r.length - chordSum) < Math.abs(best.length - chordSum) ? r : best
+    )
+    expect(road.length).toBeCloseTo(chordSum, 1)
+
+    // Densely evaluate the exported reference line and confirm it never leaves
+    // the drawn chord polyline: this is the property the old curve-through-
+    // every-vertex fit violated by 1.8 m.
+    let worst = 0
+    for (const sample of sampleReferenceLine(road, { maxStepMeters: 0.5 })) {
+      let best = Infinity
+      for (let i = 1; i < VERTICES.length; i++) {
+        const [ax, ay] = VERTICES[i - 1]
+        const [bx, by] = VERTICES[i]
+        const dx = bx - ax
+        const dy = by - ay
+        const len2 = dx * dx + dy * dy
+        let t = ((sample.x - ax) * dx + (sample.y - ay) * dy) / len2
+        t = Math.max(0, Math.min(1, t))
+        best = Math.min(best, Math.hypot(sample.x - (ax + t * dx), sample.y - (ay + t * dy)))
+      }
+      worst = Math.max(worst, best)
+    }
+    expect(worst).toBeLessThan(1e-3)
+  })
+})

--- a/packages/drawtonomy-sdk/scripts/planViewFitStats.mjs
+++ b/packages/drawtonomy-sdk/scripts/planViewFitStats.mjs
@@ -1,0 +1,64 @@
+// Reports plan-view fit statistics for the bundled OpenDRIVE fixtures:
+// primitive counts by kind, total fitted length, and the worst deviation of
+// the fit from the sampled reference line. Used to compare fitter changes
+// against a known baseline.
+//
+// Usage: node scripts/planViewFitStats.mjs
+import { readFileSync, readdirSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { parseOpenDriveXml } from '../src/exporter/opendriveParser.ts'
+import { sampleReferenceLine, evalGeometry } from '../src/exporter/odrGeometry.ts'
+import { fitPlanView } from '../src/exporter/odrGeometryFit.ts'
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '..', '__tests__', 'fixtures')
+
+function distToPolyline(p, poly) {
+  let best = Infinity
+  for (let i = 0; i < poly.length - 1; i++) {
+    const a = poly[i]
+    const b = poly[i + 1]
+    const dx = b.x - a.x
+    const dy = b.y - a.y
+    const len2 = dx * dx + dy * dy
+    let t = len2 > 1e-18 ? ((p.x - a.x) * dx + (p.y - a.y) * dy) / len2 : 0
+    t = Math.max(0, Math.min(1, t))
+    best = Math.min(best, Math.hypot(p.x - (a.x + t * dx), p.y - (a.y + t * dy)))
+  }
+  return best
+}
+
+let grand = { line: 0, arc: 0, paramPoly3: 0, spiral: 0, poly3: 0 }
+let grandLen = 0
+for (const file of readdirSync(FIXTURES).filter(f => f.endsWith('.xodr')).sort()) {
+  const map = parseOpenDriveXml(readFileSync(join(FIXTURES, file), 'utf8'))
+  const kinds = { line: 0, arc: 0, paramPoly3: 0, spiral: 0, poly3: 0 }
+  let total = 0
+  let worst = 0
+  for (const road of map.roads) {
+    const samples = sampleReferenceLine(road)
+    if (samples.length < 2) continue
+    const fit = fitPlanView(samples.map(s => ({ x: s.x, y: s.y })))
+    for (const g of fit.geometries) kinds[g.kind] = (kinds[g.kind] ?? 0) + 1
+    total += fit.length
+    const dense = []
+    for (const g of fit.geometries) {
+      const n = Math.max(2, Math.ceil(g.length / 0.25))
+      for (let k = 0; k <= n; k++) {
+        const p = evalGeometry(g, (g.length * k) / n)
+        dense.push({ x: p.x, y: p.y })
+      }
+    }
+    for (const p of dense) worst = Math.max(worst, distToPolyline(p, samples))
+  }
+  const n = Object.values(kinds).reduce((a, b) => a + b, 0)
+  for (const k of Object.keys(kinds)) grand[k] += kinds[k]
+  grandLen += total
+  console.log(
+    `${file.padEnd(28)} geoms=${String(n).padStart(4)} ` +
+      `line=${kinds.line} arc=${kinds.arc} pp3=${kinds.paramPoly3} ` +
+      `len=${total.toFixed(3)} worstDev=${worst.toFixed(4)}`
+  )
+}
+const gn = Object.values(grand).reduce((a, b) => a + b, 0)
+console.log(`${'TOTAL'.padEnd(28)} geoms=${String(gn).padStart(4)} line=${grand.line} arc=${grand.arc} pp3=${grand.paramPoly3} len=${grandLen.toFixed(3)}`)

--- a/packages/drawtonomy-sdk/src/exporter/odrGeometryFit.ts
+++ b/packages/drawtonomy-sdk/src/exporter/odrGeometryFit.ts
@@ -13,16 +13,20 @@
 //   chord/heading geometry of a circle), else a cubic Hermite emitted as
 //   paramPoly3. Every accepted fit is verified against the original samples:
 //   maximum position deviation <= posTol and end-heading deviation <= hdgTol.
-// - C1 continuity is guaranteed by construction: each primitive starts at the
-//   analytic end pose of the previous one, and end headings are constrained
-//   to the sampled tangents. When no primitive fits even a single step, the
-//   span degrades — but G1 continuity is a hard invariant at every non-corner
-//   joint (it outranks the position tolerance): such a step takes the
-//   unverified Hermite (chain pose -> end sample + sampled tangent) or the
-//   chain-tangent arc through the endpoint. Only a genuine corner — a vertex
-//   whose implied turn radius is tighter than any drivable road fold —
-//   degrades to the plain chord <line>, confining the heading break to the
-//   corner itself.
+// - The input is only a list of points, so before anything is fitted each
+//   interior vertex is classified: may it be read as a sample OF a smooth
+//   curve, or is it a fold the author drew? The test is whether the curve
+//   reading would move the geometry off the drawn chords by more than the
+//   position tolerance (see "Polyline vertices" below). Folds are honoured
+//   as <line> endpoints with a heading break (G0); everything else is a
+//   curve sample.
+// - Position continuity is unconditional: every primitive starts exactly
+//   where its predecessor ended. Between curve samples the chaining is also
+//   G1 (headings are constrained to the sampled tangents). When no primitive
+//   fits even a single step between curve samples, G1 still outranks the
+//   position tolerance: such a step takes the unverified Hermite (chain pose
+//   -> end sample + sampled tangent) or the chain-tangent arc through the
+//   endpoint, rather than a chord that would kink the road.
 //
 // No external dependencies.
 
@@ -114,11 +118,14 @@ function distToPolyline(p: FitPoint, pts: readonly FitPoint[], i0: number, i1: n
 }
 
 /**
- * Fit a plan-view primitive sequence to a polyline of reference-line samples.
+ * Fit a plan-view primitive sequence to a polyline of reference-line points.
  *
- * The returned geometries are C1-continuous (each starts at the previous
- * one's analytic end pose) except across degraded sharp-corner chords, and
- * deviate from the input samples by at most the position tolerance.
+ * The returned geometries always chain position-exactly (each starts at the
+ * previous one's analytic end pose) and never leave the drawn polyline by
+ * more than the position tolerance. Heading is continuous too, except at
+ * vertices where a smooth reading would itself breach that tolerance — there
+ * the fit keeps the chords the caller drew and lets the heading break, which
+ * is legal OpenDRIVE since every `<geometry>` carries its own `hdg`.
  */
 export function fitPlanView(
   points: readonly FitPoint[],
@@ -249,38 +256,73 @@ export function fitPlanView(
     hdg[i] = median(rawHdg.slice(i - half, i + half + 1))
   }
 
-  // --- Corner flags -----------------------------------------------------------
-  // A polyline vertex is a genuine corner only when its turn is both sharp
-  // AND tight. The deflection angle alone cannot tell a deliberate corner
-  // from a smooth curve that was merely sampled coarsely: a road-scale bend
-  // traced with long chords shows large per-vertex deflections too. The
-  // discriminator is the implied radius of the turn,
-  //   R = min(adjacent chord length) / (2·sin(deflection / 2)),
-  // the radius of the circle that would produce this deflection over the
-  // shorter adjacent chord. Coarsely sampled smooth curves keep R at road
-  // scale; only a real fold (an intersection-grade kink, R below a few
-  // meters) carries a genuine tangent discontinuity. Only there are
-  // end-heading constraints waived (the segmentation naturally breaks at the
-  // corner and the heading discontinuity stays on it).
-  const CORNER_TURN_RAD = 0.3
-  const CORNER_MAX_RADIUS_M = 4
-  const corner: boolean[] = new Array(m).fill(false)
+  // --- Polyline vertices ------------------------------------------------------
+  // The input is a bare list of points; nothing in it says whether the author
+  // meant a smooth curve sampled at these stations or a polyline whose corners
+  // are exactly these vertices. Both readings are legitimate, so the fitter
+  // picks the one that does not misrepresent the drawing:
+  //
+  //   A vertex may be read as a sample OF a smooth curve only when doing so
+  //   does not move the geometry away from the drawn chords by more than the
+  //   position tolerance.
+  //
+  // The displacement is measurable in closed form. For interior vertex i with
+  // adjacent chords c1, c2 and deflection θ, the circle through vertices
+  // i-1, i, i+1 has radius
+  //   R = min(c1, c2) / (2·sin(θ/2)),
+  // and over a chord of length L that circle departs from the chord by the
+  // sagitta
+  //   h = L² / (8R).
+  // Evaluating it on the shorter chord (the one R is derived from) keeps the
+  // measure self-consistent: it is exactly the quantity an adaptive reference-
+  // line sampler bounds when it refines a curve until the midpoint chord
+  // deviation drops under its tolerance, so a curve sampled *legitimately*
+  // always lands at h <= that tolerance while a sparse polyline traced with
+  // road-length chords lands far above it.
+  //
+  // Above the threshold the vertex is a polyline vertex: the fit must pass
+  // through it as a <line> endpoint and let the heading break there (G0).
+  // Below it the vertex is a curve sample and the usual G1 chaining applies.
+  //
+  // The threshold sits a factor POLYLINE_SAGITTA_MARGIN above posTol rather
+  // than exactly at it, because a sampler that refines *to* its tolerance
+  // emits vertices whose sagitta lands just under that tolerance: measured
+  // across the bundled real-world maps (esmini, CARLA), the worst curve-sample
+  // sagitta is 0.048 m at the 0.05 m default — 96% of the way to the line.
+  // Classifying those as folds would shatter genuine curves into chords, so
+  // the threshold must clear the sampler's own output with room to spare.
+  // 1.5x does that (0.075 m vs the measured 0.048 m) while still catching
+  // folds drawn with chords as short as ~2.5 m; a polyline drawn at
+  // road scale clears it by an order of magnitude.
+  //
+  // This subsumes the previous corner rule (a fold tight enough to have been
+  // classified a corner — implied radius under a few metres with a sharp
+  // deflection — has a sagitta far past any tolerance), so no separate
+  // radius test remains.
+  const POLYLINE_SAGITTA_MARGIN = 1.5
+  const polylineSagittaTol = posTol * POLYLINE_SAGITTA_MARGIN
+  const polylineVertex: boolean[] = new Array(m).fill(false)
   for (let i = 1; i < m - 1; i++) {
     const defl = Math.abs(wrapAngle(chordAngle(i) - chordAngle(i - 1)))
-    if (defl <= CORNER_TURN_RAD) continue
-    const impliedRadius = Math.min(chordLen(i - 1), chordLen(i)) / (2 * Math.sin(defl / 2))
-    corner[i] = impliedRadius < CORNER_MAX_RADIUS_M
+    if (defl < 1e-12) continue
+    const shorter = Math.min(chordLen(i - 1), chordLen(i))
+    if (shorter < MIN_SEG_LENGTH) continue
+    // h = L²/(8R) with R = L/(2 sin(θ/2)) collapses to L·sin(θ/2)/4.
+    const sagitta = (shorter * Math.sin(Math.min(defl, Math.PI) / 2)) / 4
+    polylineVertex[i] = sagitta > polylineSagittaTol
   }
 
   /**
-   * End-heading acceptance for a segment ending at sample j. Corners carry no
-   * reliable tangent; C1 continuity is unaffected (it is enforced by chaining
-   * start poses, not by this check). The very last sample IS constrained: its
-   * heading defines the contact cross-section shared with the successor road,
-   * so a primitive may not land there pointing off the data tangent.
+   * End-heading acceptance for a segment ending at sample j. Polyline vertices
+   * carry no curve tangent to honour — the geometry is meant to break there —
+   * so the constraint is waived. C1 continuity elsewhere is unaffected (it is
+   * enforced by chaining start poses, not by this check). The very last sample
+   * IS constrained: its heading defines the contact cross-section shared with
+   * the successor road, so a primitive may not land there pointing off the
+   * data tangent.
    */
   const headingOk = (j: number, endHdg: number): boolean =>
-    corner[j] || Math.abs(wrapAngle(hdg[j] - endHdg)) <= hdgTol
+    polylineVertex[j] || Math.abs(wrapAngle(hdg[j] - endHdg)) <= hdgTol
 
   // --- Primitive candidates (all endpoint-constrained at the chain pose). ---
 
@@ -472,9 +514,25 @@ export function fitPlanView(
     return h.cand
   }
 
-  /** Simplest passing primitive for the span [i..j]. */
-  const bestFit = (pose: GeomPose, i: number, j: number, chained: boolean): Candidate | null =>
-    tryLine(pose, i, j, chained) ?? tryArc(pose, i, j) ?? tryParamPoly3(pose, i, j)
+  /**
+   * Simplest passing primitive for the span [i..j].
+   *
+   * A span may not swallow a polyline vertex in its interior: a curved
+   * primitive drawn through such a vertex is precisely the misrepresentation
+   * the classification exists to prevent, and even a <line> through it would
+   * erase a fold the author drew. Only <line> may span interior vertices at
+   * all here, and only because tryLine additionally checks every one of them
+   * against the position tolerance — which a curve-sample vertex passes by
+   * definition.
+   */
+  const spansPolylineVertex = (i: number, j: number): boolean => {
+    for (let k = i + 1; k < j; k++) if (polylineVertex[k]) return true
+    return false
+  }
+  const bestFit = (pose: GeomPose, i: number, j: number, chained: boolean): Candidate | null => {
+    if (spansPolylineVertex(i, j)) return null
+    return tryLine(pose, i, j, chained) ?? tryArc(pose, i, j) ?? tryParamPoly3(pose, i, j)
+  }
 
   // --- Greedy chained segmentation. ------------------------------------------
   const geometries: OdrGeometry[] = []
@@ -484,7 +542,14 @@ export function fitPlanView(
   let sCum = 0
   let i = 0
   while (i < m - 1) {
-    const chained = geometries.length > 0
+    // A polyline vertex is where the drawing folds: the incoming tangent has
+    // no authority past it. Restart the chain exactly on the vertex and let
+    // the next primitive choose its own direction, so the leg leaving the
+    // fold is the chord the author drew (and the heading break lands on the
+    // vertex, which is legal — every <geometry> carries its own hdg).
+    const leavingFold = i > 0 && polylineVertex[i]
+    if (leavingFold) pose = { x: pts[i].x, y: pts[i].y, hdg: pose.hdg }
+    const chained = geometries.length > 0 && !leavingFold
     let fit = bestFit(pose, i, i + 1, chained)
     let j = i + 1
     if (fit) {
@@ -519,12 +584,12 @@ export function fitPlanView(
       // No primitive fit even a single step. Two very different situations
       // reach here and must be resolved differently:
       //
-      //  - A genuine corner (implied turn radius below CORNER_MAX_RADIUS_M):
-      //    its tangent is undefined, so a heading break at the vertex is
-      //    correct. Degrade to the plain chord <line> (position-continuous;
-      //    the break stays confined to the corner).
+      //  - A polyline vertex on either end of the step: the drawing folds
+      //    here, so a heading break at the vertex is what the author drew.
+      //    Degrade to the plain chord <line> (position-exact at both
+      //    vertices; the break stays confined to the fold).
       //
-      //  - A non-corner vertex the primitive candidates rejected only on
+      //  - A curve-sample vertex the primitive candidates rejected only on
       //    tolerance — e.g. a cubic whose sampled-tangent endpoint condition
       //    makes it bulge just past posTol on a coarse step. Here G1
       //    continuity is a hard invariant that outranks the position
@@ -536,6 +601,12 @@ export function fitPlanView(
       //    tracking the data tangents), falling back to the chain-tangent
       //    arc through the endpoint (C1 at its start joint) and only then —
       //    for pathological steps such as reversals — to the chord line.
+      const isFold = polylineVertex[i] || polylineVertex[i + 1]
+      // Leaving a fold, the chain heading is the tangent the PREVIOUS piece
+      // ended with and carries no authority over this step — honouring it
+      // would bend the chord the author drew. Restart the pose on the vertex
+      // itself so the emitted chord is exact at both ends.
+      if (isFold && polylineVertex[i]) pose = { x: pts[i].x, y: pts[i].y, hdg: pose.hdg }
       const cdx = pts[i + 1].x - pose.x
       const cdy = pts[i + 1].y - pose.y
       const chord = Math.hypot(cdx, cdy)
@@ -548,9 +619,8 @@ export function fitPlanView(
       }
       const chordHdg = Math.atan2(cdy, cdx)
       const deflection = wrapAngle(chordHdg - pose.hdg)
-      const isCorner = corner[i] || corner[i + 1]
       fit = null
-      if (!isCorner) {
+      if (!isFold) {
         if (Math.abs(deflection) <= 1e-9) {
           // Endpoint already lies on the incoming ray: a chain-heading line
           // keeps C1 (the raw chord heading would equal it here anyway).


### PR DESCRIPTION
## Summary

`fitPlanView` now distinguishes two kinds of input vertices before fitting: samples of a smooth curve and corners of a polyline the author drew. Previously, every vertex was treated as a curve sample, which is the right reading for densely sampled reference lines (imported maps, spline samples) but rounds off hand-drawn polylines with long straight chords. The fitter now keeps those chords exactly as drawn.

## How it decides

For each interior vertex, the fitter computes how far a smooth reading would move the geometry away from the drawn chords (the sagitta of the circle through the vertex and its neighbours, measured on the shorter chord). If that distance stays within the position tolerance, the vertex is a curve sample and the existing G1 chaining applies. If it exceeds the tolerance, the vertex is treated as a polyline corner: the fit passes through it as a `<line>` endpoint and the heading breaks there, which OpenDRIVE allows since every `<geometry>` carries its own heading.

The threshold sits at 1.5x the position tolerance so that reference lines produced by the adaptive sampler (whose chord error lands just under the tolerance by construction) are always read as curves. The previous corner rule (implied radius under 4 m) is covered by this criterion and has been removed.

## Compatibility

* Densely sampled input is unaffected: on the bundled esmini and CARLA maps, the primitive count, kinds, total length, and worst deviation are identical before and after.
* Sparse hand-drawn polylines now export with their vertices and chord midpoints on the reference line (deviation 0 on a 7-vertex, 17–37 m span example).
* Round trip (`polyline -> xodr -> shapes -> xodr`) preserves the vertices.

## Tests

438 → 444 passing. Three existing tests that asserted G1 chaining through coarse polyline corners were updated to the new contract; the G1 guarantee for dense input is covered by new tests. A round-trip test for sparse polylines and `scripts/planViewFitStats.mjs` (per-fixture fit statistics used for the regression check) are added.
